### PR TITLE
CLN: remove evalcontextfilter usage

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,4 +12,4 @@
 	url = https://github.com/pcdshub/lcls-twincat-pmps.git
 [submodule "tests/projects/lcls-plc-kfe-gmd-vac-ext-io"]
 	path = pytmc/tests/projects/lcls-plc-kfe-gmd-vac-ext-io
-	url = git://github.com/n-wbrown/lcls-plc-kfe-gmd-vac.git
+	url = https://github.com/n-wbrown/lcls-plc-kfe-gmd-vac.git

--- a/pytmc/bin/stcmd.py
+++ b/pytmc/bin/stcmd.py
@@ -160,16 +160,13 @@ def jinja_filters(**user_config):
     'All jinja filters'
     # TODO all can be cached based on object, if necessary
 
-    @jinja2.evalcontextfilter
-    def epics_prefix(eval_ctx, obj):
+    def epics_prefix(obj):
         return get_name(obj, user_config)[0]
 
-    @jinja2.evalcontextfilter
-    def epics_suffix(eval_ctx, obj):
+    def epics_suffix(obj):
         return get_name(obj, user_config)[1]
 
-    @jinja2.evalcontextfilter
-    def pragma(eval_ctx, obj, key, default=''):
+    def pragma(obj, key, default=''):
         item_and_config = pragmas.expand_configurations_from_chain([obj])
         if item_and_config:
             item_to_config = dict(item_and_config[0])

--- a/pytmc/bin/template.py
+++ b/pytmc/bin/template.py
@@ -254,16 +254,13 @@ def get_jinja_filters(**user_config):
     if 'prefix' not in user_config:
         user_config['prefix'] = 'PREFIX'
 
-    @jinja2.evalcontextfilter
-    def epics_prefix(eval_ctx, obj):
+    def epics_prefix(obj):
         return stcmd.get_name(obj, user_config)[0]
 
-    @jinja2.evalcontextfilter
-    def epics_suffix(eval_ctx, obj):
+    def epics_suffix(obj):
         return stcmd.get_name(obj, user_config)[1]
 
-    @jinja2.evalcontextfilter
-    def pragma(eval_ctx, obj, key, default=''):
+    def pragma(obj, key, default=''):
         item_and_config = pragmas.expand_configurations_from_chain([obj])
         if item_and_config:
             item_to_config = dict(item_and_config[0])
@@ -271,8 +268,7 @@ def get_jinja_filters(**user_config):
             return config.get(key, default)
         return default
 
-    @jinja2.evalcontextfilter
-    def title_fill(eval_ctx, text, fill_char):
+    def title_fill(text, fill_char):
         return fill_char * len(text)
 
     return {


### PR DESCRIPTION
* `evalcontextfilter` was deprecated in JInja2 and removed in 3.1
* We used this to wrap our filters but didn't use the context, so I've just removed such references
* Templates still working during local testing with Jinja2 3.1:

```
pytmc/tests/test_commandline.py::test_template_basic[/Users/klauer/Repos/pytmc/pytmc/tests/projects/lcls-plc-kfe-motion/plc-kfe-motion/plc-kfe-motion.tsproj] PASSED [ 15%]
pytmc/tests/test_commandline.py::test_template_basic[/Users/klauer/Repos/pytmc/pytmc/tests/projects/lcls-plc-kfe-gmd-vac-ext-io/plc/plc-kfe-gmd-vac/plc-kfe-gmd-vac.tsproj] PASSED [ 23%]
pytmc/tests/test_commandline.py::test_template_basic[/Users/klauer/Repos/pytmc/pytmc/tests/projects/lcls-plc-kfe-xgmd-vac/plc/plc-kfe-xgmd-vac/plc_kfe_xgmd_vac.tsproj] PASSED [ 30%]
pytmc/tests/test_commandline.py::test_template_basic[/Users/klauer/Repos/pytmc/pytmc/tests/projects/lcls-twincat-pmps/lcls-twincat-pmps/lcls-twincat-pmps.tsproj] PASSED [ 38%]
```