### PR TITLE
FIX: CP link instead of CPP link

### DIFF
--- a/pytmc/record.py
+++ b/pytmc/record.py
@@ -214,7 +214,7 @@ class RecordPackage:
         return config
 
     def _configure_link(self):
-        'Link this record to a pre-existing EPICS record via a CA (CPP) link'
+        'Link this record to a pre-existing EPICS record via a CA (CP) link'
         self.linked_to_pv = self.config.get('link') or None
 
     def _configure_pvname(self):
@@ -493,7 +493,7 @@ class TwincatTypeRecordPackage(RecordPackage):
         linked_to_pv = linked_to_pv.replace(self.macro_character, '$')
         return {
             'OMSL': 'closed_loop',
-            'DOL': linked_to_pv + ' CPP MS',
+            'DOL': linked_to_pv + ' CP MS',
             'SCAN': self.config.get('link_scan', '.5 second'),
         }
 

--- a/pytmc/tests/test_xml_collector.py
+++ b/pytmc/tests/test_xml_collector.py
@@ -517,7 +517,7 @@ def test_pv_linking():
     assert isinstance(pkg, IntegerRecordPackage)
     rec = pkg.generate_output_record()
     assert rec.fields['OMSL'] == 'closed_loop'
-    assert rec.fields['DOL'] == 'OTHER:RECORD CPP MS'
+    assert rec.fields['DOL'] == 'OTHER:RECORD CP MS'
     assert rec.fields['SCAN'] == '.5 second'
 
 
@@ -539,7 +539,7 @@ def test_pv_linking_string():
     assert lso_rec.pvname == lso_pvname
     assert lso_rec.record_type == "lso"
     assert lso_rec.fields["OMSL"] == "closed_loop"
-    assert lso_rec.fields["DOL"] == "OTHER:RECORD.VAL$ CPP MS"
+    assert lso_rec.fields["DOL"] == "OTHER:RECORD.VAL$ CP MS"
     assert lso_rec.fields["SCAN"] == ".5 second"
     assert lso_rec.fields["SIZV"] == 70
 
@@ -571,10 +571,10 @@ def test_pv_linking_struct():
 
     pkg1, pkg2 = list(pragmas.record_packages_from_symbol(struct))
     rec = pkg1.generate_output_record()
-    assert rec.fields['DOL'] == 'PREFIX:ABCD.STAT CPP MS'
+    assert rec.fields['DOL'] == 'PREFIX:ABCD.STAT CP MS'
 
     rec = pkg2.generate_output_record()
-    assert rec.fields['DOL'] == 'LINK:OTHER_PV CPP MS'
+    assert rec.fields['DOL'] == 'LINK:OTHER_PV CP MS'
 
 
 def test_pv_linking_special():
@@ -594,7 +594,7 @@ def test_pv_linking_special():
 
     pkg, = list(pragmas.record_packages_from_symbol(struct))
     rec = pkg.generate_output_record()
-    assert rec.fields['DOL'] == 'PREFIX:ABCD.STAT CPP MS'
+    assert rec.fields['DOL'] == 'PREFIX:ABCD.STAT CP MS'
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Context

Closes #282 

Prior to this PR, we are erroneously limited to 2Hz updates for all IOC->PLC PV links due to the 0.5 second SCAN rate configured for linked records. What we want is the IOC to write to the PLC on *every* update, and failing that at 2Hz.

## Background

* A `CPP` link means "channel access link which causes processing (when the monitor is fired), **only if** the record's scan field is set to Process Passive
* A `CP` link means "channel access link which causes processing (when the monitor is fired), regardless of the record's SCAN field

In our case, we want the linked record to cause processing on *every* update. This is how the mechanism is supposed to work with pytmc writing values from the IOC to the PLC.