### PR TITLE
MNT: miscellaneous minor fixes and tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   allow_failures:
-    - name: "Python 3.8 - PIP"
+    - name: "Python - PIP"
 
 after_failure:
   - cat logs/run_tests_log.txt

--- a/pytmc/bin/stcmd.py
+++ b/pytmc/bin/stcmd.py
@@ -228,7 +228,7 @@ def main(tsproj_project, *, name=None, prefix=None,
                                f'Projects: {list(by_name)}')
 
     symbols = separate_by_classname(plc.find(Symbol))
-    motors = [mot for mot in symbols['Symbol_DUT_MotionStage']
+    motors = [mot for mot in symbols.get('Symbol_DUT_MotionStage', [])
               if not mot.is_pointer]
 
     if plc.tmc is None:

--- a/pytmc/code.py
+++ b/pytmc/code.py
@@ -148,7 +148,7 @@ def variables_from_declaration(declaration, *, start_marker='var'):
     return variables
 
 
-def get_pou_call_blocks(declaration, implementation):
+def get_pou_call_blocks(declaration: str, implementation: str):
     '''
     Find all call blocks given a specific POU declaration and implementation.
     Note that this function is not "smart". Further calls will be squashed into

--- a/pytmc/code.py
+++ b/pytmc/code.py
@@ -1,10 +1,9 @@
 '''
 Code parsing-related utilities
 '''
-import logging
 import collections
+import logging
 import re
-
 
 logger = logging.getLogger(__name__)
 
@@ -70,10 +69,11 @@ def lines_between(text, start_marker, end_marker, *, include_blank=False):
     for line in text.splitlines():
         if line.strip().lower() == start_marker:
             found_start = True
-        elif line.strip().lower() == end_marker:
-            break
-        elif found_start and (line.strip() or include_blank):
-            yield line
+        elif found_start:
+            if line.strip().lower() == end_marker:
+                break
+            elif line.strip() or include_blank:
+                yield line
 
 
 def variables_from_declaration(declaration, *, start_marker='var'):

--- a/pytmc/parser.py
+++ b/pytmc/parser.py
@@ -1461,6 +1461,19 @@ class GVL(_TwincatProjectSubItem):
         return self.declaration
 
 
+class EnumerationTextList(_TwincatProjectSubItem):
+    '[TcDUT] An enumerated text list type'
+
+    @property
+    def declaration(self):
+        'The declaration code; i.e., the top portion in visual studio'
+        return self.Declaration[0].text
+
+    def get_source_code(self, *, close_block=True):
+        'The full source code - declaration only in the case of an ENUM'
+        return self.declaration
+
+
 class ST(_TwincatProjectSubItem):
     '[TcDUT/TcPOU] Structured text'
 

--- a/pytmc/parser.py
+++ b/pytmc/parser.py
@@ -152,7 +152,6 @@ class TwincatItem:
     attributes: typing.Dict[str, str]
     children: types.SimpleNamespace
     comments: typing.List[str]
-    element: lxml.etree.Element
     filename: pathlib.Path
     name: str
     parent: 'TwincatItem'
@@ -178,7 +177,6 @@ class TwincatItem:
         self._children = []
         self.children = None  # populated later
         self.comments = []
-        self.element = element
         self.filename = filename
         self.name = name
         self.parent = parent
@@ -391,7 +389,8 @@ class TwincatItem:
 class _LazyLoadPlaceholder:
     def __init__(self, cls, element, parent):
         self.cls = cls
-        self.element = element
+        self.filename = element.attrib.get('File', "").lower()
+        self.identifier = element.attrib.get('Id', "")
         self.parent = parent
 
     def __repr__(self):
@@ -402,9 +401,7 @@ class _LazyLoadPlaceholder:
 
     @property
     def key(self):
-        filename = self.element.attrib['File'].lower()
-        identifier = self.element.attrib['Id']
-        return (self.cls, identifier, filename)
+        return (self.cls, self.identifier, self.filename)
 
     def load(self, file_map):
         info = file_map[self.key]

--- a/pytmc/parser.py
+++ b/pytmc/parser.py
@@ -329,7 +329,11 @@ class TwincatItem:
                 child._finish_lazy_loading(file_map)
 
     @staticmethod
-    def parse(element, parent=None, filename=None) -> TwincatItem:
+    def parse(
+        element: lxml.etree.Element,
+        parent: Optional[TwincatItem] = None,
+        filename: Optional[str] = None
+    ) -> TwincatItem:
         '''
         Parse an XML element and return a TwincatItem
 
@@ -1806,6 +1810,7 @@ class Pdo(TwincatItem):
 
 class Entry(TwincatItem):
     """Pdo Entry, containing name and type information."""
+    Comment: List[TwincatItem]
 
     @property
     def entry_type(self) -> Optional[Type]:
@@ -1868,6 +1873,10 @@ class DefaultResolution(Resolution):
 
 
 class _VersionItemMixin:
+    # Resolution: List[TwincatItem]
+    # DefaultResolution: List[TwincatItem]
+    # Namespace: List[TwincatItem]
+
     @property
     def resolution(self) -> Optional[Union[DefaultResolution, Resolution]]:
         try:


### PR DESCRIPTION
## Changes
* Some things sitting around uncommitted for a while
* Some additional type hint cleanups/fixes
* One (probably never-hit) bug fixed: "lines_between" had a logic error that would not search for the start marker if the end marker was found before it
* Reduced memory consumption slightly by not caching the xml element on every TwincatItem
* Add `EnumerationTextList` with `get_source_code` support; as previously these translatable types were missing

## Parser classes background
So there are some unfortunate things in the way that the parser breaks out `TwincatItem` classes. Here's the background on why the parser items are as they are:
* I wanted easy mappings of TwinCAT `<xml-tag>` to Python class, where methods and properties could then be context-specific (e.g., _give me the source code of the GVL_)
* I wanted things like `gvl.Declaration` or `plc.TcSmItem.PlcProject.Mappings` to be a thing you could do, since I thought `__getitem__`-based `plc["TcSmItem"]["PlcProject"]["Mappings"]` was verbose and ugly
* I was unaware of which XML items would be able to have more than one entry in a given scope. (In retrospect, TwinCAT has xsds that provide this information)
* This led to the current (ugly) structure of `plc.TcSmItem[0].PlcProject[0].Mappings[...]`, along with all of the code that grabs the only element from an assumed single-element list

## What about better type hints?
Now, type hints weren't _really_ a thing when pytmc was getting on its feet, at least with the versions we used and whatnot.
So type hints in `TwincatItem` subclasses are unfortunately really bad, given how the classes are structured:
```python
class EnumInfo(_TmcItem):
    # Some have type hints like this now
    Comment: list  
    # What we really want to say to describe the structure as-is
    Comment: Optional[typing.List[Comment]]  
    # With a refactor to de-listify single items, this would be ideal
    Comment: Optional[Comment]  
```
The latter two appear to be circular references rather than one to a corresponding `Comment` class.

Where do we go from here? Though I'd really like to see this improved, I guess we just leave it as-is until a real refactor could be justified - unless anyone has a better idea.