### PR TITLE
ENH: link strings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   allow_failures:
-    - name: "Python 3.6 - PIP"
+    - name: "Python 3.8 - PIP"
 
 after_failure:
   - cat logs/run_tests_log.txt

--- a/pytmc/record.py
+++ b/pytmc/record.py
@@ -478,7 +478,7 @@ class TwincatTypeRecordPackage(RecordPackage):
             # Consider this temporary API, only to be used in
             # lcls-twincat-general for now.
             pv_parts = list(self.config['pv'])
-            linked_to_pv = ':'.join(
+            linked_to_pv = self.delimiter.join(
                 pv_parts[:-1] + [last_link.lstrip('*')]
             )
         else:

--- a/pytmc/record.py
+++ b/pytmc/record.py
@@ -787,6 +787,7 @@ class StringRecordPackage(TwincatTypeRecordPackage):
         )
         record.fields.pop('TSE', None)
         record.fields.pop('PINI', None)
+        record.fields["SIZV"] = self.nelm
 
         # Add our port
         record.fields.update(

--- a/pytmc/record.py
+++ b/pytmc/record.py
@@ -752,7 +752,11 @@ class StringRecordPackage(TwincatTypeRecordPackage):
     input_rtyp = 'waveform'
     output_rtyp = 'waveform'
     dtyp = 'asynInt8'
-    field_defaults = {'FTVL': 'CHAR'}
+    field_defaults = {
+        'FTVL': 'CHAR',
+        'APST': 'On Change',
+        'MPST': 'On Change',
+    }
 
     # Links to string PVs require auxiliary 'lso' record.
     link_requires_record = True

--- a/pytmc/tests/test_xml_collector.py
+++ b/pytmc/tests/test_xml_collector.py
@@ -521,6 +521,28 @@ def test_pv_linking():
     assert rec.fields['SCAN'] == '.5 second'
 
 
+def test_pv_linking_string():
+    item = make_mock_twincatitem(
+        name='Main.tcname', data_type=make_mock_type('STRING'),
+        pragma='pv: PVNAME; link: OTHER:RECORD')
+
+    pkg, = list(pragmas.record_packages_from_symbol(item))
+    assert pkg.pvname == 'PVNAME'
+    assert pkg.tcname == 'Main.tcname'
+    assert isinstance(pkg, StringRecordPackage)
+
+    in_rec, out_rec, lso_rec = pkg.records
+    assert "OMSL" not in out_rec.fields
+    assert "DOL" not in out_rec.fields
+
+    lso_pvname = pkg.delimiter.join((out_rec.pvname, pkg.link_suffix))
+    assert lso_rec.pvname == lso_pvname
+    assert lso_rec.record_type == "lso"
+    assert lso_rec.fields["OMSL"] == "closed_loop"
+    assert lso_rec.fields["DOL"] == "OTHER:RECORD CPP MS"
+    assert lso_rec.fields["SCAN"] == ".5 second"
+
+
 def test_pv_linking_special():
     struct = make_mock_twincatitem(
         name='Main.array_base',

--- a/pytmc/tests/test_xml_collector.py
+++ b/pytmc/tests/test_xml_collector.py
@@ -523,8 +523,8 @@ def test_pv_linking():
 
 def test_pv_linking_string():
     item = make_mock_twincatitem(
-        name='Main.tcname', data_type=make_mock_type('STRING'),
-        pragma='pv: PVNAME; link: OTHER:RECORD')
+        name='Main.tcname', data_type=make_mock_type('STRING', length=70),
+        pragma='pv: PVNAME; link: OTHER:RECORD.VAL$')
 
     pkg, = list(pragmas.record_packages_from_symbol(item))
     assert pkg.pvname == 'PVNAME'
@@ -539,7 +539,7 @@ def test_pv_linking_string():
     assert lso_rec.pvname == lso_pvname
     assert lso_rec.record_type == "lso"
     assert lso_rec.fields["OMSL"] == "closed_loop"
-    assert lso_rec.fields["DOL"] == "OTHER:RECORD CPP MS"
+    assert lso_rec.fields["DOL"] == "OTHER:RECORD.VAL$ CPP MS"
     assert lso_rec.fields["SCAN"] == ".5 second"
     assert lso_rec.fields["SIZV"] == 70
 

--- a/pytmc/tests/test_xml_collector.py
+++ b/pytmc/tests/test_xml_collector.py
@@ -541,6 +541,7 @@ def test_pv_linking_string():
     assert lso_rec.fields["OMSL"] == "closed_loop"
     assert lso_rec.fields["DOL"] == "OTHER:RECORD CPP MS"
     assert lso_rec.fields["SCAN"] == ".5 second"
+    assert lso_rec.fields["SIZV"] == 70
 
 
 def test_pv_linking_special():


### PR DESCRIPTION
Background
------------
`link:` allows for pytmc to generate records that push PV data _into_ the PLC from other IOCs.

Status quo
-------------
pytmc currently supports linking numeric scalar values (with corresponding records that have the `OMSL`/`DOL` fields). 
This doesn't include strings.

This PR
--------
* This PR adds in an additional record to glue the "to-plc output" waveform record
* Using the `lso` record, we have long string output support (> 40 chars)
* Closes #267 (further reference/record example there)

I'm going to build up the PLC side of this before finalizing this PR and making it ready-for-review, as one may influence the other.

Pairs with https://github.com/pcdshub/lcls-twincat-general/pull/53

Example diff
-------------

pytmc master vs this PR

```diff
diff --git a/Untitled1.db b/Untitled1.db
index 4fafd46..a2799d9 100644
--- a/Untitled1.db
+++ b/Untitled1.db
@@ -63,17 +63,23 @@ record(waveform, "IOC:TEST:LINK2:EPICSLink_RBV") {
 record(waveform, "IOC:TEST:LINK2:EPICSLink") {
   # Internal variable used to monitor EPICS PV in PLC
   field(DESC, "Internal variable us...r EPICS PV in PLC")
-  field(SCAN, ".5 second")
   field(DTYP, "asynInt8ArrayOut")
   field(INP, "@asyn($(PORT),0,1)ADSPORT=851/MAIN.fbLinkedValue2.sPLCInternalValue=")
   field(FTVL, "CHAR")
-  field(DOL, "IOC:TEST:STRING CPP MS")
-  field(OMSL, "closed_loop")
   field(NELM, "80")
   info(autosaveFields_pass0, "VAL")
   info(archive, "VAL")
 }

+record(lso, "IOC:TEST:LINK2:EPICSLink:LSO") {
+  # Aux link record for MAIN.fbLinkedValue2.sPLCInternalValue
+  field(DESC, "Aux link record for ...sPLCInternalValue")
+  field(SCAN, ".5 second")
+  field(DOL, "IOC:TEST:STRING CPP MS")
+  field(OMSL, "closed_loop")
+  field(OUT, "IOC:TEST:LINK2:EPICSLink PP MS")
+}
+
 record(longin, "IOC:TEST:LINK2:EPICSLink:LinkSeverity_RBV") {
   # Internal variable used to monitor EPICS PV severity in PLC
   field(DESC, "Internal variable us...V severity in PLC")
```