### PR TITLE
MNT: fix remaining slaclab references

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ version: ~> 1.0
 
 env:
   global:
-    # Doctr deploy key for slaclab/pytmc
+    # Doctr deploy key for pcdshub/pytmc
     - secure: "qQgwWMYHy54oQDXFotIaKoIZq+fdYlGIRCfeOHimU/uRRHRMMcP1tjsup4zADQsGf+ym3Bcu9r/VezVU2zH5At8JJeR7Cq5ZUe88tKFezrL97iCKYLw4x+DigLsKujkdgmeBOoMlaNw8EIu1t8JtHXZZ5poz8HBeCc5dGOwYs84MRuqqBzWvs6O0snTwMRlbGSb7UlaEKXrGKRQ6CDolqy8w2KgDos+IHWCmkBspXcs8XBan20BZGJiGHYuJNMKimLeF/vTE6c0mRG9imjvKxRrXzbOLfPIpmoCj1tAqX/TCBe3L08kEskVDFRiWQM4bawS8EPXhIqmdxNwTDD0c0x4YS3sVsJAa8T3rMPSYJaJW+pndX9NNJPntsvJ6o3GXS1luiYwSGwYi6YuCYgUmz7DfM8SN6d+a9aMyNXu8rCd6xi+iFZd0YcdwePxpY+FrxWAWmxV7Sp71Zg7oYX/ig5VB0JZ6bSY5vvc2emjLi7ZIgDHx03cAod/XMWtk1k67VdJVMtayAoXKkCa65LOtnSNA2qmq5FFq1v6IeS4/J2Y95pn2pC1dOk4Ti6nnQ00kiad3PkD7W9khswvH00P5TeqXzM95w+wS3MOi/sb8ZqQS8Q45CrENoFj9WJ2N3Wvmbf6Gq50p37Fxm2QhLBUfFA/tQ7CwHAwouWn+Rf5xlbI="
 
     - DOCTR_VERSIONS_MENU="1"

--- a/README.rst
+++ b/README.rst
@@ -1,16 +1,16 @@
 PYTMC
 =====
 
-.. image:: https://travis-ci.org/slaclab/pytmc.svg?branch=master
-       :target: https://travis-ci.org/slaclab/pytmc
+.. image:: https://travis-ci.org/pcdshub/pytmc.svg?branch=master
+       :target: https://travis-ci.org/pcdshub/pytmc
 
 Generate Epics DB records from TwinCAT .tmc files.
 
-See the `docs <https://slaclab.github.io/pytmc/>`_ for more information.
-     
+See the `docs <https://pcdshub.github.io/pytmc/>`_ for more information.
+
 ===============  =====
 Compatibility
 ======================
-python 3.6, 3.7  .. image:: https://travis-ci.org/slaclab/pytmc.svg?branch=master 
-                      :target: https://travis-ci.org/slaclab/pytmc
+python 3.6, 3.7  .. image:: https://travis-ci.org/pcdshub/pytmc.svg?branch=master
+                      :target: https://travis-ci.org/pcdshub/pytmc
 ===============  =====

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -33,8 +33,8 @@ test:
     - pyqt
 
 about:
-  home: https://github.com/slaclab/pytmc
-  doc_url: https://slaclab.github.io/pytmc/
+  home: https://github.com/pcdshub/pytmc
+  doc_url: https://pcdshub.github.io/pytmc/
   license: SLAC Open
   license_family: Other
   license_file: LICENSE
@@ -43,6 +43,6 @@ about:
 extra:
   recipe-maintainers:
     - klauer
-    - hhslepicka 
+    - hhslepicka
     - zllentz
     - n-wbrown

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,8 +5,8 @@
 
 Welcome to pytmc's documentation!
 =================================
-.. image:: https://travis-ci.org/slaclab/pytmc.svg?branch=master
-       :target: https://travis-ci.org/slaclab/pytmc
+.. image:: https://travis-ci.org/pcdshub/pytmc.svg?branch=master
+       :target: https://travis-ci.org/pcdshub/pytmc
 
 Pytmc helps developers automatically generate ADS based Epics records files
 from Beckhoff's TwinCAT3 projects.
@@ -14,10 +14,10 @@ from Beckhoff's TwinCAT3 projects.
 Pytmc is developed with these `guidelines
 <https://pcdshub.github.io/development.html>`_ in mind.
 
-The source code is hosted on `github <https://github.com/slaclab/pytmc>`_.
+The source code is hosted on `github <https://github.com/pcdshub/pytmc>`_.
 
 Issues and requests can be posted on the `github issue tracker
-<https://github.com/slaclab/pytmc/issues>`_. Use the ``bug`` tag for issues
+<https://github.com/pcdshub/pytmc/issues>`_. Use the ``bug`` tag for issues
 with intended features and the ``enhancement`` tag can be used for feature
 requests. The ``question`` tag will be treated like an 'enhancements' tag for
 the documentation but regular questions can be posted there as well.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,12 +4,12 @@ Installation
 Obtaining the code
 ++++++++++++++++++
 Download the code via the tagged releases posted on the `github releases page
-<https://github.com/slaclab/pytmc/releases>`_ or by cloning the source code
+<https://github.com/pcdshub/pytmc/releases>`_ or by cloning the source code
 with the following:
 
 .. code-block:: sh
 
-   $ git clone https://github.com/slaclab/pytmc.git
+   $ git clone https://github.com/pcdshub/pytmc.git
 
 Installing in an environment
 ++++++++++++++++++++++++++++
@@ -24,7 +24,7 @@ environment, you may skip this step.
 
    $ conda create --name [env-name]
 
-Activate your environment. 
+Activate your environment.
 
 .. code-block:: sh
 
@@ -65,19 +65,19 @@ If you've followed the previous steps correctly, pytmc should be installed now.
 This can be tested by seeing if the following bash commands can be found.
 
 .. code-block:: sh
-   
+
    $ pytmc --help
 
 Alternatively, a python shell can be opened and you can attempt to import
-pytmc. 
+pytmc.
 
 .. code-block:: python
 
    >>> import pytmc
 
-.. note::  
+.. note::
    While all of these instructions should work with python environments
-   managed by virtualenv and pipenv, only conda has been tested. 
+   managed by virtualenv and pipenv, only conda has been tested.
 
 
 Installing for development
@@ -86,17 +86,16 @@ To develop pytmc it is best to use a development install. This allows changes
 to the code to be immediately reflected in the program's functionality without
 needing to reinstall the code.This can be done by following the `Installing in
 an environment`_ section but with one change. The following code snippet should
-be removed: 
+be removed:
 
 .. code-block:: sh
-   
+
    $ # Don't use this step for a development install
    $ pip install .
 
 In place of the removed command, use the following to do a development install.
 
 .. code-block:: sh
-   
+
    $ # Use this command instead
    $ pip install -e .
-

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -160,22 +160,22 @@ v2.6.6 (2020-06-24)
 ===================
 
 *  Add –types (–filter-types) to ``pytmc summary``
-   (`#213 <https://github.com/slaclab/pytmc/issues/213>`__)
+   (`#213 <https://github.com/pcdshub/pytmc/issues/213>`__)
 *  Fix internal usage of deprecated API
-   (`#212 <https://github.com/slaclab/pytmc/issues/212>`__)
+   (`#212 <https://github.com/pcdshub/pytmc/issues/212>`__)
 
 
 v2.6.5 (2020-06-09)
 ===================
 
 *  Add ``info(archive)`` nodes for ads-ioc
-   (`#188 <https://github.com/slaclab/pytmc/issues/188>`__)
+   (`#188 <https://github.com/pcdshub/pytmc/issues/188>`__)
 *  Adjust defaults for binary record enum strings
-   (`#191 <https://github.com/slaclab/pytmc/issues/191>`__)
+   (`#191 <https://github.com/pcdshub/pytmc/issues/191>`__)
 *  Better messages on pragma parsing failures
-   (`#200 <https://github.com/slaclab/pytmc/issues/200>`__)
+   (`#200 <https://github.com/pcdshub/pytmc/issues/200>`__)
 *  Do not include fields only intended for input/output records in the
-   other (`#205 <https://github.com/slaclab/pytmc/issues/205>`__)
+   other (`#205 <https://github.com/pcdshub/pytmc/issues/205>`__)
 *  (Development) Fix package manifest and continuous integration
 
 
@@ -196,7 +196,7 @@ v2.6.0 (2020-02-26)
 *  Show the chain name of a failed record generation attempt
 *  Fix loading of ``_Config/IO`` files in certain cases, though there is
    still work to be done here
-   (`#187 <https://github.com/slaclab/pytmc/issues/187>`__
+   (`#187 <https://github.com/pcdshub/pytmc/issues/187>`__
 
 
 v2.5.0 (2019-12-20)
@@ -205,16 +205,16 @@ v2.5.0 (2019-12-20)
 Features
 --------
 
-* Debug tool option for showing variables which do not generate records (`#159 <https://github.com/slaclab/pytmc/issues/159>`__) “incomplete pragmas/chains”
-* Automatic generation of archive support files (`#162 <https://github.com/slaclab/pytmc/issues/162>`__)
-* Support customization of update rates via poll/notify (`#151 <https://github.com/slaclab/pytmc/issues/151>`__), looking forward to new m-epics-twincat-ads releases
-* Support record aliases (`#150 <https://github.com/slaclab/pytmc/issues/150>`__)
-* Description defaults to PLC variable path if unspecified (`#152 <https://github.com/slaclab/pytmc/issues/152>`__)
+* Debug tool option for showing variables which do not generate records (`#159 <https://github.com/pcdshub/pytmc/issues/159>`__) “incomplete pragmas/chains”
+* Automatic generation of archive support files (`#162 <https://github.com/pcdshub/pytmc/issues/162>`__)
+* Support customization of update rates via poll/notify (`#151 <https://github.com/pcdshub/pytmc/issues/151>`__), looking forward to new m-epics-twincat-ads releases
+* Support record aliases (`#150 <https://github.com/pcdshub/pytmc/issues/150>`__)
+* Description defaults to PLC variable path if unspecified (`#152 <https://github.com/pcdshub/pytmc/issues/152>`__)
 
 Fixes
 -----
-* Ordering of autosave fields (`#154 <https://github.com/slaclab/pytmc/issues/154>`__)
-* Box summary ordering (`#164 <https://github.com/slaclab/pytmc/issues/164>`__)
+* Ordering of autosave fields (`#154 <https://github.com/pcdshub/pytmc/issues/154>`__)
+* Box summary ordering (`#164 <https://github.com/pcdshub/pytmc/issues/164>`__)
 * Allow alternative character for EPICS macros (default ``@``)
 * Documentation updates + pragma key clarification
 
@@ -243,14 +243,14 @@ Fixes
 Pull requests incorporated
 --------------------------
 
-* `#130 <https://github.com/slaclab/pytmc/issues/130>`__
-* `#135 <https://github.com/slaclab/pytmc/issues/135>`__
-* `#137 <https://github.com/slaclab/pytmc/issues/137>`__
-* `#138 <https://github.com/slaclab/pytmc/issues/138>`__
-* `#141 <https://github.com/slaclab/pytmc/issues/141>`__
-* `#142 <https://github.com/slaclab/pytmc/issues/142>`__
-* `#143 <https://github.com/slaclab/pytmc/issues/143>`__
-* `#144 <https://github.com/slaclab/pytmc/issues/144>`__
+* `#130 <https://github.com/pcdshub/pytmc/issues/130>`__
+* `#135 <https://github.com/pcdshub/pytmc/issues/135>`__
+* `#137 <https://github.com/pcdshub/pytmc/issues/137>`__
+* `#138 <https://github.com/pcdshub/pytmc/issues/138>`__
+* `#141 <https://github.com/pcdshub/pytmc/issues/141>`__
+* `#142 <https://github.com/pcdshub/pytmc/issues/142>`__
+* `#143 <https://github.com/pcdshub/pytmc/issues/143>`__
+* `#144 <https://github.com/pcdshub/pytmc/issues/144>`__
 
 
 v2.3.1 (2019-11-08)
@@ -275,9 +275,9 @@ v2.3.0 (2019-10-28)
 
 PRs
 ---
-* `#123 <https://github.com/slaclab/pytmc/issues/123>`__,
-* `#124 <https://github.com/slaclab/pytmc/issues/124>`__, and
-* `#125 <https://github.com/slaclab/pytmc/issues/125>`__ to an official release.
+* `#123 <https://github.com/pcdshub/pytmc/issues/123>`__,
+* `#124 <https://github.com/pcdshub/pytmc/issues/124>`__, and
+* `#125 <https://github.com/pcdshub/pytmc/issues/125>`__ to an official release.
 
 Features
 --------

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,21 +1,23 @@
+#!/usr/bin/env python3
 """
 run_tests.py
 
-Quickly intiate pytest suite. Copied from github repository slaclab/transfocate.
+Quickly intiate pytest suite. Copied from github repository
+pcdshub/transfocate.
 """
-#!/usr/bin/env python
 import sys
+
 import pytest
 
-if __name__ == '__main__':
-    #Show output results from every test function
-    #Show the message output for skipped and expected failures
-    args = ['-v', '-vrxs','--color=yes']
+if __name__ == "__main__":
+    # Show output results from every test function
+    # Show the message output for skipped and expected failures
+    args = ["-v", "-vrxs", "--color=yes"]
 
-    #Add extra arguments
-    if len(sys.argv) >1:
+    # Add extra arguments
+    if len(sys.argv) > 1:
         args.extend(sys.argv[1:])
 
-    print('pytest arguments: {}'.format(args))
+    print("pytest arguments: {}".format(args))
 
 sys.exit(pytest.main(args))


### PR DESCRIPTION
Closes #259 

Will require new release to fix PyPI, but in principle this should do it.
Done using `git sed` (*) so should double check I didn't do anything terribly wrong.

(*) 
`.gitconfig`
```
[alias]
sed=!git grep -z --full-name -l '.' | xargs -0 sed -i '' -e
```