### PR TITLE
ENH: autosave field additions

### DIFF
--- a/pytmc/record.py
+++ b/pytmc/record.py
@@ -3,7 +3,7 @@ Record generation and templating
 """
 import logging
 from collections import ChainMap, OrderedDict
-from typing import Optional
+from typing import Dict, List, Optional, Set
 
 import jinja2
 
@@ -315,6 +315,65 @@ class RecordPackage:
         return spec(*args, chain=chain, **kwargs)
 
 
+AutosaveDefaults = Dict[str, Dict[str, Set[str]]]
+
+
+def make_autosave_defaults(
+    input_pass0: Optional[List[str]] = None,
+    input_pass1: Optional[List[str]] = None,
+    output_pass0: Optional[List[str]] = None,
+    output_pass1: Optional[List[str]] = None,
+    exclude_defaults: bool = False,
+) -> AutosaveDefaults:
+    """
+    Create autosave defaults for a given record type.
+
+    Parameters
+    ----------
+    input_pass0 : List[str]
+        Fields to save on the input record for pass 0 (pre-iocInit)
+    input_pass1 : List[str]
+        Fields to save on the input record for pass 1 (post-iocInit)
+    output_pass0 : List[str]
+        Fields to save on the output record for pass 0 (pre-iocInit)
+    output_pass1 : List[str]
+        Fields to save on the output record for pass 1 (post-iocInit)
+    exclude_defaults : bool, optional
+        Exclude the defaults normally used for all records.
+
+    Returns
+    -------
+    dict
+        Dictionary of defaults with keys "input" and "output", under which
+        are keys "pass0" and "pass1".
+    """
+
+    if not exclude_defaults:
+        default_input_pass0 = {
+            "DISS",  # Disable Alarm Sevrty
+            "UDFS",  # Undefined Alarm Sevrty
+        }
+        default_output_pass0 = {
+            "VAL",  # The value
+            "DISS",  # Disable Alarm Sevrty
+            "UDFS",  # Undefined Alarm Sevrty
+        }
+    else:
+        default_input_pass0 = set()
+        default_output_pass0 = set()
+
+    return dict(
+        input=dict(
+            pass0=set(input_pass0 or []) | default_input_pass0,
+            pass1=set(input_pass1 or []),
+        ),
+        output=dict(
+            pass0=set(output_pass0 or []) | default_output_pass0,
+            pass1=set(output_pass1 or []),
+        ),
+    )
+
+
 class TwincatTypeRecordPackage(RecordPackage):
     """
     The common parent for all RecordPackages for basic Twincat types
@@ -343,12 +402,7 @@ class TwincatTypeRecordPackage(RecordPackage):
        not required.
     """
     field_defaults = {'PINI': 1, 'TSE': -2}
-    autosave_defaults = {
-        'input': dict(pass0={},
-                      pass1={}),
-        'output': dict(pass0={'VAL'},
-                       pass1={}),
-    }
+    autosave_defaults = make_autosave_defaults()
 
     dtyp = NotImplemented
     input_rtyp = NotImplemented
@@ -567,6 +621,20 @@ class BinaryRecordPackage(TwincatTypeRecordPackage):
                           'OUT', 'RBV', 'RPVT', 'WDPT'}
     input_only_fields = {'SVAL'}
 
+    autosave_defaults = make_autosave_defaults(
+        input_pass0=[
+            "ZSV",  # Zero Error Severity
+            "OSV",  # One Error Severity
+            "SIMS",  # Simulation Mode Severity
+        ],
+        output_pass0=[
+            "ZSV",  # Zero Error Severity
+            "OSV",  # One Error Severity
+            "COSV",  # Change of State Sevr
+            "SIMS",  # Simulation Mode Severity
+        ],
+    )
+
 
 class IntegerRecordPackage(TwincatTypeRecordPackage):
     """Create a set of records for an integer Twincat Variable"""
@@ -575,6 +643,23 @@ class IntegerRecordPackage(TwincatTypeRecordPackage):
     output_only_fields = {'DOL', 'DRVH', 'DRVL', 'IVOA', 'IVOV', 'OMSL'}
     input_only_fields = {'AFTC', 'AFVL', 'SVAL'}
     dtyp = 'asynInt32'
+
+    autosave_defaults = make_autosave_defaults(
+        input_pass0=[
+            "HHSV",  # Hihi Severity
+            "HSV",  # High Severity
+            "LLSV",  # Lolo Severity
+            "LSV",  # Low Severity
+            "SIMS",  # Simulation Mode Severity
+        ],
+        output_pass0=[
+            "HHSV",  # Hihi Severity
+            "HSV",  # High Severity
+            "LLSV",  # Lolo Severity
+            "LSV",  # Low Severity
+            "SIMS",  # Simulation Mode Severity
+        ],
+    )
 
 
 class FloatRecordPackage(TwincatTypeRecordPackage):
@@ -588,12 +673,25 @@ class FloatRecordPackage(TwincatTypeRecordPackage):
                           'RBV'}
     input_only_fields = {'AFTC', 'AFVL', 'SMOO', 'SVAL'}
 
-    autosave_defaults = {
-        'input': dict(pass0={'PREC'},
-                      pass1={}),
-        'output': dict(pass0={'VAL', 'PREC'},
-                       pass1={}),
-    }
+    autosave_defaults = make_autosave_defaults(
+        input_pass0=[
+            "HHSV",  # Hihi Severity
+            "HSV",  # High Severity
+            "LLSV",  # Lolo Severity
+            "LSV",  # Low Severity
+            "PREC",  # precision
+            "SIMS",  # Simulation Mode Severity
+        ],
+        output_pass0=[
+            "HHSV",  # Hihi Severity
+            "HSV",  # High Severity
+            "LLSV",  # Lolo Severity
+            "LSV",  # Low Severity
+            "PREC",  # precision
+            "SIMS",  # Simulation Mode Severity
+            "VAL",  # the value
+        ],
+    )
 
     def get_scale_offset(self):
         """Get the scale and offset for the analog record(s)."""
@@ -634,6 +732,49 @@ class EnumRecordPackage(TwincatTypeRecordPackage):
     dtyp = 'asynInt32'
     output_only_fields = {'DOL', 'IVOA', 'IVOV', 'OMSL', 'ORBV', 'RBV'}
     input_only_fields = {'AFTC', 'AFVL', 'SVAL'}
+    autosave_defaults = make_autosave_defaults(
+        input_pass0=[
+            "ZRSV",  # State Zero Severity
+            "ONSV",  # State One Severity
+            "TWSV",  # State Two Severity
+            "THSV",  # State Three Severity
+            "FRSV",  # State Four Severity
+            "FVSV",  # State Five Severity
+            "SXSV",  # State Six Severity
+            "SVSV",  # State Seven Severity
+            "EISV",  # State Eight Severity
+            "NISV",  # State Nine Severity
+            "TESV",  # State Ten Severity
+            "ELSV",  # State Eleven Severity
+            "TVSV",  # State Twelve Severity
+            "TTSV",  # State Thirteen Sevr
+            "FTSV",  # State Fourteen Sevr
+            "FFSV",  # State Fifteen Severity
+            "UNSV",  # Unknown State Severity
+            "SIMS",  # Simulation Mode Severity
+        ],
+        output_pass0=[
+            "ZRSV",  # State Zero Severity
+            "ONSV",  # State One Severity
+            "TWSV",  # State Two Severity
+            "THSV",  # State Three Severity
+            "FRSV",  # State Four Severity
+            "FVSV",  # State Five Severity
+            "SXSV",  # State Six Severity
+            "SVSV",  # State Seven Severity
+            "EISV",  # State Eight Severity
+            "NISV",  # State Nine Severity
+            "TESV",  # State Ten Severity
+            "ELSV",  # State Eleven Severity
+            "TVSV",  # State Twelve Severity
+            "TTSV",  # State Thirteen Sevr
+            "FTSV",  # State Fourteen Sevr
+            "FFSV",  # State Fifteen Sevr
+            "UNSV",  # Unknown State Sevr
+            "COSV",  # Change of State Sevr
+            "SIMS",  # Simulation Mode Severity
+        ],
+    )
 
     mbb_fields = [
         ('ZRVL', 'ZRST'),
@@ -674,6 +815,14 @@ class WaveformRecordPackage(TwincatTypeRecordPackage):
         'APST': 'On Change',
         'MPST': 'On Change',
     }
+    autosave_defaults = make_autosave_defaults(
+        input_pass0=[
+            "SIMS",  # Simulation Mode Severity
+        ],
+        output_pass0=[
+            "SIMS",  # Simulation Mode Severity
+        ],
+    )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -757,6 +906,24 @@ class StringRecordPackage(TwincatTypeRecordPackage):
         'APST': 'On Change',
         'MPST': 'On Change',
     }
+    autosave_defaults = make_autosave_defaults(
+        input_pass0=[
+            "SIMS",  # Simulation Mode Severity
+        ],
+        output_pass0=[
+            "SIMS",  # Simulation Mode Severity
+        ],
+    )
+    # The LSO record that gets generated when a "link" is used to write
+    # string data into the PLC from another EPICS PV:
+    autosave_defaults_for_link = make_autosave_defaults(
+        input_pass0=[
+            "SIMS",  # Simulation Mode Severity
+        ],
+        output_pass0=[
+            "SIMS",  # Simulation Mode Severity
+        ],
+    )
 
     # Links to string PVs require auxiliary 'lso' record.
     link_requires_record = True
@@ -788,6 +955,7 @@ class StringRecordPackage(TwincatTypeRecordPackage):
             record_type="lso",
             direction="output",
             package=self,
+            autosave=self.autosave_defaults_for_link["output"],
         )
         record.fields.pop('TSE', None)
         record.fields.pop('PINI', None)

--- a/pytmc/record.py
+++ b/pytmc/record.py
@@ -352,11 +352,13 @@ def make_autosave_defaults(
         default_input_pass0 = {
             "DISS",  # Disable Alarm Sevrty
             "UDFS",  # Undefined Alarm Sevrty
+            "DESC",  # Description
         }
         default_output_pass0 = {
             "VAL",  # The value (pass 0, does not cause a write)
             "DISS",  # Disable Alarm Sevrty
             "UDFS",  # Undefined Alarm Sevrty
+            "DESC",  # Description
         }
     else:
         default_input_pass0 = set()
@@ -649,18 +651,33 @@ class IntegerRecordPackage(TwincatTypeRecordPackage):
 
     autosave_defaults = make_autosave_defaults(
         input_pass0=[
+            # Alarm severities
             "HHSV",  # Hihi Severity
             "HSV",  # High Severity
             "LLSV",  # Lolo Severity
             "LSV",  # Low Severity
             "SIMS",  # Simulation Mode Severity
+            # Alarm limits
+            "HIHI",  # Hihi Alarm Limit
+            "LOLO",  # Lolo Alarm Limit
+            "HIGH",  # High Alarm Limit
+            "LOW",  # Low Alarm Limit
         ],
         output_pass0=[
+            # Alarm severities
             "HHSV",  # Hihi Severity
             "HSV",  # High Severity
             "LLSV",  # Lolo Severity
             "LSV",  # Low Severity
             "SIMS",  # Simulation Mode Severity
+            # Control limits
+            "DRVH",  # Drive High Limit
+            "DRVL",  # Drive Low Limit
+            # Alarm limits
+            "HIHI",  # Hihi Alarm Limit
+            "LOLO",  # Lolo Alarm Limit
+            "HIGH",  # High Alarm Limit
+            "LOW",  # Low Alarm Limit
         ],
     )
 
@@ -678,20 +695,37 @@ class FloatRecordPackage(TwincatTypeRecordPackage):
 
     autosave_defaults = make_autosave_defaults(
         input_pass0=[
+            # Basics
+            "PREC",  # precision
+            # Alarm severities
             "HHSV",  # Hihi Severity
             "HSV",  # High Severity
             "LLSV",  # Lolo Severity
             "LSV",  # Low Severity
-            "PREC",  # precision
             "SIMS",  # Simulation Mode Severity
+            # Alarm limits
+            "HIHI",  # Hihi Alarm Limit
+            "LOLO",  # Lolo Alarm Limit
+            "HIGH",  # High Alarm Limit
+            "LOW",  # Low Alarm Limit
         ],
         output_pass0=[
+            # Basics
+            "PREC",  # precision
+            # Alarm severities
             "HHSV",  # Hihi Severity
             "HSV",  # High Severity
             "LLSV",  # Lolo Severity
             "LSV",  # Low Severity
-            "PREC",  # precision
             "SIMS",  # Simulation Mode Severity
+            # Control limits
+            "DRVH",  # Drive High Limit
+            "DRVL",  # Drive Low Limit
+            # Alarm limits
+            "HIHI",  # Hihi Alarm Limit
+            "LOLO",  # Lolo Alarm Limit
+            "HIGH",  # High Alarm Limit
+            "LOW",  # Low Alarm Limit
         ],
     )
 
@@ -736,6 +770,7 @@ class EnumRecordPackage(TwincatTypeRecordPackage):
     input_only_fields = {'AFTC', 'AFVL', 'SVAL'}
     autosave_defaults = make_autosave_defaults(
         input_pass0=[
+            # Per-state severities
             "ZRSV",  # State Zero Severity
             "ONSV",  # State One Severity
             "TWSV",  # State Two Severity
@@ -756,6 +791,7 @@ class EnumRecordPackage(TwincatTypeRecordPackage):
             "SIMS",  # Simulation Mode Severity
         ],
         output_pass0=[
+            # Per-state severities
             "ZRSV",  # State Zero Severity
             "ONSV",  # State One Severity
             "TWSV",  # State Two Severity

--- a/pytmc/record.py
+++ b/pytmc/record.py
@@ -354,7 +354,7 @@ def make_autosave_defaults(
             "UDFS",  # Undefined Alarm Sevrty
         }
         default_output_pass0 = {
-            "VAL",  # The value
+            "VAL",  # The value (pass 0, does not cause a write)
             "DISS",  # Disable Alarm Sevrty
             "UDFS",  # Undefined Alarm Sevrty
         }
@@ -577,6 +577,9 @@ class TwincatTypeRecordPackage(RecordPackage):
         record.fields['DTYP'] = self.dtyp
         record.fields['OUT'] = self.asyn_output_port_spec
 
+        # By default, NO_ALARM if the output record has not processed yet:
+        record.fields.setdefault("UDFS", "0")
+
         # Remove timestamp source and process-on-init for output records:
         record.fields.pop('TSE', None)
         record.fields.pop('PINI', None)
@@ -689,7 +692,6 @@ class FloatRecordPackage(TwincatTypeRecordPackage):
             "LSV",  # Low Severity
             "PREC",  # precision
             "SIMS",  # Simulation Mode Severity
-            "VAL",  # the value
         ],
     )
 

--- a/pytmc/tests/ads.dbd
+++ b/pytmc/tests/ads.dbd
@@ -1,15494 +1,19572 @@
-menu(waveformPOST) {
-	choice(waveformPOST_Always,"Always")
-	choice(waveformPOST_OnChange,"On Change")
-}
-menu(stringoutPOST) {
-	choice(stringoutPOST_OnChange,"On Change")
-	choice(stringoutPOST_Always,"Always")
-}
-menu(stringinPOST) {
-	choice(stringinPOST_OnChange,"On Change")
-	choice(stringinPOST_Always,"Always")
-}
-menu(serialSBIT) {
-	choice(serialSBIT_unknown,"Unknown")
-	choice(serialSBIT_1,"1")
-	choice(serialSBIT_2,"2")
-}
 menu(serialPRTY) {
-	choice(serialPRTY_unknown,"Unknown")
-	choice(serialPRTY_None,"None")
-	choice(serialPRTY_Even,"Even")
-	choice(serialPRTY_Odd,"Odd")
+    choice(serialPRTY_unknown, "Unknown")
+    choice(serialPRTY_None, "None")
+    choice(serialPRTY_Even, "Even")
+    choice(serialPRTY_Odd, "Odd")
 }
-menu(serialMCTL) {
-	choice(serialMCTL_unknown,"Unknown")
-	choice(serialMCTL_CLOCAL,"CLOCAL")
-	choice(serialMCTL_Yes,"YES")
-}
-menu(serialIX) {
-	choice(serialIX_unknown,"Unknown")
-	choice(serialIX_No,"No")
-	choice(serialIX_Yes,"Yes")
-}
-menu(serialFCTL) {
-	choice(serialFCTL_unknown,"Unknown")
-	choice(serialFCTL_None,"None")
-	choice(serialFCTL_Hardware,"Hardware")
-}
-menu(serialDBIT) {
-	choice(serialDBIT_unknown,"Unknown")
-	choice(serialDBIT_5,"5")
-	choice(serialDBIT_6,"6")
-	choice(serialDBIT_7,"7")
-	choice(serialDBIT_8,"8")
-}
-menu(serialBAUD) {
-	choice(serialBAUD_unknown,"Unknown")
-	choice(serialBAUD_300,"300")
-	choice(serialBAUD_600,"600")
-	choice(serialBAUD_1200,"1200")
-	choice(serialBAUD_2400,"2400")
-	choice(serialBAUD_4800,"4800")
-	choice(serialBAUD_9600,"9600")
-	choice(serialBAUD_19200,"19200")
-	choice(serialBAUD_38400,"38400")
-	choice(serialBAUD_57600,"57600")
-	choice(serialBAUD_115200,"115200")
-	choice(serialBAUD_230400,"230400")
-	choice(serialBAUD_460800,"460800")
-	choice(serialBAUD_576000,"576000")
-	choice(serialBAUD_921600,"921600")
-	choice(serialBAUD_1152000,"1152000")
-}
-menu(seqSELM) {
-	choice(seqSELM_All,"All")
-	choice(seqSELM_Specified,"Specified")
-	choice(seqSELM_Mask,"Mask")
-}
-menu(selSELM) {
-	choice(selSELM_Specified,"Specified")
-	choice(selSELM_High_Signal,"High Signal")
-	choice(selSELM_Low_Signal,"Low Signal")
-	choice(selSELM_Median_Signal,"Median Signal")
-}
-menu(motorUEIP) {
-	choice(motorUEIP_No,"No")
-	choice(motorUEIP_Yes,"Yes")
-}
-menu(motorTORQ) {
-	choice(motorTORQ_Disable,"Disable")
-	choice(motorTORQ_Enable,"Enable")
-}
-menu(motorSTUP) {
-	choice(motorSTUP_OFF,"OFF")
-	choice(motorSTUP_ON,"ON")
-	choice(motorSTUP_BUSY,"BUSY")
-}
-menu(motorSPMG) {
-	choice(motorSPMG_Stop,"Stop")
-	choice(motorSPMG_Pause,"Pause")
-	choice(motorSPMG_Move,"Move")
-	choice(motorSPMG_Go,"Go")
-}
-menu(motorSET) {
-	choice(motorSET_Use,"Use")
-	choice(motorSET_Set,"Set")
-}
-menu(motorRMOD) {
-	choice(motorRMOD_D,"Default")
-	choice(motorRMOD_A,"Arithmetic")
-	choice(motorRMOD_G,"Geometric")
-	choice(motorRMOD_I,"In-Position")
-}
-menu(motorFOFF) {
-	choice(motorFOFF_Variable,"Variable")
-	choice(motorFOFF_Frozen,"Frozen")
-}
-menu(motorDIR) {
-	choice(motorDIR_Pos,"Pos")
-	choice(motorDIR_Neg,"Neg")
-}
-menu(menuYesNo) {
-	choice(menuYesNoNO,"NO")
-	choice(menuYesNoYES,"YES")
-}
-menu(menuSimm) {
-	choice(menuSimmNO,"NO")
-	choice(menuSimmYES,"YES")
-	choice(menuSimmRAW,"RAW")
-}
-menu(menuScan) {
-	choice(menuScanPassive,"Passive")
-	choice(menuScanEvent,"Event")
-	choice(menuScanI_O_Intr,"I/O Intr")
-	choice(menuScan10_second,"10 second")
-	choice(menuScan5_second,"5 second")
-	choice(menuScan2_second,"2 second")
-	choice(menuScan1_second,"1 second")
-	choice(menuScan_5_second,".5 second")
-	choice(menuScan_2_second,".2 second")
-	choice(menuScan_1_second,".1 second")
-}
-menu(menuPriority) {
-	choice(menuPriorityLOW,"LOW")
-	choice(menuPriorityMEDIUM,"MEDIUM")
-	choice(menuPriorityHIGH,"HIGH")
-}
-menu(menuPini) {
-	choice(menuPiniNO,"NO")
-	choice(menuPiniYES,"YES")
-	choice(menuPiniRUN,"RUN")
-	choice(menuPiniRUNNING,"RUNNING")
-	choice(menuPiniPAUSE,"PAUSE")
-	choice(menuPiniPAUSED,"PAUSED")
-}
-menu(menuOmsl) {
-	choice(menuOmslsupervisory,"supervisory")
-	choice(menuOmslclosed_loop,"closed_loop")
-}
-menu(menuIvoa) {
-	choice(menuIvoaContinue_normally,"Continue normally")
-	choice(menuIvoaDon_t_drive_outputs,"Don't drive outputs")
-	choice(menuIvoaSet_output_to_IVOV,"Set output to IVOV")
-}
-menu(menuFtype) {
-	choice(menuFtypeSTRING,"STRING")
-	choice(menuFtypeCHAR,"CHAR")
-	choice(menuFtypeUCHAR,"UCHAR")
-	choice(menuFtypeSHORT,"SHORT")
-	choice(menuFtypeUSHORT,"USHORT")
-	choice(menuFtypeLONG,"LONG")
-	choice(menuFtypeULONG,"ULONG")
-	choice(menuFtypeFLOAT,"FLOAT")
-	choice(menuFtypeDOUBLE,"DOUBLE")
-	choice(menuFtypeENUM,"ENUM")
-}
-menu(menuConvert) {
-	choice(menuConvertNO_CONVERSION,"NO CONVERSION")
-	choice(menuConvertSLOPE,"SLOPE")
-	choice(menuConvertLINEAR,"LINEAR")
-	choice(menuConverttypeKdegF,"typeKdegF")
-	choice(menuConverttypeKdegC,"typeKdegC")
-	choice(menuConverttypeJdegF,"typeJdegF")
-	choice(menuConverttypeJdegC,"typeJdegC")
-	choice(menuConverttypeEdegF,"typeEdegF(ixe only)")
-	choice(menuConverttypeEdegC,"typeEdegC(ixe only)")
-	choice(menuConverttypeTdegF,"typeTdegF")
-	choice(menuConverttypeTdegC,"typeTdegC")
-	choice(menuConverttypeRdegF,"typeRdegF")
-	choice(menuConverttypeRdegC,"typeRdegC")
-	choice(menuConverttypeSdegF,"typeSdegF")
-	choice(menuConverttypeSdegC,"typeSdegC")
-}
-menu(menuCompress) {
-	choice(menuCompressN_to_1_First_Value,"N to 1 First Value")
-	choice(menuCompressN_to_1_Low_Value,"N to 1 Low Value")
-	choice(menuCompressN_to_1_High_Value,"N to 1 High Value")
-	choice(menuCompressN_to_1_Average,"N to 1 Average")
-}
-menu(menuAlarmStat) {
-	choice(menuAlarmStatNO_ALARM,"NO_ALARM")
-	choice(menuAlarmStatREAD,"READ")
-	choice(menuAlarmStatWRITE,"WRITE")
-	choice(menuAlarmStatHIHI,"HIHI")
-	choice(menuAlarmStatHIGH,"HIGH")
-	choice(menuAlarmStatLOLO,"LOLO")
-	choice(menuAlarmStatLOW,"LOW")
-	choice(menuAlarmStatSTATE,"STATE")
-	choice(menuAlarmStatCOS,"COS")
-	choice(menuAlarmStatCOMM,"COMM")
-	choice(menuAlarmStatTIMEOUT,"TIMEOUT")
-	choice(menuAlarmStatHWLIMIT,"HWLIMIT")
-	choice(menuAlarmStatCALC,"CALC")
-	choice(menuAlarmStatSCAN,"SCAN")
-	choice(menuAlarmStatLINK,"LINK")
-	choice(menuAlarmStatSOFT,"SOFT")
-	choice(menuAlarmStatBAD_SUB,"BAD_SUB")
-	choice(menuAlarmStatUDF,"UDF")
-	choice(menuAlarmStatDISABLE,"DISABLE")
-	choice(menuAlarmStatSIMM,"SIMM")
-	choice(menuAlarmStatREAD_ACCESS,"READ_ACCESS")
-	choice(menuAlarmStatWRITE_ACCESS,"WRITE_ACCESS")
-}
-menu(menuAlarmSevr) {
-	choice(menuAlarmSevrNO_ALARM,"NO_ALARM")
-	choice(menuAlarmSevrMINOR,"MINOR")
-	choice(menuAlarmSevrMAJOR,"MAJOR")
-	choice(menuAlarmSevrINVALID,"INVALID")
-}
-menu(ipDRTO) {
-	choice(ipDRTO_unknown,"Unknown")
-	choice(ipDRTO_No,"No")
-	choice(ipDRTO_Yes,"Yes")
-}
-menu(gpibUCMD) {
-	choice(gpibUCMD_None,"None")
-	choice(gpibUCMD_Device_Clear__DCL_,"Device Clear (DCL)")
-	choice(gpibUCMD_Local_Lockout__LL0_,"Local Lockout (LL0)")
-	choice(gpibUCMD_Serial_Poll_Disable__SPD_,"Serial Poll Disable (SPD)")
-	choice(gpibUCMD_Serial_Poll_Enable__SPE_,"Serial Poll Enable (SPE)")
-	choice(gpibUCMD_Unlisten__UNL_,"Unlisten (UNL)")
-	choice(gpibUCMD_Untalk__UNT_,"Untalk (UNT)")
-}
-menu(gpibACMD) {
-	choice(gpibACMD_None,"None")
-	choice(gpibACMD_Group_Execute_Trig___GET_,"Group Execute Trig. (GET)")
-	choice(gpibACMD_Go_To_Local__GTL_,"Go To Local (GTL)")
-	choice(gpibACMD_Selected_Dev__Clear__SDC_,"Selected Dev. Clear (SDC)")
-	choice(gpibACMD_Take_Control__TCT_,"Take Control (TCT)")
-	choice(gpibACMD_Serial_Poll,"Serial Poll")
-}
-menu(fanoutSELM) {
-	choice(fanoutSELM_All,"All")
-	choice(fanoutSELM_Specified,"Specified")
-	choice(fanoutSELM_Mask,"Mask")
-}
-menu(dfanoutSELM) {
-	choice(dfanoutSELM_All,"All")
-	choice(dfanoutSELM_Specified,"Specified")
-	choice(dfanoutSELM_Mask,"Mask")
-}
-menu(compressALG) {
-	choice(compressALG_N_to_1_Low_Value,"N to 1 Low Value")
-	choice(compressALG_N_to_1_High_Value,"N to 1 High Value")
-	choice(compressALG_N_to_1_Average,"N to 1 Average")
-	choice(compressALG_Average,"Average")
-	choice(compressALG_Circular_Buffer,"Circular Buffer")
-	choice(compressALG_N_to_1_Median,"N to 1 Median")
-}
-menu(calcoutOOPT) {
-	choice(calcoutOOPT_Every_Time,"Every Time")
-	choice(calcoutOOPT_On_Change,"On Change")
-	choice(calcoutOOPT_When_Zero,"When Zero")
-	choice(calcoutOOPT_When_Non_zero,"When Non-zero")
-	choice(calcoutOOPT_Transition_To_Zero,"Transition To Zero")
-	choice(calcoutOOPT_Transition_To_Non_zero,"Transition To Non-zero")
-}
-menu(calcoutINAV) {
-	choice(calcoutINAV_EXT_NC,"Ext PV NC")
-	choice(calcoutINAV_EXT,"Ext PV OK")
-	choice(calcoutINAV_LOC,"Local PV")
-	choice(calcoutINAV_CON,"Constant")
-}
-menu(calcoutDOPT) {
-	choice(calcoutDOPT_Use_VAL,"Use CALC")
-	choice(calcoutDOPT_Use_OVAL,"Use OCAL")
-}
-menu(asynTRACE) {
-	choice(asynTRACE_Off,"Off")
-	choice(asynTRACE_On,"On")
-}
-menu(asynTMOD) {
-	choice(asynTMOD_Write_Read,"Write/Read")
-	choice(asynTMOD_Write,"Write")
-	choice(asynTMOD_Read,"Read")
-	choice(asynTMOD_Flush,"Flush")
-	choice(asynTMOD_NoIO,"NoI/O")
-}
-menu(asynINTERFACE) {
-	choice(asynINTERFACE_OCTET,"asynOctet")
-	choice(asynINTERFACE_INT32,"asynInt32")
-	choice(asynINTERFACE_UINT32,"asynUInt32Digital")
-	choice(asynINTERFACE_FLOAT64,"asynFloat64")
-}
-menu(asynFMT) {
-	choice(asynFMT_ASCII,"ASCII")
-	choice(asynFMT_Hybrid,"Hybrid")
-	choice(asynFMT_Binary,"Binary")
-}
-menu(asynEOMREASON) {
-	choice(asynEOMREASONNone,"None")
-	choice(asynEOMREASONCNT,"Count")
-	choice(asynEOMREASONEOS,"Eos")
-	choice(asynEOMREASONCNTEOS,"Count Eos")
-	choice(asynEOMREASONEND,"End")
-	choice(asynEOMREASONCNTEND,"Count End")
-	choice(asynEOMREASONEOSEND,"Eos End")
-	choice(asynEOMREASONCNTEOSEND,"Count Eos End")
-}
-menu(asynENABLE) {
-	choice(asynENABLE_Disable,"Disable")
-	choice(asynENABLE_Enable,"Enable")
-}
-menu(asynCONNECT) {
-	choice(asynCONNECT_Disconnect,"Disconnect")
-	choice(asynCONNECT_Connect,"Connect")
-}
-menu(asynAUTOCONNECT) {
-	choice(asynAUTOCONNECT_noAutoConnect,"noAutoConnect")
-	choice(asynAUTOCONNECT_autoConnect,"autoConnect")
-}
-menu(aoOIF) {
-	choice(aoOIF_Full,"Full")
-	choice(aoOIF_Incremental,"Incremental")
+menu(waveformPOST) {
+    choice(waveformPOST_Always, "Always")
+    choice(waveformPOST_OnChange, "On Change")
 }
 menu(aaoPOST) {
-	choice(aaoPOST_Always,"Always")
-	choice(aaoPOST_OnChange,"On Change")
+    choice(aaoPOST_Always, "Always")
+    choice(aaoPOST_OnChange, "On Change")
 }
-menu(aaiPOST) {
-	choice(aaiPOST_Always,"Always")
-	choice(aaiPOST_OnChange,"On Change")
+menu(menuPriority) {
+    choice(menuPriorityLOW, "LOW")
+    choice(menuPriorityMEDIUM, "MEDIUM")
+    choice(menuPriorityHIGH, "HIGH")
+}
+menu(motorRMOD) {
+    choice(motorRMOD_D, "Default")
+    choice(motorRMOD_A, "Arithmetic")
+    choice(motorRMOD_G, "Geometric")
+    choice(motorRMOD_I, "In-Position")
+}
+menu(serialSBIT) {
+    choice(serialSBIT_unknown, "Unknown")
+    choice(serialSBIT_1, "1")
+    choice(serialSBIT_2, "2")
+}
+menu(calcoutDOPT) {
+    choice(calcoutDOPT_Use_VAL, "Use CALC")
+    choice(calcoutDOPT_Use_OVAL, "Use OCAL")
+}
+menu(motorSPMG) {
+    choice(motorSPMG_Stop, "Stop")
+    choice(motorSPMG_Pause, "Pause")
+    choice(motorSPMG_Move, "Move")
+    choice(motorSPMG_Go, "Go")
+}
+menu(motorACCSused) {
+    choice(motorACCSused_Undef, "Undef")
+    choice(motorACCSused_Accl, "Accl")
+    choice(motorACCSused_Accs, "Accs")
+}
+menu(menuOmsl) {
+    choice(menuOmslsupervisory, "supervisory")
+    choice(menuOmslclosed_loop, "closed_loop")
+}
+menu(motorFOFF) {
+    choice(motorFOFF_Variable, "Variable")
+    choice(motorFOFF_Frozen, "Frozen")
+}
+menu(menuFtype) {
+    choice(menuFtypeSTRING, "STRING")
+    choice(menuFtypeCHAR, "CHAR")
+    choice(menuFtypeUCHAR, "UCHAR")
+    choice(menuFtypeSHORT, "SHORT")
+    choice(menuFtypeUSHORT, "USHORT")
+    choice(menuFtypeLONG, "LONG")
+    choice(menuFtypeULONG, "ULONG")
+    choice(menuFtypeINT64, "INT64")
+    choice(menuFtypeUINT64, "UINT64")
+    choice(menuFtypeFLOAT, "FLOAT")
+    choice(menuFtypeDOUBLE, "DOUBLE")
+    choice(menuFtypeENUM, "ENUM")
+}
+menu(stringinPOST) {
+    choice(stringinPOST_OnChange, "On Change")
+    choice(stringinPOST_Always, "Always")
+}
+menu(menuPini) {
+    choice(menuPiniNO, "NO")
+    choice(menuPiniYES, "YES")
+    choice(menuPiniRUN, "RUN")
+    choice(menuPiniRUNNING, "RUNNING")
+    choice(menuPiniPAUSE, "PAUSE")
+    choice(menuPiniPAUSED, "PAUSED")
+}
+menu(motorUEIP) {
+    choice(motorUEIP_No, "No")
+    choice(motorUEIP_Yes, "Yes")
+}
+menu(dfanoutSELM) {
+    choice(dfanoutSELM_All, "All")
+    choice(dfanoutSELM_Specified, "Specified")
+    choice(dfanoutSELM_Mask, "Mask")
+}
+menu(menuScan) {
+    choice(menuScanPassive, "Passive")
+    choice(menuScanEvent, "Event")
+    choice(menuScanI_O_Intr, "I/O Intr")
+    choice(menuScan10_second, "10 second")
+    choice(menuScan5_second, "5 second")
+    choice(menuScan2_second, "2 second")
+    choice(menuScan1_second, "1 second")
+    choice(menuScan_5_second, ".5 second")
+    choice(menuScan_2_second, ".2 second")
+    choice(menuScan_1_second, ".1 second")
+}
+menu(gpibACMD) {
+    choice(gpibACMD_None, "None")
+    choice(gpibACMD_Group_Execute_Trig___GET_, "Group Execute Trig. (GET)")
+    choice(gpibACMD_Go_To_Local__GTL_, "Go To Local (GTL)")
+    choice(gpibACMD_Selected_Dev__Clear__SDC_, "Selected Dev. Clear (SDC)")
+    choice(gpibACMD_Take_Control__TCT_, "Take Control (TCT)")
+    choice(gpibACMD_Serial_Poll, "Serial Poll")
 }
 menu(aSubLFLG) {
-	choice(aSubLFLG_IGNORE,"IGNORE")
-	choice(aSubLFLG_READ,"READ")
+    choice(aSubLFLG_IGNORE, "IGNORE")
+    choice(aSubLFLG_READ, "READ")
+}
+menu(asynTMOD) {
+    choice(asynTMOD_Write_Read, "Write/Read")
+    choice(asynTMOD_Write, "Write")
+    choice(asynTMOD_Read, "Read")
+    choice(asynTMOD_Flush, "Flush")
+    choice(asynTMOD_NoIO, "NoI/O")
+}
+menu(ipDRTO) {
+    choice(ipDRTO_unknown, "Unknown")
+    choice(ipDRTO_No, "No")
+    choice(ipDRTO_Yes, "Yes")
+}
+menu(motorSTUP) {
+    choice(motorSTUP_OFF, "OFF")
+    choice(motorSTUP_ON, "ON")
+    choice(motorSTUP_BUSY, "BUSY")
+}
+menu(motorMODE) {
+    choice(motorMODE_Position, "Position")
+    choice(motorMODE_Velocity, "Velocity")
+}
+menu(menuPost) {
+    choice(menuPost_OnChange, "On Change")
+    choice(menuPost_Always, "Always")
+}
+menu(motorSET) {
+    choice(motorSET_Use, "Use")
+    choice(motorSET_Set, "Set")
+}
+menu(asynINTERFACE) {
+    choice(asynINTERFACE_OCTET, "asynOctet")
+    choice(asynINTERFACE_INT32, "asynInt32")
+    choice(asynINTERFACE_UINT32, "asynUInt32Digital")
+    choice(asynINTERFACE_FLOAT64, "asynFloat64")
+}
+menu(menuAlarmStat) {
+    choice(menuAlarmStatNO_ALARM, "NO_ALARM")
+    choice(menuAlarmStatREAD, "READ")
+    choice(menuAlarmStatWRITE, "WRITE")
+    choice(menuAlarmStatHIHI, "HIHI")
+    choice(menuAlarmStatHIGH, "HIGH")
+    choice(menuAlarmStatLOLO, "LOLO")
+    choice(menuAlarmStatLOW, "LOW")
+    choice(menuAlarmStatSTATE, "STATE")
+    choice(menuAlarmStatCOS, "COS")
+    choice(menuAlarmStatCOMM, "COMM")
+    choice(menuAlarmStatTIMEOUT, "TIMEOUT")
+    choice(menuAlarmStatHWLIMIT, "HWLIMIT")
+    choice(menuAlarmStatCALC, "CALC")
+    choice(menuAlarmStatSCAN, "SCAN")
+    choice(menuAlarmStatLINK, "LINK")
+    choice(menuAlarmStatSOFT, "SOFT")
+    choice(menuAlarmStatBAD_SUB, "BAD_SUB")
+    choice(menuAlarmStatUDF, "UDF")
+    choice(menuAlarmStatDISABLE, "DISABLE")
+    choice(menuAlarmStatSIMM, "SIMM")
+    choice(menuAlarmStatREAD_ACCESS, "READ_ACCESS")
+    choice(menuAlarmStatWRITE_ACCESS, "WRITE_ACCESS")
+}
+menu(aoOIF) {
+    choice(aoOIF_Full, "Full")
+    choice(aoOIF_Incremental, "Incremental")
+}
+menu(bufferingALG) {
+    choice(bufferingALG_FIFO, "FIFO Buffer")
+    choice(bufferingALG_LIFO, "LIFO Buffer")
+}
+menu(aaiPOST) {
+    choice(aaiPOST_Always, "Always")
+    choice(aaiPOST_OnChange, "On Change")
+}
+menu(calcoutINAV) {
+    choice(calcoutINAV_EXT_NC, "Ext PV NC")
+    choice(calcoutINAV_EXT, "Ext PV OK")
+    choice(calcoutINAV_LOC, "Local PV")
+    choice(calcoutINAV_CON, "Constant")
+}
+menu(asynAUTOCONNECT) {
+    choice(asynAUTOCONNECT_noAutoConnect, "noAutoConnect")
+    choice(asynAUTOCONNECT_autoConnect, "autoConnect")
+}
+menu(asynFMT) {
+    choice(asynFMT_ASCII, "ASCII")
+    choice(asynFMT_Hybrid, "Hybrid")
+    choice(asynFMT_Binary, "Binary")
+}
+menu(seqSELM) {
+    choice(seqSELM_All, "All")
+    choice(seqSELM_Specified, "Specified")
+    choice(seqSELM_Mask, "Mask")
+}
+menu(asynCONNECT) {
+    choice(asynCONNECT_Disconnect, "Disconnect")
+    choice(asynCONNECT_Connect, "Connect")
+}
+menu(gpibUCMD) {
+    choice(gpibUCMD_None, "None")
+    choice(gpibUCMD_Device_Clear__DCL_, "Device Clear (DCL)")
+    choice(gpibUCMD_Local_Lockout__LL0_, "Local Lockout (LL0)")
+    choice(gpibUCMD_Serial_Poll_Disable__SPD_, "Serial Poll Disable (SPD)")
+    choice(gpibUCMD_Serial_Poll_Enable__SPE_, "Serial Poll Enable (SPE)")
+    choice(gpibUCMD_Unlisten__UNL_, "Unlisten (UNL)")
+    choice(gpibUCMD_Untalk__UNT_, "Untalk (UNT)")
+}
+menu(serialBAUD) {
+    choice(serialBAUD_unknown, "Unknown")
+    choice(serialBAUD_300, "300")
+    choice(serialBAUD_600, "600")
+    choice(serialBAUD_1200, "1200")
+    choice(serialBAUD_2400, "2400")
+    choice(serialBAUD_4800, "4800")
+    choice(serialBAUD_9600, "9600")
+    choice(serialBAUD_19200, "19200")
+    choice(serialBAUD_38400, "38400")
+    choice(serialBAUD_57600, "57600")
+    choice(serialBAUD_115200, "115200")
+    choice(serialBAUD_230400, "230400")
+    choice(serialBAUD_460800, "460800")
+    choice(serialBAUD_576000, "576000")
+    choice(serialBAUD_921600, "921600")
+    choice(serialBAUD_1152000, "1152000")
+}
+menu(histogramCMD) {
+    choice(histogramCMD_Read, "Read")
+    choice(histogramCMD_Clear, "Clear")
+    choice(histogramCMD_Start, "Start")
+    choice(histogramCMD_Stop, "Stop")
+}
+menu(asynTRACE) {
+    choice(asynTRACE_Off, "Off")
+    choice(asynTRACE_On, "On")
+}
+menu(asynEOMREASON) {
+    choice(asynEOMREASONNone, "None")
+    choice(asynEOMREASONCNT, "Count")
+    choice(asynEOMREASONEOS, "Eos")
+    choice(asynEOMREASONCNTEOS, "Count Eos")
+    choice(asynEOMREASONEND, "End")
+    choice(asynEOMREASONCNTEND, "Count End")
+    choice(asynEOMREASONEOSEND, "Eos End")
+    choice(asynEOMREASONCNTEOSEND, "Count Eos End")
+}
+menu(menuIvoa) {
+    choice(menuIvoaContinue_normally, "Continue normally")
+    choice(menuIvoaDon_t_drive_outputs, "Don't drive outputs")
+    choice(menuIvoaSet_output_to_IVOV, "Set output to IVOV")
+}
+menu(stringoutPOST) {
+    choice(stringoutPOST_OnChange, "On Change")
+    choice(stringoutPOST_Always, "Always")
+}
+menu(menuAlarmSevr) {
+    choice(menuAlarmSevrNO_ALARM, "NO_ALARM")
+    choice(menuAlarmSevrMINOR, "MINOR")
+    choice(menuAlarmSevrMAJOR, "MAJOR")
+    choice(menuAlarmSevrINVALID, "INVALID")
+}
+menu(serialMCTL) {
+    choice(serialMCTL_unknown, "Unknown")
+    choice(serialMCTL_CLOCAL, "CLOCAL")
+    choice(serialMCTL_Yes, "YES")
+}
+menu(serialFCTL) {
+    choice(serialFCTL_unknown, "Unknown")
+    choice(serialFCTL_None, "None")
+    choice(serialFCTL_Hardware, "Hardware")
+}
+menu(menuSimm) {
+    choice(menuSimmNO, "NO")
+    choice(menuSimmYES, "YES")
+    choice(menuSimmRAW, "RAW")
+}
+menu(compressALG) {
+    choice(compressALG_N_to_1_Low_Value, "N to 1 Low Value")
+    choice(compressALG_N_to_1_High_Value, "N to 1 High Value")
+    choice(compressALG_N_to_1_Average, "N to 1 Average")
+    choice(compressALG_Average, "Average")
+    choice(compressALG_Circular_Buffer, "Circular Buffer")
+    choice(compressALG_N_to_1_Median, "N to 1 Median")
+}
+menu(motorDIR) {
+    choice(motorDIR_Pos, "Pos")
+    choice(motorDIR_Neg, "Neg")
 }
 menu(aSubEFLG) {
-	choice(aSubEFLG_NEVER,"NEVER")
-	choice(aSubEFLG_ON_CHANGE,"ON CHANGE")
-	choice(aSubEFLG_ALWAYS,"ALWAYS")
+    choice(aSubEFLG_NEVER, "NEVER")
+    choice(aSubEFLG_ON_CHANGE, "ON CHANGE")
+    choice(aSubEFLG_ALWAYS, "ALWAYS")
 }
-recordtype(aai) {
-	field(NAME,DBF_STRING) {
-		prompt("Record Name")
-		special(SPC_NOMOD)
-		size(61)
-	}
-	field(DESC,DBF_STRING) {
-		prompt("Descriptor")
-		promptgroup(GUI_COMMON)
-		size(41)
-	}
-	field(ASG,DBF_STRING) {
-		prompt("Access Security Group")
-		promptgroup(GUI_COMMON)
-		special(SPC_AS)
-		size(29)
-	}
-	field(SCAN,DBF_MENU) {
-		prompt("Scan Mechanism")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuScan)
-		interest(1)
-	}
-	field(PINI,DBF_MENU) {
-		prompt("Process at iocInit")
-		promptgroup(GUI_SCAN)
-		menu(menuPini)
-		interest(1)
-	}
-	field(PHAS,DBF_SHORT) {
-		prompt("Scan Phase")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(EVNT,DBF_SHORT) {
-		prompt("Event Number")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(TSE,DBF_SHORT) {
-		prompt("Time Stamp Event")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(TSEL,DBF_INLINK) {
-		prompt("Time Stamp Link")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(DTYP,DBF_DEVICE) {
-		prompt("Device Type")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(DISV,DBF_SHORT) {
-		prompt("Disable Value")
-		initial("1")
-		promptgroup(GUI_SCAN)
-	}
-	field(DISA,DBF_SHORT) {
-		prompt("Disable")
-	}
-	field(SDIS,DBF_INLINK) {
-		prompt("Scanning Disable")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(MLOK,DBF_NOACCESS) {
-		prompt("Monitor lock")
-		special(SPC_NOMOD)
-		extra("epicsMutexId	mlok")
-		interest(4)
-	}
-	field(MLIS,DBF_NOACCESS) {
-		prompt("Monitor List")
-		special(SPC_NOMOD)
-		extra("ELLLIST		mlis")
-		interest(4)
-	}
-	field(DISP,DBF_UCHAR) {
-		prompt("Disable putField")
-	}
-	field(PROC,DBF_UCHAR) {
-		prompt("Force Processing")
-		pp(TRUE)
-		interest(3)
-	}
-	field(STAT,DBF_MENU) {
-		prompt("Alarm Status")
-		initial("UDF")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-	}
-	field(SEVR,DBF_MENU) {
-		prompt("Alarm Severity")
-		initial("INVALID")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-	}
-	field(NSTA,DBF_MENU) {
-		prompt("New Alarm Status")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-		interest(2)
-	}
-	field(NSEV,DBF_MENU) {
-		prompt("New Alarm Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKS,DBF_MENU) {
-		prompt("Alarm Ack Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKT,DBF_MENU) {
-		prompt("Alarm Ack Transient")
-		initial("YES")
-		promptgroup(GUI_ALARMS)
-		special(SPC_NOMOD)
-		menu(menuYesNo)
-		interest(2)
-	}
-	field(DISS,DBF_MENU) {
-		prompt("Disable Alarm Sevrty")
-		promptgroup(GUI_SCAN)
-		menu(menuAlarmSevr)
-		interest(1)
-	}
-	field(LCNT,DBF_UCHAR) {
-		prompt("Lock Count")
-		special(SPC_NOMOD)
-		interest(2)
-	}
-	field(PACT,DBF_UCHAR) {
-		prompt("Record active")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(PUTF,DBF_UCHAR) {
-		prompt("dbPutField process")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(RPRO,DBF_UCHAR) {
-		prompt("Reprocess ")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(ASP,DBF_NOACCESS) {
-		prompt("Access Security Pvt")
-		special(SPC_NOMOD)
-		extra("struct asgMember *asp")
-		interest(4)
-	}
-	field(PPN,DBF_NOACCESS) {
-		prompt("addr of PUTNOTIFY")
-		special(SPC_NOMOD)
-		extra("struct putNotify *ppn")
-		interest(4)
-	}
-	field(PPNR,DBF_NOACCESS) {
-		prompt("pputNotifyRecord")
-		special(SPC_NOMOD)
-		extra("struct putNotifyRecord *ppnr")
-		interest(4)
-	}
-	field(SPVT,DBF_NOACCESS) {
-		prompt("Scan Private")
-		special(SPC_NOMOD)
-		extra("struct scan_element *spvt")
-		interest(4)
-	}
-	field(RSET,DBF_NOACCESS) {
-		prompt("Address of RSET")
-		special(SPC_NOMOD)
-		extra("struct rset	*rset")
-		interest(4)
-	}
-	field(DSET,DBF_NOACCESS) {
-		prompt("DSET address")
-		special(SPC_NOMOD)
-		extra("struct dset	*dset")
-		interest(4)
-	}
-	field(DPVT,DBF_NOACCESS) {
-		prompt("Device Private")
-		special(SPC_NOMOD)
-		extra("void		*dpvt")
-		interest(4)
-	}
-	field(RDES,DBF_NOACCESS) {
-		prompt("Address of dbRecordType")
-		special(SPC_NOMOD)
-		extra("struct dbRecordType *rdes")
-		interest(4)
-	}
-	field(LSET,DBF_NOACCESS) {
-		prompt("Lock Set")
-		special(SPC_NOMOD)
-		extra("struct lockRecord *lset")
-		interest(4)
-	}
-	field(PRIO,DBF_MENU) {
-		prompt("Scheduling Priority")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuPriority)
-		interest(1)
-	}
-	field(TPRO,DBF_UCHAR) {
-		prompt("Trace Processing")
-	}
-	field(BKPT,DBF_NOACCESS) {
-		prompt("Break Point")
-		special(SPC_NOMOD)
-		extra("char bkpt")
-		interest(1)
-	}
-	field(UDF,DBF_UCHAR) {
-		prompt("Undefined")
-		initial("1")
-		promptgroup(GUI_COMMON)
-		pp(TRUE)
-		interest(1)
-	}
-	field(TIME,DBF_NOACCESS) {
-		prompt("Time")
-		special(SPC_NOMOD)
-		extra("epicsTimeStamp	time")
-		interest(2)
-	}
-	field(FLNK,DBF_FWDLINK) {
-		prompt("Forward Process Link")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(VAL,DBF_NOACCESS) {
-		prompt("Value")
-		special(SPC_DBADDR)
-		extra("void *		val")
-		pp(TRUE)
-		asl(ASL0)
-	}
-	field(PREC,DBF_SHORT) {
-		prompt("Display Precision")
-		promptgroup(GUI_ALARMS)
-		interest(1)
-	}
-	field(INP,DBF_INLINK) {
-		prompt("Input Specification")
-		promptgroup(GUI_BITS1)
-		interest(1)
-	}
-	field(EGU,DBF_STRING) {
-		prompt("Engineering Units Name")
-		promptgroup(GUI_BITS2)
-		size(16)
-		interest(1)
-	}
-	field(HOPR,DBF_DOUBLE) {
-		prompt("High Operating Range")
-		promptgroup(GUI_CALC)
-		interest(1)
-	}
-	field(LOPR,DBF_DOUBLE) {
-		prompt("Low Operating Range")
-		promptgroup(GUI_CLOCK)
-		interest(1)
-	}
-	field(NELM,DBF_ULONG) {
-		prompt("Number of Elements")
-		initial("1")
-		promptgroup(GUI_COMPRESS)
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(FTVL,DBF_MENU) {
-		prompt("Field Type of Value")
-		promptgroup(GUI_CONVERT)
-		special(SPC_NOMOD)
-		menu(menuFtype)
-		interest(1)
-	}
-	field(NORD,DBF_ULONG) {
-		prompt("Number elements read")
-		special(SPC_NOMOD)
-	}
-	field(BPTR,DBF_NOACCESS) {
-		prompt("Buffer Pointer")
-		special(SPC_NOMOD)
-		extra("void *		bptr")
-		interest(4)
-	}
-	field(SIML,DBF_INLINK) {
-		prompt("Sim Mode Location")
-		promptgroup(GUI_HIST)
-		interest(1)
-	}
-	field(SIMM,DBF_MENU) {
-		prompt("Simulation Mode")
-		menu(menuYesNo)
-		interest(1)
-	}
-	field(SIMS,DBF_MENU) {
-		prompt("Sim mode Alarm Svrty")
-		promptgroup(GUI_INPUTS)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(SIOL,DBF_INLINK) {
-		prompt("Sim Input Specifctn")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(MPST,DBF_MENU) {
-		prompt("Post Value Monitors")
-		promptgroup(GUI_DISPLAY)
-		menu(aaiPOST)
-		interest(1)
-	}
-	field(APST,DBF_MENU) {
-		prompt("Post Archive Monitors")
-		promptgroup(GUI_DISPLAY)
-		menu(aaiPOST)
-		interest(1)
-	}
-	field(HASH,DBF_ULONG) {
-		prompt("Hash of OnChange data.")
-		interest(3)
-	}
+menu(fanoutSELM) {
+    choice(fanoutSELM_All, "All")
+    choice(fanoutSELM_Specified, "Specified")
+    choice(fanoutSELM_Mask, "Mask")
 }
-recordtype(aao) {
-	field(NAME,DBF_STRING) {
-		prompt("Record Name")
-		special(SPC_NOMOD)
-		size(61)
-	}
-	field(DESC,DBF_STRING) {
-		prompt("Descriptor")
-		promptgroup(GUI_COMMON)
-		size(41)
-	}
-	field(ASG,DBF_STRING) {
-		prompt("Access Security Group")
-		promptgroup(GUI_COMMON)
-		special(SPC_AS)
-		size(29)
-	}
-	field(SCAN,DBF_MENU) {
-		prompt("Scan Mechanism")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuScan)
-		interest(1)
-	}
-	field(PINI,DBF_MENU) {
-		prompt("Process at iocInit")
-		promptgroup(GUI_SCAN)
-		menu(menuPini)
-		interest(1)
-	}
-	field(PHAS,DBF_SHORT) {
-		prompt("Scan Phase")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(EVNT,DBF_SHORT) {
-		prompt("Event Number")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(TSE,DBF_SHORT) {
-		prompt("Time Stamp Event")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(TSEL,DBF_INLINK) {
-		prompt("Time Stamp Link")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(DTYP,DBF_DEVICE) {
-		prompt("Device Type")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(DISV,DBF_SHORT) {
-		prompt("Disable Value")
-		initial("1")
-		promptgroup(GUI_SCAN)
-	}
-	field(DISA,DBF_SHORT) {
-		prompt("Disable")
-	}
-	field(SDIS,DBF_INLINK) {
-		prompt("Scanning Disable")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(MLOK,DBF_NOACCESS) {
-		prompt("Monitor lock")
-		special(SPC_NOMOD)
-		extra("epicsMutexId	mlok")
-		interest(4)
-	}
-	field(MLIS,DBF_NOACCESS) {
-		prompt("Monitor List")
-		special(SPC_NOMOD)
-		extra("ELLLIST		mlis")
-		interest(4)
-	}
-	field(DISP,DBF_UCHAR) {
-		prompt("Disable putField")
-	}
-	field(PROC,DBF_UCHAR) {
-		prompt("Force Processing")
-		pp(TRUE)
-		interest(3)
-	}
-	field(STAT,DBF_MENU) {
-		prompt("Alarm Status")
-		initial("UDF")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-	}
-	field(SEVR,DBF_MENU) {
-		prompt("Alarm Severity")
-		initial("INVALID")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-	}
-	field(NSTA,DBF_MENU) {
-		prompt("New Alarm Status")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-		interest(2)
-	}
-	field(NSEV,DBF_MENU) {
-		prompt("New Alarm Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKS,DBF_MENU) {
-		prompt("Alarm Ack Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKT,DBF_MENU) {
-		prompt("Alarm Ack Transient")
-		initial("YES")
-		promptgroup(GUI_ALARMS)
-		special(SPC_NOMOD)
-		menu(menuYesNo)
-		interest(2)
-	}
-	field(DISS,DBF_MENU) {
-		prompt("Disable Alarm Sevrty")
-		promptgroup(GUI_SCAN)
-		menu(menuAlarmSevr)
-		interest(1)
-	}
-	field(LCNT,DBF_UCHAR) {
-		prompt("Lock Count")
-		special(SPC_NOMOD)
-		interest(2)
-	}
-	field(PACT,DBF_UCHAR) {
-		prompt("Record active")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(PUTF,DBF_UCHAR) {
-		prompt("dbPutField process")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(RPRO,DBF_UCHAR) {
-		prompt("Reprocess ")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(ASP,DBF_NOACCESS) {
-		prompt("Access Security Pvt")
-		special(SPC_NOMOD)
-		extra("struct asgMember *asp")
-		interest(4)
-	}
-	field(PPN,DBF_NOACCESS) {
-		prompt("addr of PUTNOTIFY")
-		special(SPC_NOMOD)
-		extra("struct putNotify *ppn")
-		interest(4)
-	}
-	field(PPNR,DBF_NOACCESS) {
-		prompt("pputNotifyRecord")
-		special(SPC_NOMOD)
-		extra("struct putNotifyRecord *ppnr")
-		interest(4)
-	}
-	field(SPVT,DBF_NOACCESS) {
-		prompt("Scan Private")
-		special(SPC_NOMOD)
-		extra("struct scan_element *spvt")
-		interest(4)
-	}
-	field(RSET,DBF_NOACCESS) {
-		prompt("Address of RSET")
-		special(SPC_NOMOD)
-		extra("struct rset	*rset")
-		interest(4)
-	}
-	field(DSET,DBF_NOACCESS) {
-		prompt("DSET address")
-		special(SPC_NOMOD)
-		extra("struct dset	*dset")
-		interest(4)
-	}
-	field(DPVT,DBF_NOACCESS) {
-		prompt("Device Private")
-		special(SPC_NOMOD)
-		extra("void		*dpvt")
-		interest(4)
-	}
-	field(RDES,DBF_NOACCESS) {
-		prompt("Address of dbRecordType")
-		special(SPC_NOMOD)
-		extra("struct dbRecordType *rdes")
-		interest(4)
-	}
-	field(LSET,DBF_NOACCESS) {
-		prompt("Lock Set")
-		special(SPC_NOMOD)
-		extra("struct lockRecord *lset")
-		interest(4)
-	}
-	field(PRIO,DBF_MENU) {
-		prompt("Scheduling Priority")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuPriority)
-		interest(1)
-	}
-	field(TPRO,DBF_UCHAR) {
-		prompt("Trace Processing")
-	}
-	field(BKPT,DBF_NOACCESS) {
-		prompt("Break Point")
-		special(SPC_NOMOD)
-		extra("char bkpt")
-		interest(1)
-	}
-	field(UDF,DBF_UCHAR) {
-		prompt("Undefined")
-		initial("1")
-		promptgroup(GUI_COMMON)
-		pp(TRUE)
-		interest(1)
-	}
-	field(TIME,DBF_NOACCESS) {
-		prompt("Time")
-		special(SPC_NOMOD)
-		extra("epicsTimeStamp	time")
-		interest(2)
-	}
-	field(FLNK,DBF_FWDLINK) {
-		prompt("Forward Process Link")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(VAL,DBF_NOACCESS) {
-		prompt("Value")
-		special(SPC_DBADDR)
-		extra("void *		val")
-		pp(TRUE)
-		asl(ASL0)
-	}
-	field(PREC,DBF_SHORT) {
-		prompt("Display Precision")
-		promptgroup(GUI_ALARMS)
-		interest(1)
-	}
-	field(OUT,DBF_OUTLINK) {
-		prompt("Output Specification")
-		promptgroup(GUI_BITS1)
-		interest(1)
-	}
-	field(EGU,DBF_STRING) {
-		prompt("Engineering Units Name")
-		promptgroup(GUI_BITS2)
-		size(16)
-		interest(1)
-	}
-	field(HOPR,DBF_DOUBLE) {
-		prompt("High Operating Range")
-		promptgroup(GUI_CALC)
-		interest(1)
-	}
-	field(LOPR,DBF_DOUBLE) {
-		prompt("Low Operating Range")
-		promptgroup(GUI_CLOCK)
-		interest(1)
-	}
-	field(NELM,DBF_ULONG) {
-		prompt("Number of Elements")
-		initial("1")
-		promptgroup(GUI_COMPRESS)
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(FTVL,DBF_MENU) {
-		prompt("Field Type of Value")
-		promptgroup(GUI_CONVERT)
-		special(SPC_NOMOD)
-		menu(menuFtype)
-		interest(1)
-	}
-	field(NORD,DBF_ULONG) {
-		prompt("Number elements read")
-		special(SPC_NOMOD)
-	}
-	field(BPTR,DBF_NOACCESS) {
-		prompt("Buffer Pointer")
-		special(SPC_NOMOD)
-		extra("void *		bptr")
-		interest(4)
-	}
-	field(SIML,DBF_INLINK) {
-		prompt("Sim Mode Location")
-		promptgroup(GUI_HIST)
-		interest(1)
-	}
-	field(SIMM,DBF_MENU) {
-		prompt("Simulation Mode")
-		menu(menuYesNo)
-		interest(1)
-	}
-	field(SIMS,DBF_MENU) {
-		prompt("Sim mode Alarm Svrty")
-		promptgroup(GUI_INPUTS)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(SIOL,DBF_OUTLINK) {
-		prompt("Sim Output Specifctn")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(MPST,DBF_MENU) {
-		prompt("Post Value Monitors")
-		promptgroup(GUI_DISPLAY)
-		menu(aaoPOST)
-		interest(1)
-	}
-	field(APST,DBF_MENU) {
-		prompt("Post Archive Monitors")
-		promptgroup(GUI_DISPLAY)
-		menu(aaoPOST)
-		interest(1)
-	}
-	field(HASH,DBF_ULONG) {
-		prompt("Hash of OnChange data.")
-		interest(3)
-	}
+menu(calcoutOOPT) {
+    choice(calcoutOOPT_Every_Time, "Every Time")
+    choice(calcoutOOPT_On_Change, "On Change")
+    choice(calcoutOOPT_When_Zero, "When Zero")
+    choice(calcoutOOPT_When_Non_zero, "When Non-zero")
+    choice(calcoutOOPT_Transition_To_Zero, "Transition To Zero")
+    choice(calcoutOOPT_Transition_To_Non_zero, "Transition To Non-zero")
 }
-recordtype(ai) {
-	field(NAME,DBF_STRING) {
-		prompt("Record Name")
-		special(SPC_NOMOD)
-		size(61)
-	}
-	field(DESC,DBF_STRING) {
-		prompt("Descriptor")
-		promptgroup(GUI_COMMON)
-		size(41)
-	}
-	field(ASG,DBF_STRING) {
-		prompt("Access Security Group")
-		promptgroup(GUI_COMMON)
-		special(SPC_AS)
-		size(29)
-	}
-	field(SCAN,DBF_MENU) {
-		prompt("Scan Mechanism")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuScan)
-		interest(1)
-	}
-	field(PINI,DBF_MENU) {
-		prompt("Process at iocInit")
-		promptgroup(GUI_SCAN)
-		menu(menuPini)
-		interest(1)
-	}
-	field(PHAS,DBF_SHORT) {
-		prompt("Scan Phase")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(EVNT,DBF_SHORT) {
-		prompt("Event Number")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(TSE,DBF_SHORT) {
-		prompt("Time Stamp Event")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(TSEL,DBF_INLINK) {
-		prompt("Time Stamp Link")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(DTYP,DBF_DEVICE) {
-		prompt("Device Type")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(DISV,DBF_SHORT) {
-		prompt("Disable Value")
-		initial("1")
-		promptgroup(GUI_SCAN)
-	}
-	field(DISA,DBF_SHORT) {
-		prompt("Disable")
-	}
-	field(SDIS,DBF_INLINK) {
-		prompt("Scanning Disable")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(MLOK,DBF_NOACCESS) {
-		prompt("Monitor lock")
-		special(SPC_NOMOD)
-		extra("epicsMutexId	mlok")
-		interest(4)
-	}
-	field(MLIS,DBF_NOACCESS) {
-		prompt("Monitor List")
-		special(SPC_NOMOD)
-		extra("ELLLIST		mlis")
-		interest(4)
-	}
-	field(DISP,DBF_UCHAR) {
-		prompt("Disable putField")
-	}
-	field(PROC,DBF_UCHAR) {
-		prompt("Force Processing")
-		pp(TRUE)
-		interest(3)
-	}
-	field(STAT,DBF_MENU) {
-		prompt("Alarm Status")
-		initial("UDF")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-	}
-	field(SEVR,DBF_MENU) {
-		prompt("Alarm Severity")
-		initial("INVALID")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-	}
-	field(NSTA,DBF_MENU) {
-		prompt("New Alarm Status")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-		interest(2)
-	}
-	field(NSEV,DBF_MENU) {
-		prompt("New Alarm Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKS,DBF_MENU) {
-		prompt("Alarm Ack Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKT,DBF_MENU) {
-		prompt("Alarm Ack Transient")
-		initial("YES")
-		promptgroup(GUI_ALARMS)
-		special(SPC_NOMOD)
-		menu(menuYesNo)
-		interest(2)
-	}
-	field(DISS,DBF_MENU) {
-		prompt("Disable Alarm Sevrty")
-		promptgroup(GUI_SCAN)
-		menu(menuAlarmSevr)
-		interest(1)
-	}
-	field(LCNT,DBF_UCHAR) {
-		prompt("Lock Count")
-		special(SPC_NOMOD)
-		interest(2)
-	}
-	field(PACT,DBF_UCHAR) {
-		prompt("Record active")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(PUTF,DBF_UCHAR) {
-		prompt("dbPutField process")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(RPRO,DBF_UCHAR) {
-		prompt("Reprocess ")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(ASP,DBF_NOACCESS) {
-		prompt("Access Security Pvt")
-		special(SPC_NOMOD)
-		extra("struct asgMember *asp")
-		interest(4)
-	}
-	field(PPN,DBF_NOACCESS) {
-		prompt("addr of PUTNOTIFY")
-		special(SPC_NOMOD)
-		extra("struct putNotify *ppn")
-		interest(4)
-	}
-	field(PPNR,DBF_NOACCESS) {
-		prompt("pputNotifyRecord")
-		special(SPC_NOMOD)
-		extra("struct putNotifyRecord *ppnr")
-		interest(4)
-	}
-	field(SPVT,DBF_NOACCESS) {
-		prompt("Scan Private")
-		special(SPC_NOMOD)
-		extra("struct scan_element *spvt")
-		interest(4)
-	}
-	field(RSET,DBF_NOACCESS) {
-		prompt("Address of RSET")
-		special(SPC_NOMOD)
-		extra("struct rset	*rset")
-		interest(4)
-	}
-	field(DSET,DBF_NOACCESS) {
-		prompt("DSET address")
-		special(SPC_NOMOD)
-		extra("struct dset	*dset")
-		interest(4)
-	}
-	field(DPVT,DBF_NOACCESS) {
-		prompt("Device Private")
-		special(SPC_NOMOD)
-		extra("void		*dpvt")
-		interest(4)
-	}
-	field(RDES,DBF_NOACCESS) {
-		prompt("Address of dbRecordType")
-		special(SPC_NOMOD)
-		extra("struct dbRecordType *rdes")
-		interest(4)
-	}
-	field(LSET,DBF_NOACCESS) {
-		prompt("Lock Set")
-		special(SPC_NOMOD)
-		extra("struct lockRecord *lset")
-		interest(4)
-	}
-	field(PRIO,DBF_MENU) {
-		prompt("Scheduling Priority")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuPriority)
-		interest(1)
-	}
-	field(TPRO,DBF_UCHAR) {
-		prompt("Trace Processing")
-	}
-	field(BKPT,DBF_NOACCESS) {
-		prompt("Break Point")
-		special(SPC_NOMOD)
-		extra("char bkpt")
-		interest(1)
-	}
-	field(UDF,DBF_UCHAR) {
-		prompt("Undefined")
-		initial("1")
-		promptgroup(GUI_COMMON)
-		pp(TRUE)
-		interest(1)
-	}
-	field(TIME,DBF_NOACCESS) {
-		prompt("Time")
-		special(SPC_NOMOD)
-		extra("epicsTimeStamp	time")
-		interest(2)
-	}
-	field(FLNK,DBF_FWDLINK) {
-		prompt("Forward Process Link")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(VAL,DBF_DOUBLE) {
-		prompt("Current EGU Value")
-		promptgroup(GUI_INPUTS)
-		pp(TRUE)
-		asl(ASL0)
-	}
-	field(INP,DBF_INLINK) {
-		prompt("Input Specification")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(PREC,DBF_SHORT) {
-		prompt("Display Precision")
-		promptgroup(GUI_DISPLAY)
-		interest(1)
-	}
-	field(LINR,DBF_MENU) {
-		prompt("Linearization")
-		promptgroup(GUI_CONVERT)
-		special(102)
-		menu(menuConvert)
-		pp(TRUE)
-		interest(1)
-	}
-	field(EGUF,DBF_DOUBLE) {
-		prompt("Engineer Units Full")
-		promptgroup(GUI_CONVERT)
-		special(102)
-		pp(TRUE)
-		interest(1)
-	}
-	field(EGUL,DBF_DOUBLE) {
-		prompt("Engineer Units Low")
-		promptgroup(GUI_CONVERT)
-		special(102)
-		pp(TRUE)
-		interest(1)
-	}
-	field(EGU,DBF_STRING) {
-		prompt("Engineering Units")
-		promptgroup(GUI_DISPLAY)
-		size(16)
-		interest(1)
-	}
-	field(HOPR,DBF_DOUBLE) {
-		prompt("High Operating Range")
-		promptgroup(GUI_DISPLAY)
-		interest(1)
-	}
-	field(LOPR,DBF_DOUBLE) {
-		prompt("Low Operating Range")
-		promptgroup(GUI_DISPLAY)
-		interest(1)
-	}
-	field(AOFF,DBF_DOUBLE) {
-		prompt("Adjustment Offset")
-		promptgroup(GUI_CONVERT)
-		pp(TRUE)
-		interest(1)
-	}
-	field(ASLO,DBF_DOUBLE) {
-		prompt("Adjustment Slope")
-		initial("1")
-		promptgroup(GUI_CONVERT)
-		pp(TRUE)
-		interest(1)
-	}
-	field(SMOO,DBF_DOUBLE) {
-		prompt("Smoothing")
-		promptgroup(GUI_CONVERT)
-		interest(1)
-	}
-	field(HIHI,DBF_DOUBLE) {
-		prompt("Hihi Alarm Limit")
-		promptgroup(GUI_ALARMS)
-		pp(TRUE)
-		interest(1)
-	}
-	field(LOLO,DBF_DOUBLE) {
-		prompt("Lolo Alarm Limit")
-		promptgroup(GUI_ALARMS)
-		pp(TRUE)
-		interest(1)
-	}
-	field(HIGH,DBF_DOUBLE) {
-		prompt("High Alarm Limit")
-		promptgroup(GUI_ALARMS)
-		pp(TRUE)
-		interest(1)
-	}
-	field(LOW,DBF_DOUBLE) {
-		prompt("Low Alarm Limit")
-		promptgroup(GUI_ALARMS)
-		pp(TRUE)
-		interest(1)
-	}
-	field(HHSV,DBF_MENU) {
-		prompt("Hihi Severity")
-		promptgroup(GUI_ALARMS)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(LLSV,DBF_MENU) {
-		prompt("Lolo Severity")
-		promptgroup(GUI_ALARMS)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(HSV,DBF_MENU) {
-		prompt("High Severity")
-		promptgroup(GUI_ALARMS)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(LSV,DBF_MENU) {
-		prompt("Low Severity")
-		promptgroup(GUI_ALARMS)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(HYST,DBF_DOUBLE) {
-		prompt("Alarm Deadband")
-		promptgroup(GUI_ALARMS)
-		interest(1)
-	}
-	field(ADEL,DBF_DOUBLE) {
-		prompt("Archive Deadband")
-		promptgroup(GUI_DISPLAY)
-		interest(1)
-	}
-	field(MDEL,DBF_DOUBLE) {
-		prompt("Monitor Deadband")
-		promptgroup(GUI_DISPLAY)
-		interest(1)
-	}
-	field(LALM,DBF_DOUBLE) {
-		prompt("Last Value Alarmed")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(ALST,DBF_DOUBLE) {
-		prompt("Last Value Archived")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(MLST,DBF_DOUBLE) {
-		prompt("Last Val Monitored")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(ESLO,DBF_DOUBLE) {
-		prompt("Raw to EGU Slope")
-		initial("1")
-		promptgroup(GUI_CONVERT)
-		pp(TRUE)
-		interest(2)
-	}
-	field(EOFF,DBF_DOUBLE) {
-		prompt("Raw to EGU Offset")
-		promptgroup(GUI_CONVERT)
-		pp(TRUE)
-		interest(2)
-	}
-	field(ROFF,DBF_LONG) {
-		prompt("Raw Offset, obsolete")
-		pp(TRUE)
-		interest(2)
-	}
-	field(PBRK,DBF_NOACCESS) {
-		prompt("Ptrto brkTable")
-		special(SPC_NOMOD)
-		extra("void *	pbrk")
-		interest(4)
-	}
-	field(INIT,DBF_SHORT) {
-		prompt("Initialized?")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(LBRK,DBF_SHORT) {
-		prompt("LastBreak Point")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(RVAL,DBF_LONG) {
-		prompt("Current Raw Value")
-		pp(TRUE)
-	}
-	field(ORAW,DBF_LONG) {
-		prompt("Previous Raw Value")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(SIOL,DBF_INLINK) {
-		prompt("Sim Input Specifctn")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(SVAL,DBF_DOUBLE) {
-		prompt("Simulation Value")
-	}
-	field(SIML,DBF_INLINK) {
-		prompt("Sim Mode Location")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(SIMM,DBF_MENU) {
-		prompt("Simulation Mode")
-		menu(menuSimm)
-		interest(1)
-	}
-	field(SIMS,DBF_MENU) {
-		prompt("Sim mode Alarm Svrty")
-		promptgroup(GUI_INPUTS)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
+menu(asynENABLE) {
+    choice(asynENABLE_Disable, "Disable")
+    choice(asynENABLE_Enable, "Enable")
 }
-recordtype(ao) {
-	field(NAME,DBF_STRING) {
-		prompt("Record Name")
-		special(SPC_NOMOD)
-		size(61)
-	}
-	field(DESC,DBF_STRING) {
-		prompt("Descriptor")
-		promptgroup(GUI_COMMON)
-		size(41)
-	}
-	field(ASG,DBF_STRING) {
-		prompt("Access Security Group")
-		promptgroup(GUI_COMMON)
-		special(SPC_AS)
-		size(29)
-	}
-	field(SCAN,DBF_MENU) {
-		prompt("Scan Mechanism")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuScan)
-		interest(1)
-	}
-	field(PINI,DBF_MENU) {
-		prompt("Process at iocInit")
-		promptgroup(GUI_SCAN)
-		menu(menuPini)
-		interest(1)
-	}
-	field(PHAS,DBF_SHORT) {
-		prompt("Scan Phase")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(EVNT,DBF_SHORT) {
-		prompt("Event Number")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(TSE,DBF_SHORT) {
-		prompt("Time Stamp Event")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(TSEL,DBF_INLINK) {
-		prompt("Time Stamp Link")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(DTYP,DBF_DEVICE) {
-		prompt("Device Type")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(DISV,DBF_SHORT) {
-		prompt("Disable Value")
-		initial("1")
-		promptgroup(GUI_SCAN)
-	}
-	field(DISA,DBF_SHORT) {
-		prompt("Disable")
-	}
-	field(SDIS,DBF_INLINK) {
-		prompt("Scanning Disable")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(MLOK,DBF_NOACCESS) {
-		prompt("Monitor lock")
-		special(SPC_NOMOD)
-		extra("epicsMutexId	mlok")
-		interest(4)
-	}
-	field(MLIS,DBF_NOACCESS) {
-		prompt("Monitor List")
-		special(SPC_NOMOD)
-		extra("ELLLIST		mlis")
-		interest(4)
-	}
-	field(DISP,DBF_UCHAR) {
-		prompt("Disable putField")
-	}
-	field(PROC,DBF_UCHAR) {
-		prompt("Force Processing")
-		pp(TRUE)
-		interest(3)
-	}
-	field(STAT,DBF_MENU) {
-		prompt("Alarm Status")
-		initial("UDF")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-	}
-	field(SEVR,DBF_MENU) {
-		prompt("Alarm Severity")
-		initial("INVALID")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-	}
-	field(NSTA,DBF_MENU) {
-		prompt("New Alarm Status")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-		interest(2)
-	}
-	field(NSEV,DBF_MENU) {
-		prompt("New Alarm Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKS,DBF_MENU) {
-		prompt("Alarm Ack Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKT,DBF_MENU) {
-		prompt("Alarm Ack Transient")
-		initial("YES")
-		promptgroup(GUI_ALARMS)
-		special(SPC_NOMOD)
-		menu(menuYesNo)
-		interest(2)
-	}
-	field(DISS,DBF_MENU) {
-		prompt("Disable Alarm Sevrty")
-		promptgroup(GUI_SCAN)
-		menu(menuAlarmSevr)
-		interest(1)
-	}
-	field(LCNT,DBF_UCHAR) {
-		prompt("Lock Count")
-		special(SPC_NOMOD)
-		interest(2)
-	}
-	field(PACT,DBF_UCHAR) {
-		prompt("Record active")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(PUTF,DBF_UCHAR) {
-		prompt("dbPutField process")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(RPRO,DBF_UCHAR) {
-		prompt("Reprocess ")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(ASP,DBF_NOACCESS) {
-		prompt("Access Security Pvt")
-		special(SPC_NOMOD)
-		extra("struct asgMember *asp")
-		interest(4)
-	}
-	field(PPN,DBF_NOACCESS) {
-		prompt("addr of PUTNOTIFY")
-		special(SPC_NOMOD)
-		extra("struct putNotify *ppn")
-		interest(4)
-	}
-	field(PPNR,DBF_NOACCESS) {
-		prompt("pputNotifyRecord")
-		special(SPC_NOMOD)
-		extra("struct putNotifyRecord *ppnr")
-		interest(4)
-	}
-	field(SPVT,DBF_NOACCESS) {
-		prompt("Scan Private")
-		special(SPC_NOMOD)
-		extra("struct scan_element *spvt")
-		interest(4)
-	}
-	field(RSET,DBF_NOACCESS) {
-		prompt("Address of RSET")
-		special(SPC_NOMOD)
-		extra("struct rset	*rset")
-		interest(4)
-	}
-	field(DSET,DBF_NOACCESS) {
-		prompt("DSET address")
-		special(SPC_NOMOD)
-		extra("struct dset	*dset")
-		interest(4)
-	}
-	field(DPVT,DBF_NOACCESS) {
-		prompt("Device Private")
-		special(SPC_NOMOD)
-		extra("void		*dpvt")
-		interest(4)
-	}
-	field(RDES,DBF_NOACCESS) {
-		prompt("Address of dbRecordType")
-		special(SPC_NOMOD)
-		extra("struct dbRecordType *rdes")
-		interest(4)
-	}
-	field(LSET,DBF_NOACCESS) {
-		prompt("Lock Set")
-		special(SPC_NOMOD)
-		extra("struct lockRecord *lset")
-		interest(4)
-	}
-	field(PRIO,DBF_MENU) {
-		prompt("Scheduling Priority")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuPriority)
-		interest(1)
-	}
-	field(TPRO,DBF_UCHAR) {
-		prompt("Trace Processing")
-	}
-	field(BKPT,DBF_NOACCESS) {
-		prompt("Break Point")
-		special(SPC_NOMOD)
-		extra("char bkpt")
-		interest(1)
-	}
-	field(UDF,DBF_UCHAR) {
-		prompt("Undefined")
-		initial("1")
-		promptgroup(GUI_COMMON)
-		pp(TRUE)
-		interest(1)
-	}
-	field(TIME,DBF_NOACCESS) {
-		prompt("Time")
-		special(SPC_NOMOD)
-		extra("epicsTimeStamp	time")
-		interest(2)
-	}
-	field(FLNK,DBF_FWDLINK) {
-		prompt("Forward Process Link")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(VAL,DBF_DOUBLE) {
-		prompt("Desired Output")
-		promptgroup(GUI_OUTPUT)
-		pp(TRUE)
-		asl(ASL0)
-	}
-	field(OVAL,DBF_DOUBLE) {
-		prompt("Output Value")
-	}
-	field(OUT,DBF_OUTLINK) {
-		prompt("Output Specification")
-		promptgroup(GUI_OUTPUT)
-		interest(1)
-	}
-	field(OROC,DBF_DOUBLE) {
-		prompt("Output Rate of Chang")
-		promptgroup(GUI_OUTPUT)
-		interest(1)
-	}
-	field(DOL,DBF_INLINK) {
-		prompt("Desired Output Loc")
-		promptgroup(GUI_OUTPUT)
-		interest(1)
-	}
-	field(OMSL,DBF_MENU) {
-		prompt("Output Mode Select")
-		promptgroup(GUI_OUTPUT)
-		menu(menuOmsl)
-		interest(1)
-	}
-	field(OIF,DBF_MENU) {
-		prompt("Out Full/Incremental")
-		promptgroup(GUI_OUTPUT)
-		menu(aoOIF)
-		interest(1)
-	}
-	field(PREC,DBF_SHORT) {
-		prompt("Display Precision")
-		promptgroup(GUI_DISPLAY)
-		interest(1)
-	}
-	field(LINR,DBF_MENU) {
-		prompt("Linearization")
-		promptgroup(GUI_CONVERT)
-		special(102)
-		menu(menuConvert)
-		pp(TRUE)
-		interest(1)
-	}
-	field(EGUF,DBF_DOUBLE) {
-		prompt("Eng Units Full")
-		promptgroup(GUI_CONVERT)
-		special(102)
-		pp(TRUE)
-		interest(1)
-	}
-	field(EGUL,DBF_DOUBLE) {
-		prompt("Eng Units Low")
-		promptgroup(GUI_CONVERT)
-		special(102)
-		pp(TRUE)
-		interest(1)
-	}
-	field(EGU,DBF_STRING) {
-		prompt("Engineering Units")
-		promptgroup(GUI_DISPLAY)
-		size(16)
-		interest(1)
-	}
-	field(ROFF,DBF_LONG) {
-		prompt("Raw Offset, obsolete")
-		pp(TRUE)
-		interest(2)
-	}
-	field(EOFF,DBF_DOUBLE) {
-		prompt("EGU to Raw Offset")
-		promptgroup(GUI_CONVERT)
-		pp(TRUE)
-		interest(2)
-	}
-	field(ESLO,DBF_DOUBLE) {
-		prompt("EGU to Raw Slope")
-		initial("1")
-		promptgroup(GUI_CONVERT)
-		pp(TRUE)
-		interest(2)
-	}
-	field(DRVH,DBF_DOUBLE) {
-		prompt("Drive High Limit")
-		promptgroup(GUI_OUTPUT)
-		pp(TRUE)
-		interest(1)
-	}
-	field(DRVL,DBF_DOUBLE) {
-		prompt("Drive Low Limit")
-		promptgroup(GUI_OUTPUT)
-		pp(TRUE)
-		interest(1)
-	}
-	field(HOPR,DBF_DOUBLE) {
-		prompt("High Operating Range")
-		promptgroup(GUI_DISPLAY)
-		interest(1)
-	}
-	field(LOPR,DBF_DOUBLE) {
-		prompt("Low Operating Range")
-		promptgroup(GUI_DISPLAY)
-		interest(1)
-	}
-	field(AOFF,DBF_DOUBLE) {
-		prompt("Adjustment Offset")
-		promptgroup(GUI_CONVERT)
-		pp(TRUE)
-		interest(1)
-	}
-	field(ASLO,DBF_DOUBLE) {
-		prompt("Adjustment Slope")
-		promptgroup(GUI_CONVERT)
-		pp(TRUE)
-		interest(1)
-	}
-	field(HIHI,DBF_DOUBLE) {
-		prompt("Hihi Alarm Limit")
-		promptgroup(GUI_ALARMS)
-		pp(TRUE)
-		interest(1)
-	}
-	field(LOLO,DBF_DOUBLE) {
-		prompt("Lolo Alarm Limit")
-		promptgroup(GUI_ALARMS)
-		pp(TRUE)
-		interest(1)
-	}
-	field(HIGH,DBF_DOUBLE) {
-		prompt("High Alarm Limit")
-		promptgroup(GUI_ALARMS)
-		pp(TRUE)
-		interest(1)
-	}
-	field(LOW,DBF_DOUBLE) {
-		prompt("Low Alarm Limit")
-		promptgroup(GUI_ALARMS)
-		pp(TRUE)
-		interest(1)
-	}
-	field(HHSV,DBF_MENU) {
-		prompt("Hihi Severity")
-		promptgroup(GUI_ALARMS)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(LLSV,DBF_MENU) {
-		prompt("Lolo Severity")
-		promptgroup(GUI_ALARMS)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(HSV,DBF_MENU) {
-		prompt("High Severity")
-		promptgroup(GUI_ALARMS)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(LSV,DBF_MENU) {
-		prompt("Low Severity")
-		promptgroup(GUI_ALARMS)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(HYST,DBF_DOUBLE) {
-		prompt("Alarm Deadband")
-		promptgroup(GUI_ALARMS)
-		interest(1)
-	}
-	field(ADEL,DBF_DOUBLE) {
-		prompt("Archive Deadband")
-		promptgroup(GUI_DISPLAY)
-		interest(1)
-	}
-	field(MDEL,DBF_DOUBLE) {
-		prompt("Monitor Deadband")
-		promptgroup(GUI_DISPLAY)
-		interest(1)
-	}
-	field(RVAL,DBF_LONG) {
-		prompt("Current Raw Value")
-		pp(TRUE)
-	}
-	field(ORAW,DBF_LONG) {
-		prompt("Previous Raw Value")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(RBV,DBF_LONG) {
-		prompt("Readback Value")
-		special(SPC_NOMOD)
-	}
-	field(ORBV,DBF_LONG) {
-		prompt("Prev Readback Value")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(PVAL,DBF_DOUBLE) {
-		prompt("Previous value")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(LALM,DBF_DOUBLE) {
-		prompt("Last Value Alarmed")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(ALST,DBF_DOUBLE) {
-		prompt("Last Value Archived")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(MLST,DBF_DOUBLE) {
-		prompt("Last Val Monitored")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(PBRK,DBF_NOACCESS) {
-		prompt("Ptrto brkTable")
-		special(SPC_NOMOD)
-		extra("void *	pbrk")
-		interest(4)
-	}
-	field(INIT,DBF_SHORT) {
-		prompt("Initialized?")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(LBRK,DBF_SHORT) {
-		prompt("LastBreak Point")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(SIOL,DBF_OUTLINK) {
-		prompt("Sim Output Specifctn")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(SIML,DBF_INLINK) {
-		prompt("Sim Mode Location")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(SIMM,DBF_MENU) {
-		prompt("Simulation Mode")
-		menu(menuYesNo)
-		interest(1)
-	}
-	field(SIMS,DBF_MENU) {
-		prompt("Sim mode Alarm Svrty")
-		promptgroup(GUI_INPUTS)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(IVOA,DBF_MENU) {
-		prompt("INVALID output action")
-		promptgroup(GUI_OUTPUT)
-		menu(menuIvoa)
-		interest(2)
-	}
-	field(IVOV,DBF_DOUBLE) {
-		prompt("INVALID output value")
-		promptgroup(GUI_OUTPUT)
-		interest(2)
-	}
-	field(OMOD,DBF_UCHAR) {
-		prompt("Was OVAL modified?")
-		special(SPC_NOMOD)
-	}
+menu(menuConvert) {
+    choice(menuConvertNO_CONVERSION, "NO CONVERSION")
+    choice(menuConvertSLOPE, "SLOPE")
+    choice(menuConvertLINEAR, "LINEAR")
+    choice(menuConverttypeKdegF, "typeKdegF")
+    choice(menuConverttypeKdegC, "typeKdegC")
+    choice(menuConverttypeJdegF, "typeJdegF")
+    choice(menuConverttypeJdegC, "typeJdegC")
+    choice(menuConverttypeEdegF, "typeEdegF(ixe only)")
+    choice(menuConverttypeEdegC, "typeEdegC(ixe only)")
+    choice(menuConverttypeTdegF, "typeTdegF")
+    choice(menuConverttypeTdegC, "typeTdegC")
+    choice(menuConverttypeRdegF, "typeRdegF")
+    choice(menuConverttypeRdegC, "typeRdegC")
+    choice(menuConverttypeSdegF, "typeSdegF")
+    choice(menuConverttypeSdegC, "typeSdegC")
 }
-recordtype(aSub) {
-	field(NAME,DBF_STRING) {
-		prompt("Record Name")
-		special(SPC_NOMOD)
-		size(61)
-	}
-	field(DESC,DBF_STRING) {
-		prompt("Descriptor")
-		promptgroup(GUI_COMMON)
-		size(41)
-	}
-	field(ASG,DBF_STRING) {
-		prompt("Access Security Group")
-		promptgroup(GUI_COMMON)
-		special(SPC_AS)
-		size(29)
-	}
-	field(SCAN,DBF_MENU) {
-		prompt("Scan Mechanism")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuScan)
-		interest(1)
-	}
-	field(PINI,DBF_MENU) {
-		prompt("Process at iocInit")
-		promptgroup(GUI_SCAN)
-		menu(menuPini)
-		interest(1)
-	}
-	field(PHAS,DBF_SHORT) {
-		prompt("Scan Phase")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(EVNT,DBF_SHORT) {
-		prompt("Event Number")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(TSE,DBF_SHORT) {
-		prompt("Time Stamp Event")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(TSEL,DBF_INLINK) {
-		prompt("Time Stamp Link")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(DTYP,DBF_DEVICE) {
-		prompt("Device Type")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(DISV,DBF_SHORT) {
-		prompt("Disable Value")
-		initial("1")
-		promptgroup(GUI_SCAN)
-	}
-	field(DISA,DBF_SHORT) {
-		prompt("Disable")
-	}
-	field(SDIS,DBF_INLINK) {
-		prompt("Scanning Disable")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(MLOK,DBF_NOACCESS) {
-		prompt("Monitor lock")
-		special(SPC_NOMOD)
-		extra("epicsMutexId	mlok")
-		interest(4)
-	}
-	field(MLIS,DBF_NOACCESS) {
-		prompt("Monitor List")
-		special(SPC_NOMOD)
-		extra("ELLLIST		mlis")
-		interest(4)
-	}
-	field(DISP,DBF_UCHAR) {
-		prompt("Disable putField")
-	}
-	field(PROC,DBF_UCHAR) {
-		prompt("Force Processing")
-		pp(TRUE)
-		interest(3)
-	}
-	field(STAT,DBF_MENU) {
-		prompt("Alarm Status")
-		initial("UDF")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-	}
-	field(SEVR,DBF_MENU) {
-		prompt("Alarm Severity")
-		initial("INVALID")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-	}
-	field(NSTA,DBF_MENU) {
-		prompt("New Alarm Status")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-		interest(2)
-	}
-	field(NSEV,DBF_MENU) {
-		prompt("New Alarm Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKS,DBF_MENU) {
-		prompt("Alarm Ack Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKT,DBF_MENU) {
-		prompt("Alarm Ack Transient")
-		initial("YES")
-		promptgroup(GUI_ALARMS)
-		special(SPC_NOMOD)
-		menu(menuYesNo)
-		interest(2)
-	}
-	field(DISS,DBF_MENU) {
-		prompt("Disable Alarm Sevrty")
-		promptgroup(GUI_SCAN)
-		menu(menuAlarmSevr)
-		interest(1)
-	}
-	field(LCNT,DBF_UCHAR) {
-		prompt("Lock Count")
-		special(SPC_NOMOD)
-		interest(2)
-	}
-	field(PACT,DBF_UCHAR) {
-		prompt("Record active")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(PUTF,DBF_UCHAR) {
-		prompt("dbPutField process")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(RPRO,DBF_UCHAR) {
-		prompt("Reprocess ")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(ASP,DBF_NOACCESS) {
-		prompt("Access Security Pvt")
-		special(SPC_NOMOD)
-		extra("struct asgMember *asp")
-		interest(4)
-	}
-	field(PPN,DBF_NOACCESS) {
-		prompt("addr of PUTNOTIFY")
-		special(SPC_NOMOD)
-		extra("struct putNotify *ppn")
-		interest(4)
-	}
-	field(PPNR,DBF_NOACCESS) {
-		prompt("pputNotifyRecord")
-		special(SPC_NOMOD)
-		extra("struct putNotifyRecord *ppnr")
-		interest(4)
-	}
-	field(SPVT,DBF_NOACCESS) {
-		prompt("Scan Private")
-		special(SPC_NOMOD)
-		extra("struct scan_element *spvt")
-		interest(4)
-	}
-	field(RSET,DBF_NOACCESS) {
-		prompt("Address of RSET")
-		special(SPC_NOMOD)
-		extra("struct rset	*rset")
-		interest(4)
-	}
-	field(DSET,DBF_NOACCESS) {
-		prompt("DSET address")
-		special(SPC_NOMOD)
-		extra("struct dset	*dset")
-		interest(4)
-	}
-	field(DPVT,DBF_NOACCESS) {
-		prompt("Device Private")
-		special(SPC_NOMOD)
-		extra("void		*dpvt")
-		interest(4)
-	}
-	field(RDES,DBF_NOACCESS) {
-		prompt("Address of dbRecordType")
-		special(SPC_NOMOD)
-		extra("struct dbRecordType *rdes")
-		interest(4)
-	}
-	field(LSET,DBF_NOACCESS) {
-		prompt("Lock Set")
-		special(SPC_NOMOD)
-		extra("struct lockRecord *lset")
-		interest(4)
-	}
-	field(PRIO,DBF_MENU) {
-		prompt("Scheduling Priority")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuPriority)
-		interest(1)
-	}
-	field(TPRO,DBF_UCHAR) {
-		prompt("Trace Processing")
-	}
-	field(BKPT,DBF_NOACCESS) {
-		prompt("Break Point")
-		special(SPC_NOMOD)
-		extra("char bkpt")
-		interest(1)
-	}
-	field(UDF,DBF_UCHAR) {
-		prompt("Undefined")
-		initial("1")
-		promptgroup(GUI_COMMON)
-		pp(TRUE)
-		interest(1)
-	}
-	field(TIME,DBF_NOACCESS) {
-		prompt("Time")
-		special(SPC_NOMOD)
-		extra("epicsTimeStamp	time")
-		interest(2)
-	}
-	field(FLNK,DBF_FWDLINK) {
-		prompt("Forward Process Link")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(VAL,DBF_LONG) {
-		prompt("Subr. return value")
-		asl(ASL0)
-	}
-	field(OVAL,DBF_LONG) {
-		prompt("Old return value")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(INAM,DBF_STRING) {
-		prompt("Initialize Subr. Name")
-		promptgroup(GUI_SUB)
-		special(SPC_NOMOD)
-		size(41)
-		interest(1)
-	}
-	field(LFLG,DBF_MENU) {
-		prompt("Subr. Input Enable")
-		promptgroup(GUI_SUB)
-		menu(aSubLFLG)
-		interest(1)
-	}
-	field(SUBL,DBF_INLINK) {
-		prompt("Subroutine Name Link")
-		promptgroup(GUI_SUB)
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(SNAM,DBF_STRING) {
-		prompt("Process Subr. Name")
-		promptgroup(GUI_SUB)
-		special(100)
-		size(41)
-		interest(1)
-	}
-	field(ONAM,DBF_STRING) {
-		prompt("Old Subr. Name")
-		promptgroup(GUI_SUB)
-		special(SPC_NOMOD)
-		size(41)
-		interest(3)
-	}
-	field(SADR,DBF_NOACCESS) {
-		prompt("Subroutine Address")
-		special(SPC_NOMOD)
-		extra("long (*sadr)(struct aSubRecord *)")
-		interest(2)
-	}
-	field(BRSV,DBF_MENU) {
-		prompt("Bad Return Severity")
-		promptgroup(GUI_SUB)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(PREC,DBF_SHORT) {
-		prompt("Display Precision")
-		promptgroup(GUI_DISPLAY)
-		interest(1)
-	}
-	field(EFLG,DBF_MENU) {
-		prompt("Output Event Flag")
-		initial("1")
-		promptgroup(GUI_OUTPUT)
-		menu(aSubEFLG)
-		interest(1)
-	}
-	field(INPA,DBF_INLINK) {
-		prompt("Input Link A")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(INPB,DBF_INLINK) {
-		prompt("Input Link B")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(INPC,DBF_INLINK) {
-		prompt("Input Link C")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(INPD,DBF_INLINK) {
-		prompt("Input Link D")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(INPE,DBF_INLINK) {
-		prompt("Input Link E")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(INPF,DBF_INLINK) {
-		prompt("Input Link F")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(INPG,DBF_INLINK) {
-		prompt("Input Link G")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(INPH,DBF_INLINK) {
-		prompt("Input Link H")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(INPI,DBF_INLINK) {
-		prompt("Input Link I")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(INPJ,DBF_INLINK) {
-		prompt("Input Link J")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(INPK,DBF_INLINK) {
-		prompt("Input Link K")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(INPL,DBF_INLINK) {
-		prompt("Input Link L")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(INPM,DBF_INLINK) {
-		prompt("Input Link M")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(INPN,DBF_INLINK) {
-		prompt("Input Link N")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(INPO,DBF_INLINK) {
-		prompt("Input Link O")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(INPP,DBF_INLINK) {
-		prompt("Input Link P")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(INPQ,DBF_INLINK) {
-		prompt("Input Link Q")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(INPR,DBF_INLINK) {
-		prompt("Input Link R")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(INPS,DBF_INLINK) {
-		prompt("Input Link S")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(INPT,DBF_INLINK) {
-		prompt("Input Link T")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(INPU,DBF_INLINK) {
-		prompt("Input Link U")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(A,DBF_NOACCESS) {
-		prompt("Input value A")
-		special(SPC_DBADDR)
-		extra("void *a")
-		interest(2)
-		asl(ASL0)
-	}
-	field(B,DBF_NOACCESS) {
-		prompt("Input value B")
-		special(SPC_DBADDR)
-		extra("void *b")
-		interest(2)
-		asl(ASL0)
-	}
-	field(C,DBF_NOACCESS) {
-		prompt("Input value C")
-		special(SPC_DBADDR)
-		extra("void *c")
-		interest(2)
-		asl(ASL0)
-	}
-	field(D,DBF_NOACCESS) {
-		prompt("Input value D")
-		special(SPC_DBADDR)
-		extra("void *d")
-		interest(2)
-		asl(ASL0)
-	}
-	field(E,DBF_NOACCESS) {
-		prompt("Input value E")
-		special(SPC_DBADDR)
-		extra("void *e")
-		interest(2)
-		asl(ASL0)
-	}
-	field(F,DBF_NOACCESS) {
-		prompt("Input value F")
-		special(SPC_DBADDR)
-		extra("void *f")
-		interest(2)
-		asl(ASL0)
-	}
-	field(G,DBF_NOACCESS) {
-		prompt("Input value G")
-		special(SPC_DBADDR)
-		extra("void *g")
-		interest(2)
-		asl(ASL0)
-	}
-	field(H,DBF_NOACCESS) {
-		prompt("Input value H")
-		special(SPC_DBADDR)
-		extra("void *h")
-		interest(2)
-		asl(ASL0)
-	}
-	field(I,DBF_NOACCESS) {
-		prompt("Input value I")
-		special(SPC_DBADDR)
-		extra("void *i")
-		interest(2)
-		asl(ASL0)
-	}
-	field(J,DBF_NOACCESS) {
-		prompt("Input value J")
-		special(SPC_DBADDR)
-		extra("void *j")
-		interest(2)
-		asl(ASL0)
-	}
-	field(K,DBF_NOACCESS) {
-		prompt("Input value K")
-		special(SPC_DBADDR)
-		extra("void *k")
-		interest(2)
-		asl(ASL0)
-	}
-	field(L,DBF_NOACCESS) {
-		prompt("Input value L")
-		special(SPC_DBADDR)
-		extra("void *l")
-		interest(2)
-		asl(ASL0)
-	}
-	field(M,DBF_NOACCESS) {
-		prompt("Input value M")
-		special(SPC_DBADDR)
-		extra("void *m")
-		interest(2)
-		asl(ASL0)
-	}
-	field(N,DBF_NOACCESS) {
-		prompt("Input value N")
-		special(SPC_DBADDR)
-		extra("void *n")
-		interest(2)
-		asl(ASL0)
-	}
-	field(O,DBF_NOACCESS) {
-		prompt("Input value O")
-		special(SPC_DBADDR)
-		extra("void *o")
-		interest(2)
-		asl(ASL0)
-	}
-	field(P,DBF_NOACCESS) {
-		prompt("Input value P")
-		special(SPC_DBADDR)
-		extra("void *p")
-		interest(2)
-		asl(ASL0)
-	}
-	field(Q,DBF_NOACCESS) {
-		prompt("Input value Q")
-		special(SPC_DBADDR)
-		extra("void *q")
-		interest(2)
-		asl(ASL0)
-	}
-	field(R,DBF_NOACCESS) {
-		prompt("Input value R")
-		special(SPC_DBADDR)
-		extra("void *r")
-		interest(2)
-		asl(ASL0)
-	}
-	field(S,DBF_NOACCESS) {
-		prompt("Input value S")
-		special(SPC_DBADDR)
-		extra("void *s")
-		interest(2)
-		asl(ASL0)
-	}
-	field(T,DBF_NOACCESS) {
-		prompt("Input value T")
-		special(SPC_DBADDR)
-		extra("void *t")
-		interest(2)
-		asl(ASL0)
-	}
-	field(U,DBF_NOACCESS) {
-		prompt("Input value U")
-		special(SPC_DBADDR)
-		extra("void *u")
-		interest(2)
-		asl(ASL0)
-	}
-	field(FTA,DBF_MENU) {
-		prompt("Type of A")
-		initial("DOUBLE")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		menu(menuFtype)
-		interest(1)
-	}
-	field(FTB,DBF_MENU) {
-		prompt("Type of B")
-		initial("DOUBLE")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		menu(menuFtype)
-		interest(1)
-	}
-	field(FTC,DBF_MENU) {
-		prompt("Type of C")
-		initial("DOUBLE")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		menu(menuFtype)
-		interest(1)
-	}
-	field(FTD,DBF_MENU) {
-		prompt("Type of D")
-		initial("DOUBLE")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		menu(menuFtype)
-		interest(1)
-	}
-	field(FTE,DBF_MENU) {
-		prompt("Type of E")
-		initial("DOUBLE")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		menu(menuFtype)
-		interest(1)
-	}
-	field(FTF,DBF_MENU) {
-		prompt("Type of F")
-		initial("DOUBLE")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		menu(menuFtype)
-		interest(1)
-	}
-	field(FTG,DBF_MENU) {
-		prompt("Type of G")
-		initial("DOUBLE")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		menu(menuFtype)
-		interest(1)
-	}
-	field(FTH,DBF_MENU) {
-		prompt("Type of H")
-		initial("DOUBLE")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		menu(menuFtype)
-		interest(1)
-	}
-	field(FTI,DBF_MENU) {
-		prompt("Type of I")
-		initial("DOUBLE")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		menu(menuFtype)
-		interest(1)
-	}
-	field(FTJ,DBF_MENU) {
-		prompt("Type of J")
-		initial("DOUBLE")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		menu(menuFtype)
-		interest(1)
-	}
-	field(FTK,DBF_MENU) {
-		prompt("Type of K")
-		initial("DOUBLE")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		menu(menuFtype)
-		interest(1)
-	}
-	field(FTL,DBF_MENU) {
-		prompt("Type of L")
-		initial("DOUBLE")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		menu(menuFtype)
-		interest(1)
-	}
-	field(FTM,DBF_MENU) {
-		prompt("Type of M")
-		initial("DOUBLE")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		menu(menuFtype)
-		interest(1)
-	}
-	field(FTN,DBF_MENU) {
-		prompt("Type of N")
-		initial("DOUBLE")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		menu(menuFtype)
-		interest(1)
-	}
-	field(FTO,DBF_MENU) {
-		prompt("Type of O")
-		initial("DOUBLE")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		menu(menuFtype)
-		interest(1)
-	}
-	field(FTP,DBF_MENU) {
-		prompt("Type of P")
-		initial("DOUBLE")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		menu(menuFtype)
-		interest(1)
-	}
-	field(FTQ,DBF_MENU) {
-		prompt("Type of Q")
-		initial("DOUBLE")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		menu(menuFtype)
-		interest(1)
-	}
-	field(FTR,DBF_MENU) {
-		prompt("Type of R")
-		initial("DOUBLE")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		menu(menuFtype)
-		interest(1)
-	}
-	field(FTS,DBF_MENU) {
-		prompt("Type of S")
-		initial("DOUBLE")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		menu(menuFtype)
-		interest(1)
-	}
-	field(FTT,DBF_MENU) {
-		prompt("Type of T")
-		initial("DOUBLE")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		menu(menuFtype)
-		interest(1)
-	}
-	field(FTU,DBF_MENU) {
-		prompt("Type of U")
-		initial("DOUBLE")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		menu(menuFtype)
-		interest(1)
-	}
-	field(NOA,DBF_ULONG) {
-		prompt("Max. elements in A")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(NOB,DBF_ULONG) {
-		prompt("Max. elements in B")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(NOC,DBF_ULONG) {
-		prompt("Max. elements in C")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(NOD,DBF_ULONG) {
-		prompt("Max. elements in D")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(NOE,DBF_ULONG) {
-		prompt("Max. elements in E")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(NOF,DBF_ULONG) {
-		prompt("Max. elements in F")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(NOG,DBF_ULONG) {
-		prompt("Max. elements in G")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(NOH,DBF_ULONG) {
-		prompt("Max. elements in H")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(NOI,DBF_ULONG) {
-		prompt("Max. elements in I")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(NOJ,DBF_ULONG) {
-		prompt("Max. elements in J")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(NOK,DBF_ULONG) {
-		prompt("Max. elements in K")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(NOL,DBF_ULONG) {
-		prompt("Max. elements in L")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(NOM,DBF_ULONG) {
-		prompt("Max. elements in M")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(NON,DBF_ULONG) {
-		prompt("Max. elements in N")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(NOO,DBF_ULONG) {
-		prompt("Max. elements in O")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(NOP,DBF_ULONG) {
-		prompt("Max. elements in P")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(NOQ,DBF_ULONG) {
-		prompt("Max. elements in Q")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(NOR,DBF_ULONG) {
-		prompt("Max. elements in R")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(NOS,DBF_ULONG) {
-		prompt("Max. elements in S")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(NOT,DBF_ULONG) {
-		prompt("Max. elements in T")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(NOU,DBF_ULONG) {
-		prompt("Max. elements in U")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(NEA,DBF_ULONG) {
-		prompt("Num. elements in A")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(NEB,DBF_ULONG) {
-		prompt("Num. elements in B")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(NEC,DBF_ULONG) {
-		prompt("Num. elements in C")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(NED,DBF_ULONG) {
-		prompt("Num. elements in D")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(NEE,DBF_ULONG) {
-		prompt("Num. elements in E")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(NEF,DBF_ULONG) {
-		prompt("Num. elements in F")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(NEG,DBF_ULONG) {
-		prompt("Num. elements in G")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(NEH,DBF_ULONG) {
-		prompt("Num. elements in H")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(NEI,DBF_ULONG) {
-		prompt("Num. elements in I")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(NEJ,DBF_ULONG) {
-		prompt("Num. elements in J")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(NEK,DBF_ULONG) {
-		prompt("Num. elements in K")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(NEL,DBF_ULONG) {
-		prompt("Num. elements in L")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(NEM,DBF_ULONG) {
-		prompt("Num. elements in M")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(NEN,DBF_ULONG) {
-		prompt("Num. elements in N")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(NEO,DBF_ULONG) {
-		prompt("Num. elements in O")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(NEP,DBF_ULONG) {
-		prompt("Num. elements in P")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(NEQ,DBF_ULONG) {
-		prompt("Num. elements in Q")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(NER,DBF_ULONG) {
-		prompt("Num. elements in R")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(NES,DBF_ULONG) {
-		prompt("Num. elements in S")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(NET,DBF_ULONG) {
-		prompt("Num. elements in T")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(NEU,DBF_ULONG) {
-		prompt("Num. elements in U")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(OUTA,DBF_OUTLINK) {
-		prompt("Output Link A")
-		promptgroup(GUI_OUTPUT)
-		interest(1)
-	}
-	field(OUTB,DBF_OUTLINK) {
-		prompt("Output Link B")
-		promptgroup(GUI_OUTPUT)
-		interest(1)
-	}
-	field(OUTC,DBF_OUTLINK) {
-		prompt("Output Link C")
-		promptgroup(GUI_OUTPUT)
-		interest(1)
-	}
-	field(OUTD,DBF_OUTLINK) {
-		prompt("Output Link D")
-		promptgroup(GUI_OUTPUT)
-		interest(1)
-	}
-	field(OUTE,DBF_OUTLINK) {
-		prompt("Output Link E")
-		promptgroup(GUI_OUTPUT)
-		interest(1)
-	}
-	field(OUTF,DBF_OUTLINK) {
-		prompt("Output Link F")
-		promptgroup(GUI_OUTPUT)
-		interest(1)
-	}
-	field(OUTG,DBF_OUTLINK) {
-		prompt("Output Link G")
-		promptgroup(GUI_OUTPUT)
-		interest(1)
-	}
-	field(OUTH,DBF_OUTLINK) {
-		prompt("Output Link H")
-		promptgroup(GUI_OUTPUT)
-		interest(1)
-	}
-	field(OUTI,DBF_OUTLINK) {
-		prompt("Output Link I")
-		promptgroup(GUI_OUTPUT)
-		interest(1)
-	}
-	field(OUTJ,DBF_OUTLINK) {
-		prompt("Output Link J")
-		promptgroup(GUI_OUTPUT)
-		interest(1)
-	}
-	field(OUTK,DBF_OUTLINK) {
-		prompt("Output Link K")
-		promptgroup(GUI_OUTPUT)
-		interest(1)
-	}
-	field(OUTL,DBF_OUTLINK) {
-		prompt("Output Link L")
-		promptgroup(GUI_OUTPUT)
-		interest(1)
-	}
-	field(OUTM,DBF_OUTLINK) {
-		prompt("Output Link M")
-		promptgroup(GUI_OUTPUT)
-		interest(1)
-	}
-	field(OUTN,DBF_OUTLINK) {
-		prompt("Output Link N")
-		promptgroup(GUI_OUTPUT)
-		interest(1)
-	}
-	field(OUTO,DBF_OUTLINK) {
-		prompt("Output Link O")
-		promptgroup(GUI_OUTPUT)
-		interest(1)
-	}
-	field(OUTP,DBF_OUTLINK) {
-		prompt("Output Link P")
-		promptgroup(GUI_OUTPUT)
-		interest(1)
-	}
-	field(OUTQ,DBF_OUTLINK) {
-		prompt("Output Link Q")
-		promptgroup(GUI_OUTPUT)
-		interest(1)
-	}
-	field(OUTR,DBF_OUTLINK) {
-		prompt("Output Link R")
-		promptgroup(GUI_OUTPUT)
-		interest(1)
-	}
-	field(OUTS,DBF_OUTLINK) {
-		prompt("Output Link S")
-		promptgroup(GUI_OUTPUT)
-		interest(1)
-	}
-	field(OUTT,DBF_OUTLINK) {
-		prompt("Output Link T")
-		promptgroup(GUI_OUTPUT)
-		interest(1)
-	}
-	field(OUTU,DBF_OUTLINK) {
-		prompt("Output Link U")
-		promptgroup(GUI_OUTPUT)
-		interest(1)
-	}
-	field(VALA,DBF_NOACCESS) {
-		prompt("Output value A")
-		special(SPC_DBADDR)
-		extra("void *vala")
-		interest(2)
-		asl(ASL0)
-	}
-	field(VALB,DBF_NOACCESS) {
-		prompt("Output value B")
-		special(SPC_DBADDR)
-		extra("void *valb")
-		interest(2)
-		asl(ASL0)
-	}
-	field(VALC,DBF_NOACCESS) {
-		prompt("Output value C")
-		special(SPC_DBADDR)
-		extra("void *valc")
-		interest(2)
-		asl(ASL0)
-	}
-	field(VALD,DBF_NOACCESS) {
-		prompt("Output value D")
-		special(SPC_DBADDR)
-		extra("void *vald")
-		interest(2)
-		asl(ASL0)
-	}
-	field(VALE,DBF_NOACCESS) {
-		prompt("Output value E")
-		special(SPC_DBADDR)
-		extra("void *vale")
-		interest(2)
-		asl(ASL0)
-	}
-	field(VALF,DBF_NOACCESS) {
-		prompt("Output value F")
-		special(SPC_DBADDR)
-		extra("void *valf")
-		interest(2)
-		asl(ASL0)
-	}
-	field(VALG,DBF_NOACCESS) {
-		prompt("Output value G")
-		special(SPC_DBADDR)
-		extra("void *valg")
-		interest(2)
-		asl(ASL0)
-	}
-	field(VALH,DBF_NOACCESS) {
-		prompt("Output value H")
-		special(SPC_DBADDR)
-		extra("void *valh")
-		interest(2)
-		asl(ASL0)
-	}
-	field(VALI,DBF_NOACCESS) {
-		prompt("Output value I")
-		special(SPC_DBADDR)
-		extra("void *vali")
-		interest(2)
-		asl(ASL0)
-	}
-	field(VALJ,DBF_NOACCESS) {
-		prompt("Output value J")
-		special(SPC_DBADDR)
-		extra("void *valj")
-		interest(2)
-		asl(ASL0)
-	}
-	field(VALK,DBF_NOACCESS) {
-		prompt("Output value K")
-		special(SPC_DBADDR)
-		extra("void *valk")
-		interest(2)
-		asl(ASL0)
-	}
-	field(VALL,DBF_NOACCESS) {
-		prompt("Output value L")
-		special(SPC_DBADDR)
-		extra("void *vall")
-		interest(2)
-		asl(ASL0)
-	}
-	field(VALM,DBF_NOACCESS) {
-		prompt("Output value M")
-		special(SPC_DBADDR)
-		extra("void *valm")
-		interest(2)
-		asl(ASL0)
-	}
-	field(VALN,DBF_NOACCESS) {
-		prompt("Output value N")
-		special(SPC_DBADDR)
-		extra("void *valn")
-		interest(2)
-		asl(ASL0)
-	}
-	field(VALO,DBF_NOACCESS) {
-		prompt("Output value O")
-		special(SPC_DBADDR)
-		extra("void *valo")
-		interest(2)
-		asl(ASL0)
-	}
-	field(VALP,DBF_NOACCESS) {
-		prompt("Output value P")
-		special(SPC_DBADDR)
-		extra("void *valp")
-		interest(2)
-		asl(ASL0)
-	}
-	field(VALQ,DBF_NOACCESS) {
-		prompt("Output value Q")
-		special(SPC_DBADDR)
-		extra("void *valq")
-		interest(2)
-		asl(ASL0)
-	}
-	field(VALR,DBF_NOACCESS) {
-		prompt("Output value R")
-		special(SPC_DBADDR)
-		extra("void *valr")
-		interest(2)
-		asl(ASL0)
-	}
-	field(VALS,DBF_NOACCESS) {
-		prompt("Output value S")
-		special(SPC_DBADDR)
-		extra("void *vals")
-		interest(2)
-		asl(ASL0)
-	}
-	field(VALT,DBF_NOACCESS) {
-		prompt("Output value T")
-		special(SPC_DBADDR)
-		extra("void *valt")
-		interest(2)
-		asl(ASL0)
-	}
-	field(VALU,DBF_NOACCESS) {
-		prompt("Output value U")
-		special(SPC_DBADDR)
-		extra("void *valu")
-		interest(2)
-		asl(ASL0)
-	}
-	field(OVLA,DBF_NOACCESS) {
-		prompt("Old Output A")
-		special(SPC_NOMOD)
-		extra("void *ovla")
-		interest(4)
-		asl(ASL0)
-	}
-	field(OVLB,DBF_NOACCESS) {
-		prompt("Old Output B")
-		special(SPC_NOMOD)
-		extra("void *ovlb")
-		interest(4)
-		asl(ASL0)
-	}
-	field(OVLC,DBF_NOACCESS) {
-		prompt("Old Output C")
-		special(SPC_NOMOD)
-		extra("void *ovlc")
-		interest(4)
-		asl(ASL0)
-	}
-	field(OVLD,DBF_NOACCESS) {
-		prompt("Old Output D")
-		special(SPC_NOMOD)
-		extra("void *ovld")
-		interest(4)
-		asl(ASL0)
-	}
-	field(OVLE,DBF_NOACCESS) {
-		prompt("Old Output E")
-		special(SPC_NOMOD)
-		extra("void *ovle")
-		interest(4)
-		asl(ASL0)
-	}
-	field(OVLF,DBF_NOACCESS) {
-		prompt("Old Output F")
-		special(SPC_NOMOD)
-		extra("void *ovlf")
-		interest(4)
-		asl(ASL0)
-	}
-	field(OVLG,DBF_NOACCESS) {
-		prompt("Old Output G")
-		special(SPC_NOMOD)
-		extra("void *ovlg")
-		interest(4)
-		asl(ASL0)
-	}
-	field(OVLH,DBF_NOACCESS) {
-		prompt("Old Output H")
-		special(SPC_NOMOD)
-		extra("void *ovlh")
-		interest(4)
-		asl(ASL0)
-	}
-	field(OVLI,DBF_NOACCESS) {
-		prompt("Old Output I")
-		special(SPC_NOMOD)
-		extra("void *ovli")
-		interest(4)
-		asl(ASL0)
-	}
-	field(OVLJ,DBF_NOACCESS) {
-		prompt("Old Output J")
-		special(SPC_NOMOD)
-		extra("void *ovlj")
-		interest(4)
-		asl(ASL0)
-	}
-	field(OVLK,DBF_NOACCESS) {
-		prompt("Old Output K")
-		special(SPC_NOMOD)
-		extra("void *ovlk")
-		interest(4)
-		asl(ASL0)
-	}
-	field(OVLL,DBF_NOACCESS) {
-		prompt("Old Output L")
-		special(SPC_NOMOD)
-		extra("void *ovll")
-		interest(4)
-		asl(ASL0)
-	}
-	field(OVLM,DBF_NOACCESS) {
-		prompt("Old Output M")
-		special(SPC_NOMOD)
-		extra("void *ovlm")
-		interest(4)
-		asl(ASL0)
-	}
-	field(OVLN,DBF_NOACCESS) {
-		prompt("Old Output N")
-		special(SPC_NOMOD)
-		extra("void *ovln")
-		interest(4)
-		asl(ASL0)
-	}
-	field(OVLO,DBF_NOACCESS) {
-		prompt("Old Output O")
-		special(SPC_NOMOD)
-		extra("void *ovlo")
-		interest(4)
-		asl(ASL0)
-	}
-	field(OVLP,DBF_NOACCESS) {
-		prompt("Old Output P")
-		special(SPC_NOMOD)
-		extra("void *ovlp")
-		interest(4)
-		asl(ASL0)
-	}
-	field(OVLQ,DBF_NOACCESS) {
-		prompt("Old Output Q")
-		special(SPC_NOMOD)
-		extra("void *ovlq")
-		interest(4)
-		asl(ASL0)
-	}
-	field(OVLR,DBF_NOACCESS) {
-		prompt("Old Output R")
-		special(SPC_NOMOD)
-		extra("void *ovlr")
-		interest(4)
-		asl(ASL0)
-	}
-	field(OVLS,DBF_NOACCESS) {
-		prompt("Old Output S")
-		special(SPC_NOMOD)
-		extra("void *ovls")
-		interest(4)
-		asl(ASL0)
-	}
-	field(OVLT,DBF_NOACCESS) {
-		prompt("Old Output T")
-		special(SPC_NOMOD)
-		extra("void *ovlt")
-		interest(4)
-		asl(ASL0)
-	}
-	field(OVLU,DBF_NOACCESS) {
-		prompt("Old Output U")
-		special(SPC_NOMOD)
-		extra("void *ovlu")
-		interest(4)
-		asl(ASL0)
-	}
-	field(FTVA,DBF_MENU) {
-		prompt("Type of VALA")
-		initial("DOUBLE")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		menu(menuFtype)
-		interest(1)
-	}
-	field(FTVB,DBF_MENU) {
-		prompt("Type of VALB")
-		initial("DOUBLE")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		menu(menuFtype)
-		interest(1)
-	}
-	field(FTVC,DBF_MENU) {
-		prompt("Type of VALC")
-		initial("DOUBLE")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		menu(menuFtype)
-		interest(1)
-	}
-	field(FTVD,DBF_MENU) {
-		prompt("Type of VALD")
-		initial("DOUBLE")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		menu(menuFtype)
-		interest(1)
-	}
-	field(FTVE,DBF_MENU) {
-		prompt("Type of VALE")
-		initial("DOUBLE")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		menu(menuFtype)
-		interest(1)
-	}
-	field(FTVF,DBF_MENU) {
-		prompt("Type of VALF")
-		initial("DOUBLE")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		menu(menuFtype)
-		interest(1)
-	}
-	field(FTVG,DBF_MENU) {
-		prompt("Type of VALG")
-		initial("DOUBLE")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		menu(menuFtype)
-		interest(1)
-	}
-	field(FTVH,DBF_MENU) {
-		prompt("Type of VALH")
-		initial("DOUBLE")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		menu(menuFtype)
-		interest(1)
-	}
-	field(FTVI,DBF_MENU) {
-		prompt("Type of VALI")
-		initial("DOUBLE")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		menu(menuFtype)
-		interest(1)
-	}
-	field(FTVJ,DBF_MENU) {
-		prompt("Type of VALJ")
-		initial("DOUBLE")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		menu(menuFtype)
-		interest(1)
-	}
-	field(FTVK,DBF_MENU) {
-		prompt("Type of VALK")
-		initial("DOUBLE")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		menu(menuFtype)
-		interest(1)
-	}
-	field(FTVL,DBF_MENU) {
-		prompt("Type of VALL")
-		initial("DOUBLE")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		menu(menuFtype)
-		interest(1)
-	}
-	field(FTVM,DBF_MENU) {
-		prompt("Type of VALM")
-		initial("DOUBLE")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		menu(menuFtype)
-		interest(1)
-	}
-	field(FTVN,DBF_MENU) {
-		prompt("Type of VALN")
-		initial("DOUBLE")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		menu(menuFtype)
-		interest(1)
-	}
-	field(FTVO,DBF_MENU) {
-		prompt("Type of VALO")
-		initial("DOUBLE")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		menu(menuFtype)
-		interest(1)
-	}
-	field(FTVP,DBF_MENU) {
-		prompt("Type of VALP")
-		initial("DOUBLE")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		menu(menuFtype)
-		interest(1)
-	}
-	field(FTVQ,DBF_MENU) {
-		prompt("Type of VALQ")
-		initial("DOUBLE")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		menu(menuFtype)
-		interest(1)
-	}
-	field(FTVR,DBF_MENU) {
-		prompt("Type of VALR")
-		initial("DOUBLE")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		menu(menuFtype)
-		interest(1)
-	}
-	field(FTVS,DBF_MENU) {
-		prompt("Type of VALS")
-		initial("DOUBLE")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		menu(menuFtype)
-		interest(1)
-	}
-	field(FTVT,DBF_MENU) {
-		prompt("Type of VALT")
-		initial("DOUBLE")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		menu(menuFtype)
-		interest(1)
-	}
-	field(FTVU,DBF_MENU) {
-		prompt("Type of VALU")
-		initial("DOUBLE")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		menu(menuFtype)
-		interest(1)
-	}
-	field(NOVA,DBF_ULONG) {
-		prompt("Max. elements in VALA")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(NOVB,DBF_ULONG) {
-		prompt("Max. elements in VALB")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(NOVC,DBF_ULONG) {
-		prompt("Max. elements in VALC")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(NOVD,DBF_ULONG) {
-		prompt("Max. elements in VALD")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(NOVE,DBF_ULONG) {
-		prompt("Max. elements in VALE")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(NOVF,DBF_ULONG) {
-		prompt("Max. elements in VALF")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(NOVG,DBF_ULONG) {
-		prompt("Max. elements in VALG")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(NOVH,DBF_ULONG) {
-		prompt("Max. elements in VAlH")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(NOVI,DBF_ULONG) {
-		prompt("Max. elements in VALI")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(NOVJ,DBF_ULONG) {
-		prompt("Max. elements in VALJ")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(NOVK,DBF_ULONG) {
-		prompt("Max. elements in VALK")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(NOVL,DBF_ULONG) {
-		prompt("Max. elements in VALL")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(NOVM,DBF_ULONG) {
-		prompt("Max. elements in VALM")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(NOVN,DBF_ULONG) {
-		prompt("Max. elements in VALN")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(NOVO,DBF_ULONG) {
-		prompt("Max. elements in VALO")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(NOVP,DBF_ULONG) {
-		prompt("Max. elements in VALP")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(NOVQ,DBF_ULONG) {
-		prompt("Max. elements in VALQ")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(NOVR,DBF_ULONG) {
-		prompt("Max. elements in VALR")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(NOVS,DBF_ULONG) {
-		prompt("Max. elements in VALS")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(NOVT,DBF_ULONG) {
-		prompt("Max. elements in VALT")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(NOVU,DBF_ULONG) {
-		prompt("Max. elements in VALU")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(NEVA,DBF_ULONG) {
-		prompt("Num. elements in VALA")
-		initial("1")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(NEVB,DBF_ULONG) {
-		prompt("Num. elements in VALB")
-		initial("1")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(NEVC,DBF_ULONG) {
-		prompt("Num. elements in VALC")
-		initial("1")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(NEVD,DBF_ULONG) {
-		prompt("Num. elements in VALD")
-		initial("1")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(NEVE,DBF_ULONG) {
-		prompt("Num. elements in VALE")
-		initial("1")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(NEVF,DBF_ULONG) {
-		prompt("Num. elements in VALF")
-		initial("1")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(NEVG,DBF_ULONG) {
-		prompt("Num. elements in VALG")
-		initial("1")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(NEVH,DBF_ULONG) {
-		prompt("Num. elements in VAlH")
-		initial("1")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(NEVI,DBF_ULONG) {
-		prompt("Num. elements in VALI")
-		initial("1")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(NEVJ,DBF_ULONG) {
-		prompt("Num. elements in VALJ")
-		initial("1")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(NEVK,DBF_ULONG) {
-		prompt("Num. elements in VALK")
-		initial("1")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(NEVL,DBF_ULONG) {
-		prompt("Num. elements in VALL")
-		initial("1")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(NEVM,DBF_ULONG) {
-		prompt("Num. elements in VALM")
-		initial("1")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(NEVN,DBF_ULONG) {
-		prompt("Num. elements in VALN")
-		initial("1")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(NEVO,DBF_ULONG) {
-		prompt("Num. elements in VALO")
-		initial("1")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(NEVP,DBF_ULONG) {
-		prompt("Num. elements in VALP")
-		initial("1")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(NEVQ,DBF_ULONG) {
-		prompt("Num. elements in VALQ")
-		initial("1")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(NEVR,DBF_ULONG) {
-		prompt("Num. elements in VALR")
-		initial("1")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(NEVS,DBF_ULONG) {
-		prompt("Num. elements in VALS")
-		initial("1")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(NEVT,DBF_ULONG) {
-		prompt("Num. elements in VALT")
-		initial("1")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(NEVU,DBF_ULONG) {
-		prompt("Num. elements in VALU")
-		initial("1")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(ONVA,DBF_ULONG) {
-		prompt("Num. elements in OVLA")
-		initial("1")
-		special(SPC_NOMOD)
-		interest(4)
-	}
-	field(ONVB,DBF_ULONG) {
-		prompt("Num. elements in OVLB")
-		initial("1")
-		special(SPC_NOMOD)
-		interest(4)
-	}
-	field(ONVC,DBF_ULONG) {
-		prompt("Num. elements in OVLC")
-		initial("1")
-		special(SPC_NOMOD)
-		interest(4)
-	}
-	field(ONVD,DBF_ULONG) {
-		prompt("Num. elements in OVLD")
-		initial("1")
-		special(SPC_NOMOD)
-		interest(4)
-	}
-	field(ONVE,DBF_ULONG) {
-		prompt("Num. elements in OVLE")
-		initial("1")
-		special(SPC_NOMOD)
-		interest(4)
-	}
-	field(ONVF,DBF_ULONG) {
-		prompt("Num. elements in OVLF")
-		initial("1")
-		special(SPC_NOMOD)
-		interest(4)
-	}
-	field(ONVG,DBF_ULONG) {
-		prompt("Num. elements in OVLG")
-		initial("1")
-		special(SPC_NOMOD)
-		interest(4)
-	}
-	field(ONVH,DBF_ULONG) {
-		prompt("Num. elements in VAlH")
-		initial("1")
-		special(SPC_NOMOD)
-		interest(4)
-	}
-	field(ONVI,DBF_ULONG) {
-		prompt("Num. elements in OVLI")
-		initial("1")
-		special(SPC_NOMOD)
-		interest(4)
-	}
-	field(ONVJ,DBF_ULONG) {
-		prompt("Num. elements in OVLJ")
-		initial("1")
-		special(SPC_NOMOD)
-		interest(4)
-	}
-	field(ONVK,DBF_ULONG) {
-		prompt("Num. elements in OVLK")
-		initial("1")
-		special(SPC_NOMOD)
-		interest(4)
-	}
-	field(ONVL,DBF_ULONG) {
-		prompt("Num. elements in OVLL")
-		initial("1")
-		special(SPC_NOMOD)
-		interest(4)
-	}
-	field(ONVM,DBF_ULONG) {
-		prompt("Num. elements in OVLM")
-		initial("1")
-		special(SPC_NOMOD)
-		interest(4)
-	}
-	field(ONVN,DBF_ULONG) {
-		prompt("Num. elements in OVLN")
-		initial("1")
-		special(SPC_NOMOD)
-		interest(4)
-	}
-	field(ONVO,DBF_ULONG) {
-		prompt("Num. elements in OVLO")
-		initial("1")
-		special(SPC_NOMOD)
-		interest(4)
-	}
-	field(ONVP,DBF_ULONG) {
-		prompt("Num. elements in OVLP")
-		initial("1")
-		special(SPC_NOMOD)
-		interest(4)
-	}
-	field(ONVQ,DBF_ULONG) {
-		prompt("Num. elements in OVLQ")
-		initial("1")
-		special(SPC_NOMOD)
-		interest(4)
-	}
-	field(ONVR,DBF_ULONG) {
-		prompt("Num. elements in OVLR")
-		initial("1")
-		special(SPC_NOMOD)
-		interest(4)
-	}
-	field(ONVS,DBF_ULONG) {
-		prompt("Num. elements in OVLS")
-		initial("1")
-		special(SPC_NOMOD)
-		interest(4)
-	}
-	field(ONVT,DBF_ULONG) {
-		prompt("Num. elements in OVLT")
-		initial("1")
-		special(SPC_NOMOD)
-		interest(4)
-	}
-	field(ONVU,DBF_ULONG) {
-		prompt("Num. elements in OVLU")
-		initial("1")
-		special(SPC_NOMOD)
-		interest(4)
-	}
+menu(serialIX) {
+    choice(serialIX_unknown, "Unknown")
+    choice(serialIX_No, "No")
+    choice(serialIX_Yes, "Yes")
 }
-recordtype(bi) {
-	field(NAME,DBF_STRING) {
-		prompt("Record Name")
-		special(SPC_NOMOD)
-		size(61)
-	}
-	field(DESC,DBF_STRING) {
-		prompt("Descriptor")
-		promptgroup(GUI_COMMON)
-		size(41)
-	}
-	field(ASG,DBF_STRING) {
-		prompt("Access Security Group")
-		promptgroup(GUI_COMMON)
-		special(SPC_AS)
-		size(29)
-	}
-	field(SCAN,DBF_MENU) {
-		prompt("Scan Mechanism")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuScan)
-		interest(1)
-	}
-	field(PINI,DBF_MENU) {
-		prompt("Process at iocInit")
-		promptgroup(GUI_SCAN)
-		menu(menuPini)
-		interest(1)
-	}
-	field(PHAS,DBF_SHORT) {
-		prompt("Scan Phase")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(EVNT,DBF_SHORT) {
-		prompt("Event Number")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(TSE,DBF_SHORT) {
-		prompt("Time Stamp Event")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(TSEL,DBF_INLINK) {
-		prompt("Time Stamp Link")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(DTYP,DBF_DEVICE) {
-		prompt("Device Type")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(DISV,DBF_SHORT) {
-		prompt("Disable Value")
-		initial("1")
-		promptgroup(GUI_SCAN)
-	}
-	field(DISA,DBF_SHORT) {
-		prompt("Disable")
-	}
-	field(SDIS,DBF_INLINK) {
-		prompt("Scanning Disable")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(MLOK,DBF_NOACCESS) {
-		prompt("Monitor lock")
-		special(SPC_NOMOD)
-		extra("epicsMutexId	mlok")
-		interest(4)
-	}
-	field(MLIS,DBF_NOACCESS) {
-		prompt("Monitor List")
-		special(SPC_NOMOD)
-		extra("ELLLIST		mlis")
-		interest(4)
-	}
-	field(DISP,DBF_UCHAR) {
-		prompt("Disable putField")
-	}
-	field(PROC,DBF_UCHAR) {
-		prompt("Force Processing")
-		pp(TRUE)
-		interest(3)
-	}
-	field(STAT,DBF_MENU) {
-		prompt("Alarm Status")
-		initial("UDF")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-	}
-	field(SEVR,DBF_MENU) {
-		prompt("Alarm Severity")
-		initial("INVALID")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-	}
-	field(NSTA,DBF_MENU) {
-		prompt("New Alarm Status")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-		interest(2)
-	}
-	field(NSEV,DBF_MENU) {
-		prompt("New Alarm Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKS,DBF_MENU) {
-		prompt("Alarm Ack Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKT,DBF_MENU) {
-		prompt("Alarm Ack Transient")
-		initial("YES")
-		promptgroup(GUI_ALARMS)
-		special(SPC_NOMOD)
-		menu(menuYesNo)
-		interest(2)
-	}
-	field(DISS,DBF_MENU) {
-		prompt("Disable Alarm Sevrty")
-		promptgroup(GUI_SCAN)
-		menu(menuAlarmSevr)
-		interest(1)
-	}
-	field(LCNT,DBF_UCHAR) {
-		prompt("Lock Count")
-		special(SPC_NOMOD)
-		interest(2)
-	}
-	field(PACT,DBF_UCHAR) {
-		prompt("Record active")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(PUTF,DBF_UCHAR) {
-		prompt("dbPutField process")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(RPRO,DBF_UCHAR) {
-		prompt("Reprocess ")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(ASP,DBF_NOACCESS) {
-		prompt("Access Security Pvt")
-		special(SPC_NOMOD)
-		extra("struct asgMember *asp")
-		interest(4)
-	}
-	field(PPN,DBF_NOACCESS) {
-		prompt("addr of PUTNOTIFY")
-		special(SPC_NOMOD)
-		extra("struct putNotify *ppn")
-		interest(4)
-	}
-	field(PPNR,DBF_NOACCESS) {
-		prompt("pputNotifyRecord")
-		special(SPC_NOMOD)
-		extra("struct putNotifyRecord *ppnr")
-		interest(4)
-	}
-	field(SPVT,DBF_NOACCESS) {
-		prompt("Scan Private")
-		special(SPC_NOMOD)
-		extra("struct scan_element *spvt")
-		interest(4)
-	}
-	field(RSET,DBF_NOACCESS) {
-		prompt("Address of RSET")
-		special(SPC_NOMOD)
-		extra("struct rset	*rset")
-		interest(4)
-	}
-	field(DSET,DBF_NOACCESS) {
-		prompt("DSET address")
-		special(SPC_NOMOD)
-		extra("struct dset	*dset")
-		interest(4)
-	}
-	field(DPVT,DBF_NOACCESS) {
-		prompt("Device Private")
-		special(SPC_NOMOD)
-		extra("void		*dpvt")
-		interest(4)
-	}
-	field(RDES,DBF_NOACCESS) {
-		prompt("Address of dbRecordType")
-		special(SPC_NOMOD)
-		extra("struct dbRecordType *rdes")
-		interest(4)
-	}
-	field(LSET,DBF_NOACCESS) {
-		prompt("Lock Set")
-		special(SPC_NOMOD)
-		extra("struct lockRecord *lset")
-		interest(4)
-	}
-	field(PRIO,DBF_MENU) {
-		prompt("Scheduling Priority")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuPriority)
-		interest(1)
-	}
-	field(TPRO,DBF_UCHAR) {
-		prompt("Trace Processing")
-	}
-	field(BKPT,DBF_NOACCESS) {
-		prompt("Break Point")
-		special(SPC_NOMOD)
-		extra("char bkpt")
-		interest(1)
-	}
-	field(UDF,DBF_UCHAR) {
-		prompt("Undefined")
-		initial("1")
-		promptgroup(GUI_COMMON)
-		pp(TRUE)
-		interest(1)
-	}
-	field(TIME,DBF_NOACCESS) {
-		prompt("Time")
-		special(SPC_NOMOD)
-		extra("epicsTimeStamp	time")
-		interest(2)
-	}
-	field(FLNK,DBF_FWDLINK) {
-		prompt("Forward Process Link")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(INP,DBF_INLINK) {
-		prompt("Input Specification")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(VAL,DBF_ENUM) {
-		prompt("Current Value")
-		promptgroup(GUI_INPUTS)
-		pp(TRUE)
-		asl(ASL0)
-	}
-	field(ZSV,DBF_MENU) {
-		prompt("Zero Error Severity")
-		promptgroup(GUI_ALARMS)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(OSV,DBF_MENU) {
-		prompt("One Error Severity")
-		promptgroup(GUI_BITS1)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(COSV,DBF_MENU) {
-		prompt("Change of State Svr")
-		promptgroup(GUI_BITS2)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(ZNAM,DBF_STRING) {
-		prompt("Zero Name")
-		promptgroup(GUI_CALC)
-		size(26)
-		pp(TRUE)
-		interest(1)
-	}
-	field(ONAM,DBF_STRING) {
-		prompt("One Name")
-		promptgroup(GUI_CLOCK)
-		size(26)
-		pp(TRUE)
-		interest(1)
-	}
-	field(RVAL,DBF_ULONG) {
-		prompt("Raw Value")
-		pp(TRUE)
-	}
-	field(ORAW,DBF_ULONG) {
-		prompt("prev Raw Value")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(MASK,DBF_ULONG) {
-		prompt("Hardware Mask")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(LALM,DBF_USHORT) {
-		prompt("Last Value Alarmed")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(MLST,DBF_USHORT) {
-		prompt("Last Value Monitored")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(SIOL,DBF_INLINK) {
-		prompt("Sim Input Specifctn")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(SVAL,DBF_ULONG) {
-		prompt("Simulation Value")
-	}
-	field(SIML,DBF_INLINK) {
-		prompt("Sim Mode Location")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(SIMM,DBF_MENU) {
-		prompt("Simulation Mode")
-		menu(menuSimm)
-		interest(1)
-	}
-	field(SIMS,DBF_MENU) {
-		prompt("Sim mode Alarm Svrty")
-		promptgroup(GUI_INPUTS)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
+menu(motorTORQ) {
+    choice(motorTORQ_Disable, "Disable")
+    choice(motorTORQ_Enable, "Enable")
 }
-recordtype(bo) {
-	field(NAME,DBF_STRING) {
-		prompt("Record Name")
-		special(SPC_NOMOD)
-		size(61)
-	}
-	field(DESC,DBF_STRING) {
-		prompt("Descriptor")
-		promptgroup(GUI_COMMON)
-		size(41)
-	}
-	field(ASG,DBF_STRING) {
-		prompt("Access Security Group")
-		promptgroup(GUI_COMMON)
-		special(SPC_AS)
-		size(29)
-	}
-	field(SCAN,DBF_MENU) {
-		prompt("Scan Mechanism")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuScan)
-		interest(1)
-	}
-	field(PINI,DBF_MENU) {
-		prompt("Process at iocInit")
-		promptgroup(GUI_SCAN)
-		menu(menuPini)
-		interest(1)
-	}
-	field(PHAS,DBF_SHORT) {
-		prompt("Scan Phase")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(EVNT,DBF_SHORT) {
-		prompt("Event Number")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(TSE,DBF_SHORT) {
-		prompt("Time Stamp Event")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(TSEL,DBF_INLINK) {
-		prompt("Time Stamp Link")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(DTYP,DBF_DEVICE) {
-		prompt("Device Type")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(DISV,DBF_SHORT) {
-		prompt("Disable Value")
-		initial("1")
-		promptgroup(GUI_SCAN)
-	}
-	field(DISA,DBF_SHORT) {
-		prompt("Disable")
-	}
-	field(SDIS,DBF_INLINK) {
-		prompt("Scanning Disable")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(MLOK,DBF_NOACCESS) {
-		prompt("Monitor lock")
-		special(SPC_NOMOD)
-		extra("epicsMutexId	mlok")
-		interest(4)
-	}
-	field(MLIS,DBF_NOACCESS) {
-		prompt("Monitor List")
-		special(SPC_NOMOD)
-		extra("ELLLIST		mlis")
-		interest(4)
-	}
-	field(DISP,DBF_UCHAR) {
-		prompt("Disable putField")
-	}
-	field(PROC,DBF_UCHAR) {
-		prompt("Force Processing")
-		pp(TRUE)
-		interest(3)
-	}
-	field(STAT,DBF_MENU) {
-		prompt("Alarm Status")
-		initial("UDF")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-	}
-	field(SEVR,DBF_MENU) {
-		prompt("Alarm Severity")
-		initial("INVALID")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-	}
-	field(NSTA,DBF_MENU) {
-		prompt("New Alarm Status")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-		interest(2)
-	}
-	field(NSEV,DBF_MENU) {
-		prompt("New Alarm Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKS,DBF_MENU) {
-		prompt("Alarm Ack Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKT,DBF_MENU) {
-		prompt("Alarm Ack Transient")
-		initial("YES")
-		promptgroup(GUI_ALARMS)
-		special(SPC_NOMOD)
-		menu(menuYesNo)
-		interest(2)
-	}
-	field(DISS,DBF_MENU) {
-		prompt("Disable Alarm Sevrty")
-		promptgroup(GUI_SCAN)
-		menu(menuAlarmSevr)
-		interest(1)
-	}
-	field(LCNT,DBF_UCHAR) {
-		prompt("Lock Count")
-		special(SPC_NOMOD)
-		interest(2)
-	}
-	field(PACT,DBF_UCHAR) {
-		prompt("Record active")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(PUTF,DBF_UCHAR) {
-		prompt("dbPutField process")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(RPRO,DBF_UCHAR) {
-		prompt("Reprocess ")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(ASP,DBF_NOACCESS) {
-		prompt("Access Security Pvt")
-		special(SPC_NOMOD)
-		extra("struct asgMember *asp")
-		interest(4)
-	}
-	field(PPN,DBF_NOACCESS) {
-		prompt("addr of PUTNOTIFY")
-		special(SPC_NOMOD)
-		extra("struct putNotify *ppn")
-		interest(4)
-	}
-	field(PPNR,DBF_NOACCESS) {
-		prompt("pputNotifyRecord")
-		special(SPC_NOMOD)
-		extra("struct putNotifyRecord *ppnr")
-		interest(4)
-	}
-	field(SPVT,DBF_NOACCESS) {
-		prompt("Scan Private")
-		special(SPC_NOMOD)
-		extra("struct scan_element *spvt")
-		interest(4)
-	}
-	field(RSET,DBF_NOACCESS) {
-		prompt("Address of RSET")
-		special(SPC_NOMOD)
-		extra("struct rset	*rset")
-		interest(4)
-	}
-	field(DSET,DBF_NOACCESS) {
-		prompt("DSET address")
-		special(SPC_NOMOD)
-		extra("struct dset	*dset")
-		interest(4)
-	}
-	field(DPVT,DBF_NOACCESS) {
-		prompt("Device Private")
-		special(SPC_NOMOD)
-		extra("void		*dpvt")
-		interest(4)
-	}
-	field(RDES,DBF_NOACCESS) {
-		prompt("Address of dbRecordType")
-		special(SPC_NOMOD)
-		extra("struct dbRecordType *rdes")
-		interest(4)
-	}
-	field(LSET,DBF_NOACCESS) {
-		prompt("Lock Set")
-		special(SPC_NOMOD)
-		extra("struct lockRecord *lset")
-		interest(4)
-	}
-	field(PRIO,DBF_MENU) {
-		prompt("Scheduling Priority")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuPriority)
-		interest(1)
-	}
-	field(TPRO,DBF_UCHAR) {
-		prompt("Trace Processing")
-	}
-	field(BKPT,DBF_NOACCESS) {
-		prompt("Break Point")
-		special(SPC_NOMOD)
-		extra("char bkpt")
-		interest(1)
-	}
-	field(UDF,DBF_UCHAR) {
-		prompt("Undefined")
-		initial("1")
-		promptgroup(GUI_COMMON)
-		pp(TRUE)
-		interest(1)
-	}
-	field(TIME,DBF_NOACCESS) {
-		prompt("Time")
-		special(SPC_NOMOD)
-		extra("epicsTimeStamp	time")
-		interest(2)
-	}
-	field(FLNK,DBF_FWDLINK) {
-		prompt("Forward Process Link")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(VAL,DBF_ENUM) {
-		prompt("Current Value")
-		promptgroup(GUI_OUTPUT)
-		pp(TRUE)
-		asl(ASL0)
-	}
-	field(OMSL,DBF_MENU) {
-		prompt("Output Mode Select")
-		promptgroup(GUI_OUTPUT)
-		menu(menuOmsl)
-		interest(1)
-	}
-	field(DOL,DBF_INLINK) {
-		prompt("Desired Output Loc")
-		promptgroup(GUI_OUTPUT)
-		interest(1)
-	}
-	field(OUT,DBF_OUTLINK) {
-		prompt("Output Specification")
-		promptgroup(GUI_OUTPUT)
-		interest(1)
-	}
-	field(HIGH,DBF_DOUBLE) {
-		prompt("Seconds to Hold High")
-		promptgroup(GUI_OUTPUT)
-		interest(1)
-	}
-	field(ZNAM,DBF_STRING) {
-		prompt("Zero Name")
-		promptgroup(GUI_DISPLAY)
-		size(26)
-		pp(TRUE)
-		interest(1)
-	}
-	field(ONAM,DBF_STRING) {
-		prompt("One Name")
-		promptgroup(GUI_DISPLAY)
-		size(26)
-		pp(TRUE)
-		interest(1)
-	}
-	field(RVAL,DBF_ULONG) {
-		prompt("Raw Value")
-		pp(TRUE)
-	}
-	field(ORAW,DBF_ULONG) {
-		prompt("prev Raw Value")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(MASK,DBF_ULONG) {
-		prompt("Hardware Mask")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(RPVT,DBF_NOACCESS) {
-		prompt("Record Private")
-		special(SPC_NOMOD)
-		extra("void *  rpvt")
-		interest(4)
-	}
-	field(WDPT,DBF_NOACCESS) {
-		prompt("Watch Dog Timer ID")
-		special(SPC_NOMOD)
-		extra("void *	wdpt")
-		interest(4)
-	}
-	field(ZSV,DBF_MENU) {
-		prompt("Zero Error Severity")
-		promptgroup(GUI_ALARMS)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(OSV,DBF_MENU) {
-		prompt("One Error Severity")
-		promptgroup(GUI_ALARMS)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(COSV,DBF_MENU) {
-		prompt("Change of State Sevr")
-		promptgroup(GUI_ALARMS)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(RBV,DBF_ULONG) {
-		prompt("Readback Value")
-		special(SPC_NOMOD)
-	}
-	field(ORBV,DBF_ULONG) {
-		prompt("Prev Readback Value")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(MLST,DBF_USHORT) {
-		prompt("Last Value Monitored")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(LALM,DBF_USHORT) {
-		prompt("Last Value Alarmed")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(SIOL,DBF_OUTLINK) {
-		prompt("Sim Output Specifctn")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(SIML,DBF_INLINK) {
-		prompt("Sim Mode Location")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(SIMM,DBF_MENU) {
-		prompt("Simulation Mode")
-		menu(menuYesNo)
-		interest(1)
-	}
-	field(SIMS,DBF_MENU) {
-		prompt("Sim mode Alarm Svrty")
-		promptgroup(GUI_INPUTS)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(IVOA,DBF_MENU) {
-		prompt("INVALID outpt action")
-		promptgroup(GUI_OUTPUT)
-		menu(menuIvoa)
-		interest(2)
-	}
-	field(IVOV,DBF_USHORT) {
-		prompt("INVALID output value")
-		promptgroup(GUI_OUTPUT)
-		interest(2)
-	}
+menu(menuYesNo) {
+    choice(menuYesNoNO, "NO")
+    choice(menuYesNoYES, "YES")
 }
-recordtype(calc) {
-	field(NAME,DBF_STRING) {
-		prompt("Record Name")
-		special(SPC_NOMOD)
-		size(61)
-	}
-	field(DESC,DBF_STRING) {
-		prompt("Descriptor")
-		promptgroup(GUI_COMMON)
-		size(41)
-	}
-	field(ASG,DBF_STRING) {
-		prompt("Access Security Group")
-		promptgroup(GUI_COMMON)
-		special(SPC_AS)
-		size(29)
-	}
-	field(SCAN,DBF_MENU) {
-		prompt("Scan Mechanism")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuScan)
-		interest(1)
-	}
-	field(PINI,DBF_MENU) {
-		prompt("Process at iocInit")
-		promptgroup(GUI_SCAN)
-		menu(menuPini)
-		interest(1)
-	}
-	field(PHAS,DBF_SHORT) {
-		prompt("Scan Phase")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(EVNT,DBF_SHORT) {
-		prompt("Event Number")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(TSE,DBF_SHORT) {
-		prompt("Time Stamp Event")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(TSEL,DBF_INLINK) {
-		prompt("Time Stamp Link")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(DTYP,DBF_DEVICE) {
-		prompt("Device Type")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(DISV,DBF_SHORT) {
-		prompt("Disable Value")
-		initial("1")
-		promptgroup(GUI_SCAN)
-	}
-	field(DISA,DBF_SHORT) {
-		prompt("Disable")
-	}
-	field(SDIS,DBF_INLINK) {
-		prompt("Scanning Disable")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(MLOK,DBF_NOACCESS) {
-		prompt("Monitor lock")
-		special(SPC_NOMOD)
-		extra("epicsMutexId	mlok")
-		interest(4)
-	}
-	field(MLIS,DBF_NOACCESS) {
-		prompt("Monitor List")
-		special(SPC_NOMOD)
-		extra("ELLLIST		mlis")
-		interest(4)
-	}
-	field(DISP,DBF_UCHAR) {
-		prompt("Disable putField")
-	}
-	field(PROC,DBF_UCHAR) {
-		prompt("Force Processing")
-		pp(TRUE)
-		interest(3)
-	}
-	field(STAT,DBF_MENU) {
-		prompt("Alarm Status")
-		initial("UDF")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-	}
-	field(SEVR,DBF_MENU) {
-		prompt("Alarm Severity")
-		initial("INVALID")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-	}
-	field(NSTA,DBF_MENU) {
-		prompt("New Alarm Status")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-		interest(2)
-	}
-	field(NSEV,DBF_MENU) {
-		prompt("New Alarm Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKS,DBF_MENU) {
-		prompt("Alarm Ack Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKT,DBF_MENU) {
-		prompt("Alarm Ack Transient")
-		initial("YES")
-		promptgroup(GUI_ALARMS)
-		special(SPC_NOMOD)
-		menu(menuYesNo)
-		interest(2)
-	}
-	field(DISS,DBF_MENU) {
-		prompt("Disable Alarm Sevrty")
-		promptgroup(GUI_SCAN)
-		menu(menuAlarmSevr)
-		interest(1)
-	}
-	field(LCNT,DBF_UCHAR) {
-		prompt("Lock Count")
-		special(SPC_NOMOD)
-		interest(2)
-	}
-	field(PACT,DBF_UCHAR) {
-		prompt("Record active")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(PUTF,DBF_UCHAR) {
-		prompt("dbPutField process")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(RPRO,DBF_UCHAR) {
-		prompt("Reprocess ")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(ASP,DBF_NOACCESS) {
-		prompt("Access Security Pvt")
-		special(SPC_NOMOD)
-		extra("struct asgMember *asp")
-		interest(4)
-	}
-	field(PPN,DBF_NOACCESS) {
-		prompt("addr of PUTNOTIFY")
-		special(SPC_NOMOD)
-		extra("struct putNotify *ppn")
-		interest(4)
-	}
-	field(PPNR,DBF_NOACCESS) {
-		prompt("pputNotifyRecord")
-		special(SPC_NOMOD)
-		extra("struct putNotifyRecord *ppnr")
-		interest(4)
-	}
-	field(SPVT,DBF_NOACCESS) {
-		prompt("Scan Private")
-		special(SPC_NOMOD)
-		extra("struct scan_element *spvt")
-		interest(4)
-	}
-	field(RSET,DBF_NOACCESS) {
-		prompt("Address of RSET")
-		special(SPC_NOMOD)
-		extra("struct rset	*rset")
-		interest(4)
-	}
-	field(DSET,DBF_NOACCESS) {
-		prompt("DSET address")
-		special(SPC_NOMOD)
-		extra("struct dset	*dset")
-		interest(4)
-	}
-	field(DPVT,DBF_NOACCESS) {
-		prompt("Device Private")
-		special(SPC_NOMOD)
-		extra("void		*dpvt")
-		interest(4)
-	}
-	field(RDES,DBF_NOACCESS) {
-		prompt("Address of dbRecordType")
-		special(SPC_NOMOD)
-		extra("struct dbRecordType *rdes")
-		interest(4)
-	}
-	field(LSET,DBF_NOACCESS) {
-		prompt("Lock Set")
-		special(SPC_NOMOD)
-		extra("struct lockRecord *lset")
-		interest(4)
-	}
-	field(PRIO,DBF_MENU) {
-		prompt("Scheduling Priority")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuPriority)
-		interest(1)
-	}
-	field(TPRO,DBF_UCHAR) {
-		prompt("Trace Processing")
-	}
-	field(BKPT,DBF_NOACCESS) {
-		prompt("Break Point")
-		special(SPC_NOMOD)
-		extra("char bkpt")
-		interest(1)
-	}
-	field(UDF,DBF_UCHAR) {
-		prompt("Undefined")
-		initial("1")
-		promptgroup(GUI_COMMON)
-		pp(TRUE)
-		interest(1)
-	}
-	field(TIME,DBF_NOACCESS) {
-		prompt("Time")
-		special(SPC_NOMOD)
-		extra("epicsTimeStamp	time")
-		interest(2)
-	}
-	field(FLNK,DBF_FWDLINK) {
-		prompt("Forward Process Link")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(VAL,DBF_DOUBLE) {
-		prompt("Result")
-		asl(ASL0)
-	}
-	field(CALC,DBF_STRING) {
-		prompt("Calculation")
-		initial("0")
-		promptgroup(GUI_CALC)
-		special(103)
-		size(80)
-		pp(TRUE)
-	}
-	field(INPA,DBF_INLINK) {
-		prompt("Input A")
-		promptgroup(GUI_CALC)
-		interest(1)
-	}
-	field(INPB,DBF_INLINK) {
-		prompt("Input B")
-		promptgroup(GUI_CALC)
-		interest(1)
-	}
-	field(INPC,DBF_INLINK) {
-		prompt("Input C")
-		promptgroup(GUI_CALC)
-		interest(1)
-	}
-	field(INPD,DBF_INLINK) {
-		prompt("Input D")
-		promptgroup(GUI_CALC)
-		interest(1)
-	}
-	field(INPE,DBF_INLINK) {
-		prompt("Input E")
-		promptgroup(GUI_CALC)
-		interest(1)
-	}
-	field(INPF,DBF_INLINK) {
-		prompt("Input F")
-		promptgroup(GUI_CALC)
-		interest(1)
-	}
-	field(INPG,DBF_INLINK) {
-		prompt("Input G")
-		promptgroup(GUI_CALC)
-		interest(1)
-	}
-	field(INPH,DBF_INLINK) {
-		prompt("Input H")
-		promptgroup(GUI_CALC)
-		interest(1)
-	}
-	field(INPI,DBF_INLINK) {
-		prompt("Input I")
-		promptgroup(GUI_CALC)
-		interest(1)
-	}
-	field(INPJ,DBF_INLINK) {
-		prompt("Input J")
-		promptgroup(GUI_CALC)
-		interest(1)
-	}
-	field(INPK,DBF_INLINK) {
-		prompt("Input K")
-		promptgroup(GUI_CALC)
-		interest(1)
-	}
-	field(INPL,DBF_INLINK) {
-		prompt("Input L")
-		promptgroup(GUI_CALC)
-		interest(1)
-	}
-	field(EGU,DBF_STRING) {
-		prompt("Units Name")
-		promptgroup(GUI_DISPLAY)
-		size(16)
-		interest(1)
-	}
-	field(PREC,DBF_SHORT) {
-		prompt("Display Precision")
-		promptgroup(GUI_DISPLAY)
-		interest(1)
-	}
-	field(HOPR,DBF_DOUBLE) {
-		prompt("High Operating Rng")
-		promptgroup(GUI_DISPLAY)
-		interest(1)
-	}
-	field(LOPR,DBF_DOUBLE) {
-		prompt("Low Operating Range")
-		promptgroup(GUI_DISPLAY)
-		interest(1)
-	}
-	field(HIHI,DBF_DOUBLE) {
-		prompt("Hihi Alarm Limit")
-		promptgroup(GUI_ALARMS)
-		pp(TRUE)
-		interest(1)
-	}
-	field(LOLO,DBF_DOUBLE) {
-		prompt("Lolo Alarm Limit")
-		promptgroup(GUI_ALARMS)
-		pp(TRUE)
-		interest(1)
-	}
-	field(HIGH,DBF_DOUBLE) {
-		prompt("High Alarm Limit")
-		promptgroup(GUI_ALARMS)
-		pp(TRUE)
-		interest(1)
-	}
-	field(LOW,DBF_DOUBLE) {
-		prompt("Low Alarm Limit")
-		promptgroup(GUI_ALARMS)
-		pp(TRUE)
-		interest(1)
-	}
-	field(HHSV,DBF_MENU) {
-		prompt("Hihi Severity")
-		promptgroup(GUI_ALARMS)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(LLSV,DBF_MENU) {
-		prompt("Lolo Severity")
-		promptgroup(GUI_ALARMS)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(HSV,DBF_MENU) {
-		prompt("High Severity")
-		promptgroup(GUI_ALARMS)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(LSV,DBF_MENU) {
-		prompt("Low Severity")
-		promptgroup(GUI_ALARMS)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(HYST,DBF_DOUBLE) {
-		prompt("Alarm Deadband")
-		promptgroup(GUI_ALARMS)
-		interest(1)
-	}
-	field(ADEL,DBF_DOUBLE) {
-		prompt("Archive Deadband")
-		promptgroup(GUI_DISPLAY)
-		interest(1)
-	}
-	field(MDEL,DBF_DOUBLE) {
-		prompt("Monitor Deadband")
-		promptgroup(GUI_DISPLAY)
-		interest(1)
-	}
-	field(A,DBF_DOUBLE) {
-		prompt("Value of Input A")
-		pp(TRUE)
-	}
-	field(B,DBF_DOUBLE) {
-		prompt("Value of Input B")
-		pp(TRUE)
-	}
-	field(C,DBF_DOUBLE) {
-		prompt("Value of Input C")
-		pp(TRUE)
-	}
-	field(D,DBF_DOUBLE) {
-		prompt("Value of Input D")
-		pp(TRUE)
-	}
-	field(E,DBF_DOUBLE) {
-		prompt("Value of Input E")
-		pp(TRUE)
-	}
-	field(F,DBF_DOUBLE) {
-		prompt("Value of Input F")
-		pp(TRUE)
-	}
-	field(G,DBF_DOUBLE) {
-		prompt("Value of Input G")
-		pp(TRUE)
-	}
-	field(H,DBF_DOUBLE) {
-		prompt("Value of Input H")
-		pp(TRUE)
-	}
-	field(I,DBF_DOUBLE) {
-		prompt("Value of Input I")
-		pp(TRUE)
-	}
-	field(J,DBF_DOUBLE) {
-		prompt("Value of Input J")
-		pp(TRUE)
-	}
-	field(K,DBF_DOUBLE) {
-		prompt("Value of Input K")
-		pp(TRUE)
-	}
-	field(L,DBF_DOUBLE) {
-		prompt("Value of Input L")
-		pp(TRUE)
-	}
-	field(LA,DBF_DOUBLE) {
-		prompt("Prev Value of A")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(LB,DBF_DOUBLE) {
-		prompt("Prev Value of B")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(LC,DBF_DOUBLE) {
-		prompt("Prev Value of C")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(LD,DBF_DOUBLE) {
-		prompt("Prev Value of D")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(LE,DBF_DOUBLE) {
-		prompt("Prev Value of E")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(LF,DBF_DOUBLE) {
-		prompt("Prev Value of F")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(LG,DBF_DOUBLE) {
-		prompt("Prev Value of G")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(LH,DBF_DOUBLE) {
-		prompt("Prev Value of H")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(LI,DBF_DOUBLE) {
-		prompt("Prev Value of I")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(LJ,DBF_DOUBLE) {
-		prompt("Prev Value of J")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(LK,DBF_DOUBLE) {
-		prompt("Prev Value of K")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(LL,DBF_DOUBLE) {
-		prompt("Prev Value of L")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(LALM,DBF_DOUBLE) {
-		prompt("Last Value Alarmed")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(ALST,DBF_DOUBLE) {
-		prompt("Last Value Archived")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(MLST,DBF_DOUBLE) {
-		prompt("Last Val Monitored")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(RPCL,DBF_NOACCESS) {
-		prompt("Reverse Polish Calc")
-		special(SPC_NOMOD)
-		extra("char	rpcl[INFIX_TO_POSTFIX_SIZE(80)]")
-		interest(4)
-	}
+menu(serialDBIT) {
+    choice(serialDBIT_unknown, "Unknown")
+    choice(serialDBIT_5, "5")
+    choice(serialDBIT_6, "6")
+    choice(serialDBIT_7, "7")
+    choice(serialDBIT_8, "8")
+}
+menu(selSELM) {
+    choice(selSELM_Specified, "Specified")
+    choice(selSELM_High_Signal, "High Signal")
+    choice(selSELM_Low_Signal, "Low Signal")
+    choice(selSELM_Median_Signal, "Median Signal")
 }
 recordtype(calcout) {
-	field(NAME,DBF_STRING) {
-		prompt("Record Name")
-		special(SPC_NOMOD)
-		size(61)
-	}
-	field(DESC,DBF_STRING) {
-		prompt("Descriptor")
-		promptgroup(GUI_COMMON)
-		size(41)
-	}
-	field(ASG,DBF_STRING) {
-		prompt("Access Security Group")
-		promptgroup(GUI_COMMON)
-		special(SPC_AS)
-		size(29)
-	}
-	field(SCAN,DBF_MENU) {
-		prompt("Scan Mechanism")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuScan)
-		interest(1)
-	}
-	field(PINI,DBF_MENU) {
-		prompt("Process at iocInit")
-		promptgroup(GUI_SCAN)
-		menu(menuPini)
-		interest(1)
-	}
-	field(PHAS,DBF_SHORT) {
-		prompt("Scan Phase")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(EVNT,DBF_SHORT) {
-		prompt("Event Number")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(TSE,DBF_SHORT) {
-		prompt("Time Stamp Event")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(TSEL,DBF_INLINK) {
-		prompt("Time Stamp Link")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(DTYP,DBF_DEVICE) {
-		prompt("Device Type")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(DISV,DBF_SHORT) {
-		prompt("Disable Value")
-		initial("1")
-		promptgroup(GUI_SCAN)
-	}
-	field(DISA,DBF_SHORT) {
-		prompt("Disable")
-	}
-	field(SDIS,DBF_INLINK) {
-		prompt("Scanning Disable")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(MLOK,DBF_NOACCESS) {
-		prompt("Monitor lock")
-		special(SPC_NOMOD)
-		extra("epicsMutexId	mlok")
-		interest(4)
-	}
-	field(MLIS,DBF_NOACCESS) {
-		prompt("Monitor List")
-		special(SPC_NOMOD)
-		extra("ELLLIST		mlis")
-		interest(4)
-	}
-	field(DISP,DBF_UCHAR) {
-		prompt("Disable putField")
-	}
-	field(PROC,DBF_UCHAR) {
-		prompt("Force Processing")
-		pp(TRUE)
-		interest(3)
-	}
-	field(STAT,DBF_MENU) {
-		prompt("Alarm Status")
-		initial("UDF")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-	}
-	field(SEVR,DBF_MENU) {
-		prompt("Alarm Severity")
-		initial("INVALID")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-	}
-	field(NSTA,DBF_MENU) {
-		prompt("New Alarm Status")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-		interest(2)
-	}
-	field(NSEV,DBF_MENU) {
-		prompt("New Alarm Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKS,DBF_MENU) {
-		prompt("Alarm Ack Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKT,DBF_MENU) {
-		prompt("Alarm Ack Transient")
-		initial("YES")
-		promptgroup(GUI_ALARMS)
-		special(SPC_NOMOD)
-		menu(menuYesNo)
-		interest(2)
-	}
-	field(DISS,DBF_MENU) {
-		prompt("Disable Alarm Sevrty")
-		promptgroup(GUI_SCAN)
-		menu(menuAlarmSevr)
-		interest(1)
-	}
-	field(LCNT,DBF_UCHAR) {
-		prompt("Lock Count")
-		special(SPC_NOMOD)
-		interest(2)
-	}
-	field(PACT,DBF_UCHAR) {
-		prompt("Record active")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(PUTF,DBF_UCHAR) {
-		prompt("dbPutField process")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(RPRO,DBF_UCHAR) {
-		prompt("Reprocess ")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(ASP,DBF_NOACCESS) {
-		prompt("Access Security Pvt")
-		special(SPC_NOMOD)
-		extra("struct asgMember *asp")
-		interest(4)
-	}
-	field(PPN,DBF_NOACCESS) {
-		prompt("addr of PUTNOTIFY")
-		special(SPC_NOMOD)
-		extra("struct putNotify *ppn")
-		interest(4)
-	}
-	field(PPNR,DBF_NOACCESS) {
-		prompt("pputNotifyRecord")
-		special(SPC_NOMOD)
-		extra("struct putNotifyRecord *ppnr")
-		interest(4)
-	}
-	field(SPVT,DBF_NOACCESS) {
-		prompt("Scan Private")
-		special(SPC_NOMOD)
-		extra("struct scan_element *spvt")
-		interest(4)
-	}
-	field(RSET,DBF_NOACCESS) {
-		prompt("Address of RSET")
-		special(SPC_NOMOD)
-		extra("struct rset	*rset")
-		interest(4)
-	}
-	field(DSET,DBF_NOACCESS) {
-		prompt("DSET address")
-		special(SPC_NOMOD)
-		extra("struct dset	*dset")
-		interest(4)
-	}
-	field(DPVT,DBF_NOACCESS) {
-		prompt("Device Private")
-		special(SPC_NOMOD)
-		extra("void		*dpvt")
-		interest(4)
-	}
-	field(RDES,DBF_NOACCESS) {
-		prompt("Address of dbRecordType")
-		special(SPC_NOMOD)
-		extra("struct dbRecordType *rdes")
-		interest(4)
-	}
-	field(LSET,DBF_NOACCESS) {
-		prompt("Lock Set")
-		special(SPC_NOMOD)
-		extra("struct lockRecord *lset")
-		interest(4)
-	}
-	field(PRIO,DBF_MENU) {
-		prompt("Scheduling Priority")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuPriority)
-		interest(1)
-	}
-	field(TPRO,DBF_UCHAR) {
-		prompt("Trace Processing")
-	}
-	field(BKPT,DBF_NOACCESS) {
-		prompt("Break Point")
-		special(SPC_NOMOD)
-		extra("char bkpt")
-		interest(1)
-	}
-	field(UDF,DBF_UCHAR) {
-		prompt("Undefined")
-		initial("1")
-		promptgroup(GUI_COMMON)
-		pp(TRUE)
-		interest(1)
-	}
-	field(TIME,DBF_NOACCESS) {
-		prompt("Time")
-		special(SPC_NOMOD)
-		extra("epicsTimeStamp	time")
-		interest(2)
-	}
-	field(FLNK,DBF_FWDLINK) {
-		prompt("Forward Process Link")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(RPVT,DBF_NOACCESS) {
-		prompt("Record Private")
-		special(SPC_NOMOD)
-		extra("struct rpvtStruct *rpvt")
-		interest(4)
-	}
-	field(VAL,DBF_DOUBLE) {
-		prompt("Result")
-		promptgroup(GUI_OUTPUT)
-		asl(ASL0)
-	}
-	field(PVAL,DBF_DOUBLE) {
-		prompt("Previous Value")
-	}
-	field(CALC,DBF_STRING) {
-		prompt("Calculation")
-		initial("0")
-		promptgroup(GUI_CALC)
-		special(103)
-		size(80)
-		pp(TRUE)
-	}
-	field(CLCV,DBF_LONG) {
-		prompt("CALC Valid")
-		interest(1)
-	}
-	field(INPA,DBF_INLINK) {
-		prompt("Input A")
-		promptgroup(GUI_CALC)
-		special(100)
-		interest(1)
-	}
-	field(INPB,DBF_INLINK) {
-		prompt("Input B")
-		promptgroup(GUI_CALC)
-		special(100)
-		interest(1)
-	}
-	field(INPC,DBF_INLINK) {
-		prompt("Input C")
-		promptgroup(GUI_CALC)
-		special(100)
-		interest(1)
-	}
-	field(INPD,DBF_INLINK) {
-		prompt("Input D")
-		promptgroup(GUI_CALC)
-		special(100)
-		interest(1)
-	}
-	field(INPE,DBF_INLINK) {
-		prompt("Input E")
-		promptgroup(GUI_CALC)
-		special(100)
-		interest(1)
-	}
-	field(INPF,DBF_INLINK) {
-		prompt("Input F")
-		promptgroup(GUI_CALC)
-		special(100)
-		interest(1)
-	}
-	field(INPG,DBF_INLINK) {
-		prompt("Input G")
-		promptgroup(GUI_CALC)
-		special(100)
-		interest(1)
-	}
-	field(INPH,DBF_INLINK) {
-		prompt("Input H")
-		promptgroup(GUI_CALC)
-		special(100)
-		interest(1)
-	}
-	field(INPI,DBF_INLINK) {
-		prompt("Input I")
-		promptgroup(GUI_CALC)
-		special(100)
-		interest(1)
-	}
-	field(INPJ,DBF_INLINK) {
-		prompt("Input J")
-		promptgroup(GUI_CALC)
-		special(100)
-		interest(1)
-	}
-	field(INPK,DBF_INLINK) {
-		prompt("Input K")
-		promptgroup(GUI_CALC)
-		special(100)
-		interest(1)
-	}
-	field(INPL,DBF_INLINK) {
-		prompt("Input L")
-		promptgroup(GUI_CALC)
-		special(100)
-		interest(1)
-	}
-	field(OUT,DBF_OUTLINK) {
-		prompt("Output Specification")
-		promptgroup(GUI_OUTPUT)
-		special(100)
-		interest(1)
-	}
-	field(INAV,DBF_MENU) {
-		prompt("INPA PV Status")
-		initial("1")
-		special(SPC_NOMOD)
-		menu(calcoutINAV)
-		interest(1)
-	}
-	field(INBV,DBF_MENU) {
-		prompt("INPB PV Status")
-		initial("1")
-		special(SPC_NOMOD)
-		menu(calcoutINAV)
-		interest(1)
-	}
-	field(INCV,DBF_MENU) {
-		prompt("INPC PV Status")
-		initial("1")
-		special(SPC_NOMOD)
-		menu(calcoutINAV)
-		interest(1)
-	}
-	field(INDV,DBF_MENU) {
-		prompt("INPD PV Status")
-		initial("1")
-		special(SPC_NOMOD)
-		menu(calcoutINAV)
-		interest(1)
-	}
-	field(INEV,DBF_MENU) {
-		prompt("INPE PV Status")
-		initial("1")
-		special(SPC_NOMOD)
-		menu(calcoutINAV)
-		interest(1)
-	}
-	field(INFV,DBF_MENU) {
-		prompt("INPF PV Status")
-		initial("1")
-		special(SPC_NOMOD)
-		menu(calcoutINAV)
-		interest(1)
-	}
-	field(INGV,DBF_MENU) {
-		prompt("INPG PV Status")
-		initial("1")
-		special(SPC_NOMOD)
-		menu(calcoutINAV)
-		interest(1)
-	}
-	field(INHV,DBF_MENU) {
-		prompt("INPH PV Status")
-		initial("1")
-		special(SPC_NOMOD)
-		menu(calcoutINAV)
-		interest(1)
-	}
-	field(INIV,DBF_MENU) {
-		prompt("INPI PV Status")
-		initial("1")
-		special(SPC_NOMOD)
-		menu(calcoutINAV)
-		interest(1)
-	}
-	field(INJV,DBF_MENU) {
-		prompt("INPJ PV Status")
-		initial("1")
-		special(SPC_NOMOD)
-		menu(calcoutINAV)
-		interest(1)
-	}
-	field(INKV,DBF_MENU) {
-		prompt("INPK PV Status")
-		initial("1")
-		special(SPC_NOMOD)
-		menu(calcoutINAV)
-		interest(1)
-	}
-	field(INLV,DBF_MENU) {
-		prompt("INPL PV Status")
-		initial("1")
-		special(SPC_NOMOD)
-		menu(calcoutINAV)
-		interest(1)
-	}
-	field(OUTV,DBF_MENU) {
-		prompt("OUT PV Status")
-		special(SPC_NOMOD)
-		menu(calcoutINAV)
-		interest(1)
-	}
-	field(OOPT,DBF_MENU) {
-		prompt("Output Execute Opt")
-		promptgroup(GUI_CALC)
-		menu(calcoutOOPT)
-		interest(1)
-	}
-	field(ODLY,DBF_DOUBLE) {
-		prompt("Output Execute Delay")
-		promptgroup(GUI_ALARMS)
-		interest(1)
-		asl(ASL0)
-	}
-	field(DLYA,DBF_USHORT) {
-		prompt("Output Delay Active")
-		special(SPC_NOMOD)
-		asl(ASL0)
-	}
-	field(DOPT,DBF_MENU) {
-		prompt("Output Data Opt")
-		promptgroup(GUI_CALC)
-		menu(calcoutDOPT)
-		interest(1)
-	}
-	field(OCAL,DBF_STRING) {
-		prompt("Output Calculation")
-		initial("0")
-		promptgroup(GUI_CALC)
-		special(103)
-		size(80)
-		pp(TRUE)
-	}
-	field(OCLV,DBF_LONG) {
-		prompt("OCAL Valid")
-		interest(1)
-	}
-	field(OEVT,DBF_USHORT) {
-		prompt("Event To Issue")
-		promptgroup(GUI_CLOCK)
-		asl(ASL0)
-	}
-	field(IVOA,DBF_MENU) {
-		prompt("INVALID output action")
-		promptgroup(GUI_OUTPUT)
-		menu(menuIvoa)
-		interest(2)
-	}
-	field(IVOV,DBF_DOUBLE) {
-		prompt("INVALID output value")
-		promptgroup(GUI_OUTPUT)
-		interest(2)
-	}
-	field(EGU,DBF_STRING) {
-		prompt("Units Name")
-		promptgroup(GUI_DISPLAY)
-		size(16)
-		interest(1)
-	}
-	field(PREC,DBF_SHORT) {
-		prompt("Display Precision")
-		promptgroup(GUI_DISPLAY)
-		interest(1)
-	}
-	field(HOPR,DBF_DOUBLE) {
-		prompt("High Operating Rng")
-		promptgroup(GUI_DISPLAY)
-		interest(1)
-	}
-	field(LOPR,DBF_DOUBLE) {
-		prompt("Low Operating Range")
-		promptgroup(GUI_DISPLAY)
-		interest(1)
-	}
-	field(HIHI,DBF_DOUBLE) {
-		prompt("Hihi Alarm Limit")
-		promptgroup(GUI_ALARMS)
-		pp(TRUE)
-		interest(1)
-	}
-	field(LOLO,DBF_DOUBLE) {
-		prompt("Lolo Alarm Limit")
-		promptgroup(GUI_ALARMS)
-		pp(TRUE)
-		interest(1)
-	}
-	field(HIGH,DBF_DOUBLE) {
-		prompt("High Alarm Limit")
-		promptgroup(GUI_ALARMS)
-		pp(TRUE)
-		interest(1)
-	}
-	field(LOW,DBF_DOUBLE) {
-		prompt("Low Alarm Limit")
-		promptgroup(GUI_ALARMS)
-		pp(TRUE)
-		interest(1)
-	}
-	field(HHSV,DBF_MENU) {
-		prompt("Hihi Severity")
-		promptgroup(GUI_ALARMS)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(LLSV,DBF_MENU) {
-		prompt("Lolo Severity")
-		promptgroup(GUI_ALARMS)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(HSV,DBF_MENU) {
-		prompt("High Severity")
-		promptgroup(GUI_ALARMS)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(LSV,DBF_MENU) {
-		prompt("Low Severity")
-		promptgroup(GUI_ALARMS)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(HYST,DBF_DOUBLE) {
-		prompt("Alarm Deadband")
-		promptgroup(GUI_ALARMS)
-		interest(1)
-	}
-	field(ADEL,DBF_DOUBLE) {
-		prompt("Archive Deadband")
-		promptgroup(GUI_DISPLAY)
-		interest(1)
-	}
-	field(MDEL,DBF_DOUBLE) {
-		prompt("Monitor Deadband")
-		promptgroup(GUI_DISPLAY)
-		interest(1)
-	}
-	field(A,DBF_DOUBLE) {
-		prompt("Value of Input A")
-		pp(TRUE)
-	}
-	field(B,DBF_DOUBLE) {
-		prompt("Value of Input B")
-		pp(TRUE)
-	}
-	field(C,DBF_DOUBLE) {
-		prompt("Value of Input C")
-		pp(TRUE)
-	}
-	field(D,DBF_DOUBLE) {
-		prompt("Value of Input D")
-		pp(TRUE)
-	}
-	field(E,DBF_DOUBLE) {
-		prompt("Value of Input E")
-		pp(TRUE)
-	}
-	field(F,DBF_DOUBLE) {
-		prompt("Value of Input F")
-		pp(TRUE)
-	}
-	field(G,DBF_DOUBLE) {
-		prompt("Value of Input G")
-		pp(TRUE)
-	}
-	field(H,DBF_DOUBLE) {
-		prompt("Value of Input H")
-		pp(TRUE)
-	}
-	field(I,DBF_DOUBLE) {
-		prompt("Value of Input I")
-		pp(TRUE)
-	}
-	field(J,DBF_DOUBLE) {
-		prompt("Value of Input J")
-		pp(TRUE)
-	}
-	field(K,DBF_DOUBLE) {
-		prompt("Value of Input K")
-		pp(TRUE)
-	}
-	field(L,DBF_DOUBLE) {
-		prompt("Value of Input L")
-		pp(TRUE)
-	}
-	field(OVAL,DBF_DOUBLE) {
-		prompt("Output Value")
-		asl(ASL0)
-	}
-	field(LA,DBF_DOUBLE) {
-		prompt("Prev Value of A")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(LB,DBF_DOUBLE) {
-		prompt("Prev Value of B")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(LC,DBF_DOUBLE) {
-		prompt("Prev Value of C")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(LD,DBF_DOUBLE) {
-		prompt("Prev Value of D")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(LE,DBF_DOUBLE) {
-		prompt("Prev Value of E")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(LF,DBF_DOUBLE) {
-		prompt("Prev Value of F")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(LG,DBF_DOUBLE) {
-		prompt("Prev Value of G")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(LH,DBF_DOUBLE) {
-		prompt("Prev Value of H")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(LI,DBF_DOUBLE) {
-		prompt("Prev Value of I")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(LJ,DBF_DOUBLE) {
-		prompt("Prev Value of J")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(LK,DBF_DOUBLE) {
-		prompt("Prev Value of K")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(LL,DBF_DOUBLE) {
-		prompt("Prev Value of L")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(POVL,DBF_DOUBLE) {
-		prompt("Prev Value of OVAL")
-		asl(ASL0)
-	}
-	field(LALM,DBF_DOUBLE) {
-		prompt("Last Value Alarmed")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(ALST,DBF_DOUBLE) {
-		prompt("Last Value Archived")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(MLST,DBF_DOUBLE) {
-		prompt("Last Val Monitored")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(RPCL,DBF_NOACCESS) {
-		prompt("Reverse Polish Calc")
-		special(SPC_NOMOD)
-		extra("char	rpcl[INFIX_TO_POSTFIX_SIZE(80)]")
-		interest(4)
-	}
-	field(ORPC,DBF_NOACCESS) {
-		prompt("Reverse Polish OCalc")
-		special(SPC_NOMOD)
-		extra("char	orpc[INFIX_TO_POSTFIX_SIZE(80)]")
-		interest(4)
-	}
+    %#include "epicsTypes.h"
+    %#include "link.h"
+    %#include "epicsMutex.h"
+    %#include "ellLib.h"
+    %#include "epicsTime.h"
+    %#include "dbScan.h"
+    %#include "postfix.h"
+    field(NAME, DBF_STRING) {
+        special(SPC_NOMOD)
+        size(61)
+        prompt("Record Name")
+    }
+    field(DESC, DBF_STRING) {
+        promptgroup("10 - Common")
+        size(41)
+        prompt("Descriptor")
+    }
+    field(ASG, DBF_STRING) {
+        promptgroup("10 - Common")
+        special(SPC_AS)
+        size(29)
+        prompt("Access Security Group")
+    }
+    field(SCAN, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuScan)
+        interest(1)
+        prompt("Scan Mechanism")
+    }
+    field(PINI, DBF_MENU) {
+        promptgroup("20 - Scan")
+        menu(menuPini)
+        interest(1)
+        prompt("Process at iocInit")
+    }
+    field(PHAS, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        prompt("Scan Phase")
+    }
+    field(EVNT, DBF_STRING) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        size(40)
+        prompt("Event Name")
+    }
+    field(TSE, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Event")
+    }
+    field(TSEL, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Link")
+    }
+    field(DTYP, DBF_DEVICE) {
+        promptgroup("10 - Common")
+        interest(1)
+        prompt("Device Type")
+    }
+    field(DISV, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        initial("1")
+        prompt("Disable Value")
+    }
+    field(DISA, DBF_SHORT) {
+        prompt("Disable")
+    }
+    field(SDIS, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Scanning Disable")
+    }
+    field(MLOK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsMutexId        mlok")
+        interest(4)
+        prompt("Monitor lock")
+    }
+    field(MLIS, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             mlis")
+        interest(4)
+        prompt("Monitor List")
+    }
+    field(BKLNK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             bklnk")
+        interest(4)
+        prompt("Backwards link tracking")
+    }
+    field(DISP, DBF_UCHAR) {
+        prompt("Disable putField")
+    }
+    field(PROC, DBF_UCHAR) {
+        interest(3)
+        pp(TRUE)
+        prompt("Force Processing")
+    }
+    field(STAT, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        initial("UDF")
+        prompt("Alarm Status")
+    }
+    field(SEVR, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        prompt("Alarm Severity")
+    }
+    field(NSTA, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        interest(2)
+        prompt("New Alarm Status")
+    }
+    field(NSEV, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("New Alarm Severity")
+    }
+    field(ACKS, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("Alarm Ack Severity")
+    }
+    field(ACKT, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        special(SPC_NOMOD)
+        menu(menuYesNo)
+        initial("YES")
+        interest(2)
+        prompt("Alarm Ack Transient")
+    }
+    field(DISS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        prompt("Disable Alarm Sevrty")
+    }
+    field(LCNT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(2)
+        prompt("Lock Count")
+    }
+    field(PACT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Record active")
+    }
+    field(PUTF, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("dbPutField process")
+    }
+    field(RPRO, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Reprocess ")
+    }
+    field(ASP, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct asgMember    *asp")
+        interest(4)
+        prompt("Access Security Pvt")
+    }
+    field(PPN, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotify *ppn")
+        interest(4)
+        prompt("pprocessNotify")
+    }
+    field(PPNR, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotifyRecord *ppnr")
+        interest(4)
+        prompt("pprocessNotifyRecord")
+    }
+    field(SPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct scan_element *spvt")
+        interest(4)
+        prompt("Scan Private")
+    }
+    field(RSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct typed_rset   *rset")
+        interest(4)
+        prompt("Address of RSET")
+    }
+    field(DSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dset         *dset")
+        interest(4)
+        prompt("DSET address")
+    }
+    field(DPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("void                *dpvt")
+        interest(4)
+        prompt("Device Private")
+    }
+    field(RDES, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dbRecordType *rdes")
+        interest(4)
+        prompt("Address of dbRecordType")
+    }
+    field(LSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct lockRecord   *lset")
+        interest(4)
+        prompt("Lock Set")
+    }
+    field(PRIO, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuPriority)
+        interest(1)
+        prompt("Scheduling Priority")
+    }
+    field(TPRO, DBF_UCHAR) {
+        prompt("Trace Processing")
+    }
+    field(BKPT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("char                bkpt")
+        interest(1)
+        prompt("Break Point")
+    }
+    field(UDF, DBF_UCHAR) {
+        promptgroup("10 - Common")
+        initial("1")
+        interest(1)
+        pp(TRUE)
+        prompt("Undefined")
+    }
+    field(UDFS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        initial("INVALID")
+        interest(1)
+        prompt("Undefined Alarm Sevrty")
+    }
+    field(TIME, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsTimeStamp      time")
+        interest(2)
+        prompt("Time")
+    }
+    field(FLNK, DBF_FWDLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Forward Process Link")
+    }
+    field(RPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct rpvtStruct *rpvt")
+        interest(4)
+        prompt("Record Private")
+    }
+    field(VAL, DBF_DOUBLE) {
+        promptgroup("50 - Output")
+        asl(ASL0)
+        prompt("Result")
+    }
+    field(PVAL, DBF_DOUBLE) {
+        prompt("Previous Value")
+    }
+    field(CALC, DBF_STRING) {
+        promptgroup("30 - Action")
+        special(SPC_CALC)
+        initial("0")
+        pp(TRUE)
+        size(80)
+        prompt("Calculation")
+    }
+    field(CLCV, DBF_LONG) {
+        interest(1)
+        prompt("CALC Valid")
+    }
+    field(INPA, DBF_INLINK) {
+        promptgroup("41 - Input A-F")
+        special(SPC_MOD)
+        interest(1)
+        prompt("Input A")
+    }
+    field(INPB, DBF_INLINK) {
+        promptgroup("41 - Input A-F")
+        special(SPC_MOD)
+        interest(1)
+        prompt("Input B")
+    }
+    field(INPC, DBF_INLINK) {
+        promptgroup("41 - Input A-F")
+        special(SPC_MOD)
+        interest(1)
+        prompt("Input C")
+    }
+    field(INPD, DBF_INLINK) {
+        promptgroup("41 - Input A-F")
+        special(SPC_MOD)
+        interest(1)
+        prompt("Input D")
+    }
+    field(INPE, DBF_INLINK) {
+        promptgroup("41 - Input A-F")
+        special(SPC_MOD)
+        interest(1)
+        prompt("Input E")
+    }
+    field(INPF, DBF_INLINK) {
+        promptgroup("41 - Input A-F")
+        special(SPC_MOD)
+        interest(1)
+        prompt("Input F")
+    }
+    field(INPG, DBF_INLINK) {
+        promptgroup("42 - Input G-L")
+        special(SPC_MOD)
+        interest(1)
+        prompt("Input G")
+    }
+    field(INPH, DBF_INLINK) {
+        promptgroup("42 - Input G-L")
+        special(SPC_MOD)
+        interest(1)
+        prompt("Input H")
+    }
+    field(INPI, DBF_INLINK) {
+        promptgroup("42 - Input G-L")
+        special(SPC_MOD)
+        interest(1)
+        prompt("Input I")
+    }
+    field(INPJ, DBF_INLINK) {
+        promptgroup("42 - Input G-L")
+        special(SPC_MOD)
+        interest(1)
+        prompt("Input J")
+    }
+    field(INPK, DBF_INLINK) {
+        promptgroup("42 - Input G-L")
+        special(SPC_MOD)
+        interest(1)
+        prompt("Input K")
+    }
+    field(INPL, DBF_INLINK) {
+        promptgroup("42 - Input G-L")
+        special(SPC_MOD)
+        interest(1)
+        prompt("Input L")
+    }
+    field(OUT, DBF_OUTLINK) {
+        promptgroup("50 - Output")
+        special(SPC_MOD)
+        interest(1)
+        prompt("Output Specification")
+    }
+    field(INAV, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(calcoutINAV)
+        initial("1")
+        interest(1)
+        prompt("INPA PV Status")
+    }
+    field(INBV, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(calcoutINAV)
+        initial("1")
+        interest(1)
+        prompt("INPB PV Status")
+    }
+    field(INCV, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(calcoutINAV)
+        initial("1")
+        interest(1)
+        prompt("INPC PV Status")
+    }
+    field(INDV, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(calcoutINAV)
+        initial("1")
+        interest(1)
+        prompt("INPD PV Status")
+    }
+    field(INEV, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(calcoutINAV)
+        initial("1")
+        interest(1)
+        prompt("INPE PV Status")
+    }
+    field(INFV, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(calcoutINAV)
+        initial("1")
+        interest(1)
+        prompt("INPF PV Status")
+    }
+    field(INGV, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(calcoutINAV)
+        initial("1")
+        interest(1)
+        prompt("INPG PV Status")
+    }
+    field(INHV, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(calcoutINAV)
+        initial("1")
+        interest(1)
+        prompt("INPH PV Status")
+    }
+    field(INIV, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(calcoutINAV)
+        initial("1")
+        interest(1)
+        prompt("INPI PV Status")
+    }
+    field(INJV, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(calcoutINAV)
+        initial("1")
+        interest(1)
+        prompt("INPJ PV Status")
+    }
+    field(INKV, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(calcoutINAV)
+        initial("1")
+        interest(1)
+        prompt("INPK PV Status")
+    }
+    field(INLV, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(calcoutINAV)
+        initial("1")
+        interest(1)
+        prompt("INPL PV Status")
+    }
+    field(OUTV, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(calcoutINAV)
+        interest(1)
+        prompt("OUT PV Status")
+    }
+    field(OOPT, DBF_MENU) {
+        promptgroup("50 - Output")
+        menu(calcoutOOPT)
+        interest(1)
+        prompt("Output Execute Opt")
+    }
+    field(ODLY, DBF_DOUBLE) {
+        promptgroup("50 - Output")
+        asl(ASL0)
+        interest(1)
+        prompt("Output Execute Delay")
+    }
+    field(DLYA, DBF_USHORT) {
+        special(SPC_NOMOD)
+        asl(ASL0)
+        prompt("Output Delay Active")
+    }
+    field(DOPT, DBF_MENU) {
+        promptgroup("30 - Action")
+        menu(calcoutDOPT)
+        interest(1)
+        prompt("Output Data Opt")
+    }
+    field(OCAL, DBF_STRING) {
+        promptgroup("30 - Action")
+        special(SPC_CALC)
+        initial("0")
+        pp(TRUE)
+        size(80)
+        prompt("Output Calculation")
+    }
+    field(OCLV, DBF_LONG) {
+        interest(1)
+        prompt("OCAL Valid")
+    }
+    field(OEVT, DBF_STRING) {
+        promptgroup("30 - Action")
+        special(SPC_MOD)
+        asl(ASL0)
+        size(40)
+        prompt("Event To Issue")
+    }
+    field(EPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("EVENTPVT epvt")
+        interest(4)
+        prompt("Event private")
+    }
+    field(IVOA, DBF_MENU) {
+        promptgroup("50 - Output")
+        menu(menuIvoa)
+        interest(2)
+        prompt("INVALID output action")
+    }
+    field(IVOV, DBF_DOUBLE) {
+        promptgroup("50 - Output")
+        interest(2)
+        prompt("INVALID output value")
+    }
+    field(EGU, DBF_STRING) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        size(16)
+        prompt("Engineering Units")
+    }
+    field(PREC, DBF_SHORT) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("Display Precision")
+    }
+    field(HOPR, DBF_DOUBLE) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("High Operating Rng")
+    }
+    field(LOPR, DBF_DOUBLE) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("Low Operating Range")
+    }
+    field(HIHI, DBF_DOUBLE) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        interest(1)
+        pp(TRUE)
+        prompt("Hihi Alarm Limit")
+    }
+    field(LOLO, DBF_DOUBLE) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        interest(1)
+        pp(TRUE)
+        prompt("Lolo Alarm Limit")
+    }
+    field(HIGH, DBF_DOUBLE) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        interest(1)
+        pp(TRUE)
+        prompt("High Alarm Limit")
+    }
+    field(LOW, DBF_DOUBLE) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        interest(1)
+        pp(TRUE)
+        prompt("Low Alarm Limit")
+    }
+    field(HHSV, DBF_MENU) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("Hihi Severity")
+    }
+    field(LLSV, DBF_MENU) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("Lolo Severity")
+    }
+    field(HSV, DBF_MENU) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("High Severity")
+    }
+    field(LSV, DBF_MENU) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("Low Severity")
+    }
+    field(HYST, DBF_DOUBLE) {
+        promptgroup("70 - Alarm")
+        interest(1)
+        prompt("Alarm Deadband")
+    }
+    field(ADEL, DBF_DOUBLE) {
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("Archive Deadband")
+    }
+    field(MDEL, DBF_DOUBLE) {
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("Monitor Deadband")
+    }
+    field(A, DBF_DOUBLE) {
+        pp(TRUE)
+        prompt("Value of Input A")
+    }
+    field(B, DBF_DOUBLE) {
+        pp(TRUE)
+        prompt("Value of Input B")
+    }
+    field(C, DBF_DOUBLE) {
+        pp(TRUE)
+        prompt("Value of Input C")
+    }
+    field(D, DBF_DOUBLE) {
+        pp(TRUE)
+        prompt("Value of Input D")
+    }
+    field(E, DBF_DOUBLE) {
+        pp(TRUE)
+        prompt("Value of Input E")
+    }
+    field(F, DBF_DOUBLE) {
+        pp(TRUE)
+        prompt("Value of Input F")
+    }
+    field(G, DBF_DOUBLE) {
+        pp(TRUE)
+        prompt("Value of Input G")
+    }
+    field(H, DBF_DOUBLE) {
+        pp(TRUE)
+        prompt("Value of Input H")
+    }
+    field(I, DBF_DOUBLE) {
+        pp(TRUE)
+        prompt("Value of Input I")
+    }
+    field(J, DBF_DOUBLE) {
+        pp(TRUE)
+        prompt("Value of Input J")
+    }
+    field(K, DBF_DOUBLE) {
+        pp(TRUE)
+        prompt("Value of Input K")
+    }
+    field(L, DBF_DOUBLE) {
+        pp(TRUE)
+        prompt("Value of Input L")
+    }
+    field(OVAL, DBF_DOUBLE) {
+        asl(ASL0)
+        prompt("Output Value")
+    }
+    field(LA, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Prev Value of A")
+    }
+    field(LB, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Prev Value of B")
+    }
+    field(LC, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Prev Value of C")
+    }
+    field(LD, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Prev Value of D")
+    }
+    field(LE, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Prev Value of E")
+    }
+    field(LF, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Prev Value of F")
+    }
+    field(LG, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Prev Value of G")
+    }
+    field(LH, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Prev Value of H")
+    }
+    field(LI, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Prev Value of I")
+    }
+    field(LJ, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Prev Value of J")
+    }
+    field(LK, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Prev Value of K")
+    }
+    field(LL, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Prev Value of L")
+    }
+    field(POVL, DBF_DOUBLE) {
+        asl(ASL0)
+        prompt("Prev Value of OVAL")
+    }
+    field(LALM, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Last Value Alarmed")
+    }
+    field(ALST, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Last Value Archived")
+    }
+    field(MLST, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Last Val Monitored")
+    }
+    field(RPCL, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("char	rpcl[INFIX_TO_POSTFIX_SIZE(80)]")
+        interest(4)
+        prompt("Reverse Polish Calc")
+    }
+    field(ORPC, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("char	orpc[INFIX_TO_POSTFIX_SIZE(80)]")
+        interest(4)
+        prompt("Reverse Polish OCalc")
+    }
 }
-recordtype(compress) {
-	field(NAME,DBF_STRING) {
-		prompt("Record Name")
-		special(SPC_NOMOD)
-		size(61)
-	}
-	field(DESC,DBF_STRING) {
-		prompt("Descriptor")
-		promptgroup(GUI_COMMON)
-		size(41)
-	}
-	field(ASG,DBF_STRING) {
-		prompt("Access Security Group")
-		promptgroup(GUI_COMMON)
-		special(SPC_AS)
-		size(29)
-	}
-	field(SCAN,DBF_MENU) {
-		prompt("Scan Mechanism")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuScan)
-		interest(1)
-	}
-	field(PINI,DBF_MENU) {
-		prompt("Process at iocInit")
-		promptgroup(GUI_SCAN)
-		menu(menuPini)
-		interest(1)
-	}
-	field(PHAS,DBF_SHORT) {
-		prompt("Scan Phase")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(EVNT,DBF_SHORT) {
-		prompt("Event Number")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(TSE,DBF_SHORT) {
-		prompt("Time Stamp Event")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(TSEL,DBF_INLINK) {
-		prompt("Time Stamp Link")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(DTYP,DBF_DEVICE) {
-		prompt("Device Type")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(DISV,DBF_SHORT) {
-		prompt("Disable Value")
-		initial("1")
-		promptgroup(GUI_SCAN)
-	}
-	field(DISA,DBF_SHORT) {
-		prompt("Disable")
-	}
-	field(SDIS,DBF_INLINK) {
-		prompt("Scanning Disable")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(MLOK,DBF_NOACCESS) {
-		prompt("Monitor lock")
-		special(SPC_NOMOD)
-		extra("epicsMutexId	mlok")
-		interest(4)
-	}
-	field(MLIS,DBF_NOACCESS) {
-		prompt("Monitor List")
-		special(SPC_NOMOD)
-		extra("ELLLIST		mlis")
-		interest(4)
-	}
-	field(DISP,DBF_UCHAR) {
-		prompt("Disable putField")
-	}
-	field(PROC,DBF_UCHAR) {
-		prompt("Force Processing")
-		pp(TRUE)
-		interest(3)
-	}
-	field(STAT,DBF_MENU) {
-		prompt("Alarm Status")
-		initial("UDF")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-	}
-	field(SEVR,DBF_MENU) {
-		prompt("Alarm Severity")
-		initial("INVALID")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-	}
-	field(NSTA,DBF_MENU) {
-		prompt("New Alarm Status")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-		interest(2)
-	}
-	field(NSEV,DBF_MENU) {
-		prompt("New Alarm Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKS,DBF_MENU) {
-		prompt("Alarm Ack Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKT,DBF_MENU) {
-		prompt("Alarm Ack Transient")
-		initial("YES")
-		promptgroup(GUI_ALARMS)
-		special(SPC_NOMOD)
-		menu(menuYesNo)
-		interest(2)
-	}
-	field(DISS,DBF_MENU) {
-		prompt("Disable Alarm Sevrty")
-		promptgroup(GUI_SCAN)
-		menu(menuAlarmSevr)
-		interest(1)
-	}
-	field(LCNT,DBF_UCHAR) {
-		prompt("Lock Count")
-		special(SPC_NOMOD)
-		interest(2)
-	}
-	field(PACT,DBF_UCHAR) {
-		prompt("Record active")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(PUTF,DBF_UCHAR) {
-		prompt("dbPutField process")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(RPRO,DBF_UCHAR) {
-		prompt("Reprocess ")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(ASP,DBF_NOACCESS) {
-		prompt("Access Security Pvt")
-		special(SPC_NOMOD)
-		extra("struct asgMember *asp")
-		interest(4)
-	}
-	field(PPN,DBF_NOACCESS) {
-		prompt("addr of PUTNOTIFY")
-		special(SPC_NOMOD)
-		extra("struct putNotify *ppn")
-		interest(4)
-	}
-	field(PPNR,DBF_NOACCESS) {
-		prompt("pputNotifyRecord")
-		special(SPC_NOMOD)
-		extra("struct putNotifyRecord *ppnr")
-		interest(4)
-	}
-	field(SPVT,DBF_NOACCESS) {
-		prompt("Scan Private")
-		special(SPC_NOMOD)
-		extra("struct scan_element *spvt")
-		interest(4)
-	}
-	field(RSET,DBF_NOACCESS) {
-		prompt("Address of RSET")
-		special(SPC_NOMOD)
-		extra("struct rset	*rset")
-		interest(4)
-	}
-	field(DSET,DBF_NOACCESS) {
-		prompt("DSET address")
-		special(SPC_NOMOD)
-		extra("struct dset	*dset")
-		interest(4)
-	}
-	field(DPVT,DBF_NOACCESS) {
-		prompt("Device Private")
-		special(SPC_NOMOD)
-		extra("void		*dpvt")
-		interest(4)
-	}
-	field(RDES,DBF_NOACCESS) {
-		prompt("Address of dbRecordType")
-		special(SPC_NOMOD)
-		extra("struct dbRecordType *rdes")
-		interest(4)
-	}
-	field(LSET,DBF_NOACCESS) {
-		prompt("Lock Set")
-		special(SPC_NOMOD)
-		extra("struct lockRecord *lset")
-		interest(4)
-	}
-	field(PRIO,DBF_MENU) {
-		prompt("Scheduling Priority")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuPriority)
-		interest(1)
-	}
-	field(TPRO,DBF_UCHAR) {
-		prompt("Trace Processing")
-	}
-	field(BKPT,DBF_NOACCESS) {
-		prompt("Break Point")
-		special(SPC_NOMOD)
-		extra("char bkpt")
-		interest(1)
-	}
-	field(UDF,DBF_UCHAR) {
-		prompt("Undefined")
-		initial("1")
-		promptgroup(GUI_COMMON)
-		pp(TRUE)
-		interest(1)
-	}
-	field(TIME,DBF_NOACCESS) {
-		prompt("Time")
-		special(SPC_NOMOD)
-		extra("epicsTimeStamp	time")
-		interest(2)
-	}
-	field(FLNK,DBF_FWDLINK) {
-		prompt("Forward Process Link")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(VAL,DBF_NOACCESS) {
-		prompt("Value")
-		special(SPC_DBADDR)
-		extra("void *		val")
-		pp(TRUE)
-		asl(ASL0)
-	}
-	field(INP,DBF_INLINK) {
-		prompt("Input Specification")
-		promptgroup(GUI_COMPRESS)
-		interest(1)
-	}
-	field(RES,DBF_SHORT) {
-		prompt("Reset")
-		special(101)
-		interest(3)
-		asl(ASL0)
-	}
-	field(ALG,DBF_MENU) {
-		prompt("Compression Algorithm")
-		promptgroup(GUI_ALARMS)
-		special(101)
-		menu(compressALG)
-		interest(1)
-	}
-	field(NSAM,DBF_ULONG) {
-		prompt("Number of Values")
-		initial("1")
-		promptgroup(GUI_COMPRESS)
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(N,DBF_ULONG) {
-		prompt("N to 1 Compression")
-		initial("1")
-		promptgroup(GUI_COMPRESS)
-		special(101)
-		interest(1)
-	}
-	field(IHIL,DBF_DOUBLE) {
-		prompt("Init High Interest Lim")
-		promptgroup(GUI_COMPRESS)
-		interest(1)
-	}
-	field(ILIL,DBF_DOUBLE) {
-		prompt("Init Low Interest Lim")
-		promptgroup(GUI_COMPRESS)
-		interest(1)
-	}
-	field(HOPR,DBF_DOUBLE) {
-		prompt("High Operating Range")
-		promptgroup(GUI_DISPLAY)
-		interest(1)
-	}
-	field(LOPR,DBF_DOUBLE) {
-		prompt("Low Operating Range")
-		promptgroup(GUI_DISPLAY)
-		interest(1)
-	}
-	field(PREC,DBF_SHORT) {
-		prompt("Display Precision")
-		promptgroup(GUI_DISPLAY)
-		interest(1)
-	}
-	field(EGU,DBF_STRING) {
-		prompt("EngineeringUnits")
-		promptgroup(GUI_DISPLAY)
-		size(16)
-		interest(1)
-	}
-	field(OFF,DBF_ULONG) {
-		prompt("Offset")
-		special(SPC_NOMOD)
-	}
-	field(NUSE,DBF_ULONG) {
-		prompt("Number Used")
-		special(SPC_NOMOD)
-	}
-	field(OUSE,DBF_ULONG) {
-		prompt("Old Number Used")
-		special(SPC_NOMOD)
-	}
-	field(BPTR,DBF_NOACCESS) {
-		prompt("Buffer Pointer")
-		special(SPC_NOMOD)
-		extra("double		*bptr")
-		interest(4)
-	}
-	field(SPTR,DBF_NOACCESS) {
-		prompt("Summing Buffer Ptr")
-		special(SPC_NOMOD)
-		extra("double		*sptr")
-		interest(4)
-	}
-	field(WPTR,DBF_NOACCESS) {
-		prompt("Working Buffer Ptr")
-		special(SPC_NOMOD)
-		extra("double		*wptr")
-		interest(4)
-	}
-	field(INPN,DBF_LONG) {
-		prompt("Number of elements in Working Buffer")
-		special(SPC_NOMOD)
-		interest(4)
-	}
-	field(CVB,DBF_DOUBLE) {
-		prompt("Compress Value Buffer")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(INX,DBF_ULONG) {
-		prompt("Compressed Array Inx")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-}
-recordtype(dfanout) {
-	field(NAME,DBF_STRING) {
-		prompt("Record Name")
-		special(SPC_NOMOD)
-		size(61)
-	}
-	field(DESC,DBF_STRING) {
-		prompt("Descriptor")
-		promptgroup(GUI_COMMON)
-		size(41)
-	}
-	field(ASG,DBF_STRING) {
-		prompt("Access Security Group")
-		promptgroup(GUI_COMMON)
-		special(SPC_AS)
-		size(29)
-	}
-	field(SCAN,DBF_MENU) {
-		prompt("Scan Mechanism")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuScan)
-		interest(1)
-	}
-	field(PINI,DBF_MENU) {
-		prompt("Process at iocInit")
-		promptgroup(GUI_SCAN)
-		menu(menuPini)
-		interest(1)
-	}
-	field(PHAS,DBF_SHORT) {
-		prompt("Scan Phase")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(EVNT,DBF_SHORT) {
-		prompt("Event Number")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(TSE,DBF_SHORT) {
-		prompt("Time Stamp Event")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(TSEL,DBF_INLINK) {
-		prompt("Time Stamp Link")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(DTYP,DBF_DEVICE) {
-		prompt("Device Type")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(DISV,DBF_SHORT) {
-		prompt("Disable Value")
-		initial("1")
-		promptgroup(GUI_SCAN)
-	}
-	field(DISA,DBF_SHORT) {
-		prompt("Disable")
-	}
-	field(SDIS,DBF_INLINK) {
-		prompt("Scanning Disable")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(MLOK,DBF_NOACCESS) {
-		prompt("Monitor lock")
-		special(SPC_NOMOD)
-		extra("epicsMutexId	mlok")
-		interest(4)
-	}
-	field(MLIS,DBF_NOACCESS) {
-		prompt("Monitor List")
-		special(SPC_NOMOD)
-		extra("ELLLIST		mlis")
-		interest(4)
-	}
-	field(DISP,DBF_UCHAR) {
-		prompt("Disable putField")
-	}
-	field(PROC,DBF_UCHAR) {
-		prompt("Force Processing")
-		pp(TRUE)
-		interest(3)
-	}
-	field(STAT,DBF_MENU) {
-		prompt("Alarm Status")
-		initial("UDF")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-	}
-	field(SEVR,DBF_MENU) {
-		prompt("Alarm Severity")
-		initial("INVALID")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-	}
-	field(NSTA,DBF_MENU) {
-		prompt("New Alarm Status")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-		interest(2)
-	}
-	field(NSEV,DBF_MENU) {
-		prompt("New Alarm Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKS,DBF_MENU) {
-		prompt("Alarm Ack Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKT,DBF_MENU) {
-		prompt("Alarm Ack Transient")
-		initial("YES")
-		promptgroup(GUI_ALARMS)
-		special(SPC_NOMOD)
-		menu(menuYesNo)
-		interest(2)
-	}
-	field(DISS,DBF_MENU) {
-		prompt("Disable Alarm Sevrty")
-		promptgroup(GUI_SCAN)
-		menu(menuAlarmSevr)
-		interest(1)
-	}
-	field(LCNT,DBF_UCHAR) {
-		prompt("Lock Count")
-		special(SPC_NOMOD)
-		interest(2)
-	}
-	field(PACT,DBF_UCHAR) {
-		prompt("Record active")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(PUTF,DBF_UCHAR) {
-		prompt("dbPutField process")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(RPRO,DBF_UCHAR) {
-		prompt("Reprocess ")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(ASP,DBF_NOACCESS) {
-		prompt("Access Security Pvt")
-		special(SPC_NOMOD)
-		extra("struct asgMember *asp")
-		interest(4)
-	}
-	field(PPN,DBF_NOACCESS) {
-		prompt("addr of PUTNOTIFY")
-		special(SPC_NOMOD)
-		extra("struct putNotify *ppn")
-		interest(4)
-	}
-	field(PPNR,DBF_NOACCESS) {
-		prompt("pputNotifyRecord")
-		special(SPC_NOMOD)
-		extra("struct putNotifyRecord *ppnr")
-		interest(4)
-	}
-	field(SPVT,DBF_NOACCESS) {
-		prompt("Scan Private")
-		special(SPC_NOMOD)
-		extra("struct scan_element *spvt")
-		interest(4)
-	}
-	field(RSET,DBF_NOACCESS) {
-		prompt("Address of RSET")
-		special(SPC_NOMOD)
-		extra("struct rset	*rset")
-		interest(4)
-	}
-	field(DSET,DBF_NOACCESS) {
-		prompt("DSET address")
-		special(SPC_NOMOD)
-		extra("struct dset	*dset")
-		interest(4)
-	}
-	field(DPVT,DBF_NOACCESS) {
-		prompt("Device Private")
-		special(SPC_NOMOD)
-		extra("void		*dpvt")
-		interest(4)
-	}
-	field(RDES,DBF_NOACCESS) {
-		prompt("Address of dbRecordType")
-		special(SPC_NOMOD)
-		extra("struct dbRecordType *rdes")
-		interest(4)
-	}
-	field(LSET,DBF_NOACCESS) {
-		prompt("Lock Set")
-		special(SPC_NOMOD)
-		extra("struct lockRecord *lset")
-		interest(4)
-	}
-	field(PRIO,DBF_MENU) {
-		prompt("Scheduling Priority")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuPriority)
-		interest(1)
-	}
-	field(TPRO,DBF_UCHAR) {
-		prompt("Trace Processing")
-	}
-	field(BKPT,DBF_NOACCESS) {
-		prompt("Break Point")
-		special(SPC_NOMOD)
-		extra("char bkpt")
-		interest(1)
-	}
-	field(UDF,DBF_UCHAR) {
-		prompt("Undefined")
-		initial("1")
-		promptgroup(GUI_COMMON)
-		pp(TRUE)
-		interest(1)
-	}
-	field(TIME,DBF_NOACCESS) {
-		prompt("Time")
-		special(SPC_NOMOD)
-		extra("epicsTimeStamp	time")
-		interest(2)
-	}
-	field(FLNK,DBF_FWDLINK) {
-		prompt("Forward Process Link")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(VAL,DBF_DOUBLE) {
-		prompt("Desired Output")
-		pp(TRUE)
-		asl(ASL0)
-	}
-	field(SELM,DBF_MENU) {
-		prompt("Select Mechanism")
-		promptgroup(GUI_LINKS)
-		menu(dfanoutSELM)
-		interest(1)
-	}
-	field(SELN,DBF_USHORT) {
-		prompt("Link Selection")
-		initial("1")
-		interest(1)
-	}
-	field(SELL,DBF_INLINK) {
-		prompt("Link Selection Loc")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(OUTA,DBF_OUTLINK) {
-		prompt("Output Spec A")
-		promptgroup(GUI_OUTPUT)
-		interest(1)
-	}
-	field(OUTB,DBF_OUTLINK) {
-		prompt("Output Spec B")
-		promptgroup(GUI_OUTPUT)
-		interest(1)
-	}
-	field(OUTC,DBF_OUTLINK) {
-		prompt("Output Spec C")
-		promptgroup(GUI_OUTPUT)
-		interest(1)
-	}
-	field(OUTD,DBF_OUTLINK) {
-		prompt("Output Spec D")
-		promptgroup(GUI_OUTPUT)
-		interest(1)
-	}
-	field(OUTE,DBF_OUTLINK) {
-		prompt("Output Spec E")
-		promptgroup(GUI_OUTPUT)
-		interest(1)
-	}
-	field(OUTF,DBF_OUTLINK) {
-		prompt("Output Spec F")
-		promptgroup(GUI_OUTPUT)
-		interest(1)
-	}
-	field(OUTG,DBF_OUTLINK) {
-		prompt("Output Spec G")
-		promptgroup(GUI_OUTPUT)
-		interest(1)
-	}
-	field(OUTH,DBF_OUTLINK) {
-		prompt("Output Spec H")
-		promptgroup(GUI_OUTPUT)
-		interest(1)
-	}
-	field(DOL,DBF_INLINK) {
-		prompt("Desired Output Loc")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(OMSL,DBF_MENU) {
-		prompt("Output Mode Select")
-		promptgroup(GUI_OUTPUT)
-		menu(menuOmsl)
-		interest(1)
-	}
-	field(EGU,DBF_STRING) {
-		prompt("Units name")
-		promptgroup(GUI_DISPLAY)
-		size(16)
-		interest(1)
-	}
-	field(PREC,DBF_SHORT) {
-		prompt("Display Precision")
-		promptgroup(GUI_DISPLAY)
-		interest(1)
-	}
-	field(HOPR,DBF_DOUBLE) {
-		prompt("High Operating Range")
-		promptgroup(GUI_DISPLAY)
-		interest(1)
-	}
-	field(LOPR,DBF_DOUBLE) {
-		prompt("Low Operating Range")
-		promptgroup(GUI_DISPLAY)
-		interest(1)
-	}
-	field(HIHI,DBF_DOUBLE) {
-		prompt("Hihi Alarm Limit")
-		promptgroup(GUI_ALARMS)
-		pp(TRUE)
-		interest(1)
-	}
-	field(LOLO,DBF_DOUBLE) {
-		prompt("Lolo Alarm Limit")
-		promptgroup(GUI_ALARMS)
-		pp(TRUE)
-		interest(1)
-	}
-	field(HIGH,DBF_DOUBLE) {
-		prompt("High Alarm Limit")
-		promptgroup(GUI_ALARMS)
-		pp(TRUE)
-		interest(1)
-	}
-	field(LOW,DBF_DOUBLE) {
-		prompt("Low Alarm Limit")
-		promptgroup(GUI_ALARMS)
-		pp(TRUE)
-		interest(1)
-	}
-	field(HHSV,DBF_MENU) {
-		prompt("Hihi Severity")
-		promptgroup(GUI_ALARMS)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(LLSV,DBF_MENU) {
-		prompt("Lolo Severity")
-		promptgroup(GUI_ALARMS)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(HSV,DBF_MENU) {
-		prompt("High Severity")
-		promptgroup(GUI_ALARMS)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(LSV,DBF_MENU) {
-		prompt("Low Severity")
-		promptgroup(GUI_ALARMS)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(HYST,DBF_DOUBLE) {
-		prompt("Alarm Deadband")
-		promptgroup(GUI_ALARMS)
-		interest(1)
-	}
-	field(ADEL,DBF_DOUBLE) {
-		prompt("Archive Deadband")
-		promptgroup(GUI_DISPLAY)
-		interest(1)
-	}
-	field(MDEL,DBF_DOUBLE) {
-		prompt("Monitor Deadband")
-		promptgroup(GUI_DISPLAY)
-		interest(1)
-	}
-	field(LALM,DBF_DOUBLE) {
-		prompt("Last Value Alarmed")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(ALST,DBF_DOUBLE) {
-		prompt("Last Value Archived")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(MLST,DBF_DOUBLE) {
-		prompt("Last Val Monitored")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-}
-recordtype(event) {
-	field(NAME,DBF_STRING) {
-		prompt("Record Name")
-		special(SPC_NOMOD)
-		size(61)
-	}
-	field(DESC,DBF_STRING) {
-		prompt("Descriptor")
-		promptgroup(GUI_COMMON)
-		size(41)
-	}
-	field(ASG,DBF_STRING) {
-		prompt("Access Security Group")
-		promptgroup(GUI_COMMON)
-		special(SPC_AS)
-		size(29)
-	}
-	field(SCAN,DBF_MENU) {
-		prompt("Scan Mechanism")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuScan)
-		interest(1)
-	}
-	field(PINI,DBF_MENU) {
-		prompt("Process at iocInit")
-		promptgroup(GUI_SCAN)
-		menu(menuPini)
-		interest(1)
-	}
-	field(PHAS,DBF_SHORT) {
-		prompt("Scan Phase")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(EVNT,DBF_SHORT) {
-		prompt("Event Number")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(TSE,DBF_SHORT) {
-		prompt("Time Stamp Event")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(TSEL,DBF_INLINK) {
-		prompt("Time Stamp Link")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(DTYP,DBF_DEVICE) {
-		prompt("Device Type")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(DISV,DBF_SHORT) {
-		prompt("Disable Value")
-		initial("1")
-		promptgroup(GUI_SCAN)
-	}
-	field(DISA,DBF_SHORT) {
-		prompt("Disable")
-	}
-	field(SDIS,DBF_INLINK) {
-		prompt("Scanning Disable")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(MLOK,DBF_NOACCESS) {
-		prompt("Monitor lock")
-		special(SPC_NOMOD)
-		extra("epicsMutexId	mlok")
-		interest(4)
-	}
-	field(MLIS,DBF_NOACCESS) {
-		prompt("Monitor List")
-		special(SPC_NOMOD)
-		extra("ELLLIST		mlis")
-		interest(4)
-	}
-	field(DISP,DBF_UCHAR) {
-		prompt("Disable putField")
-	}
-	field(PROC,DBF_UCHAR) {
-		prompt("Force Processing")
-		pp(TRUE)
-		interest(3)
-	}
-	field(STAT,DBF_MENU) {
-		prompt("Alarm Status")
-		initial("UDF")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-	}
-	field(SEVR,DBF_MENU) {
-		prompt("Alarm Severity")
-		initial("INVALID")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-	}
-	field(NSTA,DBF_MENU) {
-		prompt("New Alarm Status")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-		interest(2)
-	}
-	field(NSEV,DBF_MENU) {
-		prompt("New Alarm Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKS,DBF_MENU) {
-		prompt("Alarm Ack Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKT,DBF_MENU) {
-		prompt("Alarm Ack Transient")
-		initial("YES")
-		promptgroup(GUI_ALARMS)
-		special(SPC_NOMOD)
-		menu(menuYesNo)
-		interest(2)
-	}
-	field(DISS,DBF_MENU) {
-		prompt("Disable Alarm Sevrty")
-		promptgroup(GUI_SCAN)
-		menu(menuAlarmSevr)
-		interest(1)
-	}
-	field(LCNT,DBF_UCHAR) {
-		prompt("Lock Count")
-		special(SPC_NOMOD)
-		interest(2)
-	}
-	field(PACT,DBF_UCHAR) {
-		prompt("Record active")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(PUTF,DBF_UCHAR) {
-		prompt("dbPutField process")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(RPRO,DBF_UCHAR) {
-		prompt("Reprocess ")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(ASP,DBF_NOACCESS) {
-		prompt("Access Security Pvt")
-		special(SPC_NOMOD)
-		extra("struct asgMember *asp")
-		interest(4)
-	}
-	field(PPN,DBF_NOACCESS) {
-		prompt("addr of PUTNOTIFY")
-		special(SPC_NOMOD)
-		extra("struct putNotify *ppn")
-		interest(4)
-	}
-	field(PPNR,DBF_NOACCESS) {
-		prompt("pputNotifyRecord")
-		special(SPC_NOMOD)
-		extra("struct putNotifyRecord *ppnr")
-		interest(4)
-	}
-	field(SPVT,DBF_NOACCESS) {
-		prompt("Scan Private")
-		special(SPC_NOMOD)
-		extra("struct scan_element *spvt")
-		interest(4)
-	}
-	field(RSET,DBF_NOACCESS) {
-		prompt("Address of RSET")
-		special(SPC_NOMOD)
-		extra("struct rset	*rset")
-		interest(4)
-	}
-	field(DSET,DBF_NOACCESS) {
-		prompt("DSET address")
-		special(SPC_NOMOD)
-		extra("struct dset	*dset")
-		interest(4)
-	}
-	field(DPVT,DBF_NOACCESS) {
-		prompt("Device Private")
-		special(SPC_NOMOD)
-		extra("void		*dpvt")
-		interest(4)
-	}
-	field(RDES,DBF_NOACCESS) {
-		prompt("Address of dbRecordType")
-		special(SPC_NOMOD)
-		extra("struct dbRecordType *rdes")
-		interest(4)
-	}
-	field(LSET,DBF_NOACCESS) {
-		prompt("Lock Set")
-		special(SPC_NOMOD)
-		extra("struct lockRecord *lset")
-		interest(4)
-	}
-	field(PRIO,DBF_MENU) {
-		prompt("Scheduling Priority")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuPriority)
-		interest(1)
-	}
-	field(TPRO,DBF_UCHAR) {
-		prompt("Trace Processing")
-	}
-	field(BKPT,DBF_NOACCESS) {
-		prompt("Break Point")
-		special(SPC_NOMOD)
-		extra("char bkpt")
-		interest(1)
-	}
-	field(UDF,DBF_UCHAR) {
-		prompt("Undefined")
-		initial("1")
-		promptgroup(GUI_COMMON)
-		pp(TRUE)
-		interest(1)
-	}
-	field(TIME,DBF_NOACCESS) {
-		prompt("Time")
-		special(SPC_NOMOD)
-		extra("epicsTimeStamp	time")
-		interest(2)
-	}
-	field(FLNK,DBF_FWDLINK) {
-		prompt("Forward Process Link")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(VAL,DBF_USHORT) {
-		prompt("Event Number To Post")
-		promptgroup(GUI_INPUTS)
-		asl(ASL0)
-	}
-	field(INP,DBF_INLINK) {
-		prompt("Input Specification")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(SIOL,DBF_INLINK) {
-		prompt("Sim Input Specifctn")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(SVAL,DBF_USHORT) {
-		prompt("Simulation Value")
-	}
-	field(SIML,DBF_INLINK) {
-		prompt("Sim Mode Location")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(SIMM,DBF_MENU) {
-		prompt("Simulation Mode")
-		menu(menuYesNo)
-		interest(1)
-	}
-	field(SIMS,DBF_MENU) {
-		prompt("Sim mode Alarm Svrty")
-		promptgroup(GUI_INPUTS)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-}
-recordtype(fanout) {
-	field(NAME,DBF_STRING) {
-		prompt("Record Name")
-		special(SPC_NOMOD)
-		size(61)
-	}
-	field(DESC,DBF_STRING) {
-		prompt("Descriptor")
-		promptgroup(GUI_COMMON)
-		size(41)
-	}
-	field(ASG,DBF_STRING) {
-		prompt("Access Security Group")
-		promptgroup(GUI_COMMON)
-		special(SPC_AS)
-		size(29)
-	}
-	field(SCAN,DBF_MENU) {
-		prompt("Scan Mechanism")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuScan)
-		interest(1)
-	}
-	field(PINI,DBF_MENU) {
-		prompt("Process at iocInit")
-		promptgroup(GUI_SCAN)
-		menu(menuPini)
-		interest(1)
-	}
-	field(PHAS,DBF_SHORT) {
-		prompt("Scan Phase")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(EVNT,DBF_SHORT) {
-		prompt("Event Number")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(TSE,DBF_SHORT) {
-		prompt("Time Stamp Event")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(TSEL,DBF_INLINK) {
-		prompt("Time Stamp Link")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(DTYP,DBF_DEVICE) {
-		prompt("Device Type")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(DISV,DBF_SHORT) {
-		prompt("Disable Value")
-		initial("1")
-		promptgroup(GUI_SCAN)
-	}
-	field(DISA,DBF_SHORT) {
-		prompt("Disable")
-	}
-	field(SDIS,DBF_INLINK) {
-		prompt("Scanning Disable")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(MLOK,DBF_NOACCESS) {
-		prompt("Monitor lock")
-		special(SPC_NOMOD)
-		extra("epicsMutexId	mlok")
-		interest(4)
-	}
-	field(MLIS,DBF_NOACCESS) {
-		prompt("Monitor List")
-		special(SPC_NOMOD)
-		extra("ELLLIST		mlis")
-		interest(4)
-	}
-	field(DISP,DBF_UCHAR) {
-		prompt("Disable putField")
-	}
-	field(PROC,DBF_UCHAR) {
-		prompt("Force Processing")
-		pp(TRUE)
-		interest(3)
-	}
-	field(STAT,DBF_MENU) {
-		prompt("Alarm Status")
-		initial("UDF")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-	}
-	field(SEVR,DBF_MENU) {
-		prompt("Alarm Severity")
-		initial("INVALID")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-	}
-	field(NSTA,DBF_MENU) {
-		prompt("New Alarm Status")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-		interest(2)
-	}
-	field(NSEV,DBF_MENU) {
-		prompt("New Alarm Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKS,DBF_MENU) {
-		prompt("Alarm Ack Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKT,DBF_MENU) {
-		prompt("Alarm Ack Transient")
-		initial("YES")
-		promptgroup(GUI_ALARMS)
-		special(SPC_NOMOD)
-		menu(menuYesNo)
-		interest(2)
-	}
-	field(DISS,DBF_MENU) {
-		prompt("Disable Alarm Sevrty")
-		promptgroup(GUI_SCAN)
-		menu(menuAlarmSevr)
-		interest(1)
-	}
-	field(LCNT,DBF_UCHAR) {
-		prompt("Lock Count")
-		special(SPC_NOMOD)
-		interest(2)
-	}
-	field(PACT,DBF_UCHAR) {
-		prompt("Record active")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(PUTF,DBF_UCHAR) {
-		prompt("dbPutField process")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(RPRO,DBF_UCHAR) {
-		prompt("Reprocess ")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(ASP,DBF_NOACCESS) {
-		prompt("Access Security Pvt")
-		special(SPC_NOMOD)
-		extra("struct asgMember *asp")
-		interest(4)
-	}
-	field(PPN,DBF_NOACCESS) {
-		prompt("addr of PUTNOTIFY")
-		special(SPC_NOMOD)
-		extra("struct putNotify *ppn")
-		interest(4)
-	}
-	field(PPNR,DBF_NOACCESS) {
-		prompt("pputNotifyRecord")
-		special(SPC_NOMOD)
-		extra("struct putNotifyRecord *ppnr")
-		interest(4)
-	}
-	field(SPVT,DBF_NOACCESS) {
-		prompt("Scan Private")
-		special(SPC_NOMOD)
-		extra("struct scan_element *spvt")
-		interest(4)
-	}
-	field(RSET,DBF_NOACCESS) {
-		prompt("Address of RSET")
-		special(SPC_NOMOD)
-		extra("struct rset	*rset")
-		interest(4)
-	}
-	field(DSET,DBF_NOACCESS) {
-		prompt("DSET address")
-		special(SPC_NOMOD)
-		extra("struct dset	*dset")
-		interest(4)
-	}
-	field(DPVT,DBF_NOACCESS) {
-		prompt("Device Private")
-		special(SPC_NOMOD)
-		extra("void		*dpvt")
-		interest(4)
-	}
-	field(RDES,DBF_NOACCESS) {
-		prompt("Address of dbRecordType")
-		special(SPC_NOMOD)
-		extra("struct dbRecordType *rdes")
-		interest(4)
-	}
-	field(LSET,DBF_NOACCESS) {
-		prompt("Lock Set")
-		special(SPC_NOMOD)
-		extra("struct lockRecord *lset")
-		interest(4)
-	}
-	field(PRIO,DBF_MENU) {
-		prompt("Scheduling Priority")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuPriority)
-		interest(1)
-	}
-	field(TPRO,DBF_UCHAR) {
-		prompt("Trace Processing")
-	}
-	field(BKPT,DBF_NOACCESS) {
-		prompt("Break Point")
-		special(SPC_NOMOD)
-		extra("char bkpt")
-		interest(1)
-	}
-	field(UDF,DBF_UCHAR) {
-		prompt("Undefined")
-		initial("1")
-		promptgroup(GUI_COMMON)
-		pp(TRUE)
-		interest(1)
-	}
-	field(TIME,DBF_NOACCESS) {
-		prompt("Time")
-		special(SPC_NOMOD)
-		extra("epicsTimeStamp	time")
-		interest(2)
-	}
-	field(FLNK,DBF_FWDLINK) {
-		prompt("Forward Process Link")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(VAL,DBF_LONG) {
-		prompt("Used to trigger")
-		pp(TRUE)
-		asl(ASL0)
-	}
-	field(SELM,DBF_MENU) {
-		prompt("Select Mechanism")
-		promptgroup(GUI_LINKS)
-		menu(fanoutSELM)
-		interest(1)
-	}
-	field(SELN,DBF_USHORT) {
-		prompt("Link Selection")
-		initial("1")
-		interest(1)
-	}
-	field(SELL,DBF_INLINK) {
-		prompt("Link Selection Loc")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(LNK1,DBF_FWDLINK) {
-		prompt("Forward Link 1")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(LNK2,DBF_FWDLINK) {
-		prompt("Forward Link 2")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(LNK3,DBF_FWDLINK) {
-		prompt("Forward Link 3")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(LNK4,DBF_FWDLINK) {
-		prompt("Forward Link 4")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(LNK5,DBF_FWDLINK) {
-		prompt("Forward Link 5")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(LNK6,DBF_FWDLINK) {
-		prompt("Forward Link 6")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-}
-recordtype(longin) {
-	field(NAME,DBF_STRING) {
-		prompt("Record Name")
-		special(SPC_NOMOD)
-		size(61)
-	}
-	field(DESC,DBF_STRING) {
-		prompt("Descriptor")
-		promptgroup(GUI_COMMON)
-		size(41)
-	}
-	field(ASG,DBF_STRING) {
-		prompt("Access Security Group")
-		promptgroup(GUI_COMMON)
-		special(SPC_AS)
-		size(29)
-	}
-	field(SCAN,DBF_MENU) {
-		prompt("Scan Mechanism")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuScan)
-		interest(1)
-	}
-	field(PINI,DBF_MENU) {
-		prompt("Process at iocInit")
-		promptgroup(GUI_SCAN)
-		menu(menuPini)
-		interest(1)
-	}
-	field(PHAS,DBF_SHORT) {
-		prompt("Scan Phase")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(EVNT,DBF_SHORT) {
-		prompt("Event Number")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(TSE,DBF_SHORT) {
-		prompt("Time Stamp Event")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(TSEL,DBF_INLINK) {
-		prompt("Time Stamp Link")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(DTYP,DBF_DEVICE) {
-		prompt("Device Type")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(DISV,DBF_SHORT) {
-		prompt("Disable Value")
-		initial("1")
-		promptgroup(GUI_SCAN)
-	}
-	field(DISA,DBF_SHORT) {
-		prompt("Disable")
-	}
-	field(SDIS,DBF_INLINK) {
-		prompt("Scanning Disable")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(MLOK,DBF_NOACCESS) {
-		prompt("Monitor lock")
-		special(SPC_NOMOD)
-		extra("epicsMutexId	mlok")
-		interest(4)
-	}
-	field(MLIS,DBF_NOACCESS) {
-		prompt("Monitor List")
-		special(SPC_NOMOD)
-		extra("ELLLIST		mlis")
-		interest(4)
-	}
-	field(DISP,DBF_UCHAR) {
-		prompt("Disable putField")
-	}
-	field(PROC,DBF_UCHAR) {
-		prompt("Force Processing")
-		pp(TRUE)
-		interest(3)
-	}
-	field(STAT,DBF_MENU) {
-		prompt("Alarm Status")
-		initial("UDF")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-	}
-	field(SEVR,DBF_MENU) {
-		prompt("Alarm Severity")
-		initial("INVALID")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-	}
-	field(NSTA,DBF_MENU) {
-		prompt("New Alarm Status")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-		interest(2)
-	}
-	field(NSEV,DBF_MENU) {
-		prompt("New Alarm Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKS,DBF_MENU) {
-		prompt("Alarm Ack Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKT,DBF_MENU) {
-		prompt("Alarm Ack Transient")
-		initial("YES")
-		promptgroup(GUI_ALARMS)
-		special(SPC_NOMOD)
-		menu(menuYesNo)
-		interest(2)
-	}
-	field(DISS,DBF_MENU) {
-		prompt("Disable Alarm Sevrty")
-		promptgroup(GUI_SCAN)
-		menu(menuAlarmSevr)
-		interest(1)
-	}
-	field(LCNT,DBF_UCHAR) {
-		prompt("Lock Count")
-		special(SPC_NOMOD)
-		interest(2)
-	}
-	field(PACT,DBF_UCHAR) {
-		prompt("Record active")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(PUTF,DBF_UCHAR) {
-		prompt("dbPutField process")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(RPRO,DBF_UCHAR) {
-		prompt("Reprocess ")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(ASP,DBF_NOACCESS) {
-		prompt("Access Security Pvt")
-		special(SPC_NOMOD)
-		extra("struct asgMember *asp")
-		interest(4)
-	}
-	field(PPN,DBF_NOACCESS) {
-		prompt("addr of PUTNOTIFY")
-		special(SPC_NOMOD)
-		extra("struct putNotify *ppn")
-		interest(4)
-	}
-	field(PPNR,DBF_NOACCESS) {
-		prompt("pputNotifyRecord")
-		special(SPC_NOMOD)
-		extra("struct putNotifyRecord *ppnr")
-		interest(4)
-	}
-	field(SPVT,DBF_NOACCESS) {
-		prompt("Scan Private")
-		special(SPC_NOMOD)
-		extra("struct scan_element *spvt")
-		interest(4)
-	}
-	field(RSET,DBF_NOACCESS) {
-		prompt("Address of RSET")
-		special(SPC_NOMOD)
-		extra("struct rset	*rset")
-		interest(4)
-	}
-	field(DSET,DBF_NOACCESS) {
-		prompt("DSET address")
-		special(SPC_NOMOD)
-		extra("struct dset	*dset")
-		interest(4)
-	}
-	field(DPVT,DBF_NOACCESS) {
-		prompt("Device Private")
-		special(SPC_NOMOD)
-		extra("void		*dpvt")
-		interest(4)
-	}
-	field(RDES,DBF_NOACCESS) {
-		prompt("Address of dbRecordType")
-		special(SPC_NOMOD)
-		extra("struct dbRecordType *rdes")
-		interest(4)
-	}
-	field(LSET,DBF_NOACCESS) {
-		prompt("Lock Set")
-		special(SPC_NOMOD)
-		extra("struct lockRecord *lset")
-		interest(4)
-	}
-	field(PRIO,DBF_MENU) {
-		prompt("Scheduling Priority")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuPriority)
-		interest(1)
-	}
-	field(TPRO,DBF_UCHAR) {
-		prompt("Trace Processing")
-	}
-	field(BKPT,DBF_NOACCESS) {
-		prompt("Break Point")
-		special(SPC_NOMOD)
-		extra("char bkpt")
-		interest(1)
-	}
-	field(UDF,DBF_UCHAR) {
-		prompt("Undefined")
-		initial("1")
-		promptgroup(GUI_COMMON)
-		pp(TRUE)
-		interest(1)
-	}
-	field(TIME,DBF_NOACCESS) {
-		prompt("Time")
-		special(SPC_NOMOD)
-		extra("epicsTimeStamp	time")
-		interest(2)
-	}
-	field(FLNK,DBF_FWDLINK) {
-		prompt("Forward Process Link")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(VAL,DBF_LONG) {
-		prompt("Current value")
-		promptgroup(GUI_INPUTS)
-		pp(TRUE)
-		asl(ASL0)
-	}
-	field(INP,DBF_INLINK) {
-		prompt("Input Specification")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(EGU,DBF_STRING) {
-		prompt("Units name")
-		promptgroup(GUI_DISPLAY)
-		size(16)
-		interest(1)
-	}
-	field(HOPR,DBF_LONG) {
-		prompt("High Operating Range")
-		promptgroup(GUI_DISPLAY)
-		interest(1)
-	}
-	field(LOPR,DBF_LONG) {
-		prompt("Low Operating Range")
-		promptgroup(GUI_DISPLAY)
-		interest(1)
-	}
-	field(HIHI,DBF_LONG) {
-		prompt("Hihi Alarm Limit")
-		promptgroup(GUI_ALARMS)
-		pp(TRUE)
-		interest(1)
-	}
-	field(LOLO,DBF_LONG) {
-		prompt("Lolo Alarm Limit")
-		promptgroup(GUI_ALARMS)
-		pp(TRUE)
-		interest(1)
-	}
-	field(HIGH,DBF_LONG) {
-		prompt("High Alarm Limit")
-		promptgroup(GUI_ALARMS)
-		pp(TRUE)
-		interest(1)
-	}
-	field(LOW,DBF_LONG) {
-		prompt("Low Alarm Limit")
-		promptgroup(GUI_ALARMS)
-		pp(TRUE)
-		interest(1)
-	}
-	field(HHSV,DBF_MENU) {
-		prompt("Hihi Severity")
-		promptgroup(GUI_ALARMS)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(LLSV,DBF_MENU) {
-		prompt("Lolo Severity")
-		promptgroup(GUI_ALARMS)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(HSV,DBF_MENU) {
-		prompt("High Severity")
-		promptgroup(GUI_ALARMS)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(LSV,DBF_MENU) {
-		prompt("Low Severity")
-		promptgroup(GUI_ALARMS)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(HYST,DBF_LONG) {
-		prompt("Alarm Deadband")
-		promptgroup(GUI_ALARMS)
-		interest(1)
-	}
-	field(ADEL,DBF_LONG) {
-		prompt("Archive Deadband")
-		promptgroup(GUI_DISPLAY)
-		interest(1)
-	}
-	field(MDEL,DBF_LONG) {
-		prompt("Monitor Deadband")
-		promptgroup(GUI_DISPLAY)
-		interest(1)
-	}
-	field(LALM,DBF_LONG) {
-		prompt("Last Value Alarmed")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(ALST,DBF_LONG) {
-		prompt("Last Value Archived")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(MLST,DBF_LONG) {
-		prompt("Last Val Monitored")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(SIOL,DBF_INLINK) {
-		prompt("Sim Input Specifctn")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(SVAL,DBF_LONG) {
-		prompt("Simulation Value")
-	}
-	field(SIML,DBF_INLINK) {
-		prompt("Sim Mode Location")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(SIMM,DBF_MENU) {
-		prompt("Simulation Mode")
-		menu(menuYesNo)
-		interest(1)
-	}
-	field(SIMS,DBF_MENU) {
-		prompt("Sim mode Alarm Svrty")
-		promptgroup(GUI_INPUTS)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-}
-recordtype(longout) {
-	field(NAME,DBF_STRING) {
-		prompt("Record Name")
-		special(SPC_NOMOD)
-		size(61)
-	}
-	field(DESC,DBF_STRING) {
-		prompt("Descriptor")
-		promptgroup(GUI_COMMON)
-		size(41)
-	}
-	field(ASG,DBF_STRING) {
-		prompt("Access Security Group")
-		promptgroup(GUI_COMMON)
-		special(SPC_AS)
-		size(29)
-	}
-	field(SCAN,DBF_MENU) {
-		prompt("Scan Mechanism")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuScan)
-		interest(1)
-	}
-	field(PINI,DBF_MENU) {
-		prompt("Process at iocInit")
-		promptgroup(GUI_SCAN)
-		menu(menuPini)
-		interest(1)
-	}
-	field(PHAS,DBF_SHORT) {
-		prompt("Scan Phase")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(EVNT,DBF_SHORT) {
-		prompt("Event Number")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(TSE,DBF_SHORT) {
-		prompt("Time Stamp Event")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(TSEL,DBF_INLINK) {
-		prompt("Time Stamp Link")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(DTYP,DBF_DEVICE) {
-		prompt("Device Type")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(DISV,DBF_SHORT) {
-		prompt("Disable Value")
-		initial("1")
-		promptgroup(GUI_SCAN)
-	}
-	field(DISA,DBF_SHORT) {
-		prompt("Disable")
-	}
-	field(SDIS,DBF_INLINK) {
-		prompt("Scanning Disable")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(MLOK,DBF_NOACCESS) {
-		prompt("Monitor lock")
-		special(SPC_NOMOD)
-		extra("epicsMutexId	mlok")
-		interest(4)
-	}
-	field(MLIS,DBF_NOACCESS) {
-		prompt("Monitor List")
-		special(SPC_NOMOD)
-		extra("ELLLIST		mlis")
-		interest(4)
-	}
-	field(DISP,DBF_UCHAR) {
-		prompt("Disable putField")
-	}
-	field(PROC,DBF_UCHAR) {
-		prompt("Force Processing")
-		pp(TRUE)
-		interest(3)
-	}
-	field(STAT,DBF_MENU) {
-		prompt("Alarm Status")
-		initial("UDF")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-	}
-	field(SEVR,DBF_MENU) {
-		prompt("Alarm Severity")
-		initial("INVALID")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-	}
-	field(NSTA,DBF_MENU) {
-		prompt("New Alarm Status")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-		interest(2)
-	}
-	field(NSEV,DBF_MENU) {
-		prompt("New Alarm Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKS,DBF_MENU) {
-		prompt("Alarm Ack Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKT,DBF_MENU) {
-		prompt("Alarm Ack Transient")
-		initial("YES")
-		promptgroup(GUI_ALARMS)
-		special(SPC_NOMOD)
-		menu(menuYesNo)
-		interest(2)
-	}
-	field(DISS,DBF_MENU) {
-		prompt("Disable Alarm Sevrty")
-		promptgroup(GUI_SCAN)
-		menu(menuAlarmSevr)
-		interest(1)
-	}
-	field(LCNT,DBF_UCHAR) {
-		prompt("Lock Count")
-		special(SPC_NOMOD)
-		interest(2)
-	}
-	field(PACT,DBF_UCHAR) {
-		prompt("Record active")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(PUTF,DBF_UCHAR) {
-		prompt("dbPutField process")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(RPRO,DBF_UCHAR) {
-		prompt("Reprocess ")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(ASP,DBF_NOACCESS) {
-		prompt("Access Security Pvt")
-		special(SPC_NOMOD)
-		extra("struct asgMember *asp")
-		interest(4)
-	}
-	field(PPN,DBF_NOACCESS) {
-		prompt("addr of PUTNOTIFY")
-		special(SPC_NOMOD)
-		extra("struct putNotify *ppn")
-		interest(4)
-	}
-	field(PPNR,DBF_NOACCESS) {
-		prompt("pputNotifyRecord")
-		special(SPC_NOMOD)
-		extra("struct putNotifyRecord *ppnr")
-		interest(4)
-	}
-	field(SPVT,DBF_NOACCESS) {
-		prompt("Scan Private")
-		special(SPC_NOMOD)
-		extra("struct scan_element *spvt")
-		interest(4)
-	}
-	field(RSET,DBF_NOACCESS) {
-		prompt("Address of RSET")
-		special(SPC_NOMOD)
-		extra("struct rset	*rset")
-		interest(4)
-	}
-	field(DSET,DBF_NOACCESS) {
-		prompt("DSET address")
-		special(SPC_NOMOD)
-		extra("struct dset	*dset")
-		interest(4)
-	}
-	field(DPVT,DBF_NOACCESS) {
-		prompt("Device Private")
-		special(SPC_NOMOD)
-		extra("void		*dpvt")
-		interest(4)
-	}
-	field(RDES,DBF_NOACCESS) {
-		prompt("Address of dbRecordType")
-		special(SPC_NOMOD)
-		extra("struct dbRecordType *rdes")
-		interest(4)
-	}
-	field(LSET,DBF_NOACCESS) {
-		prompt("Lock Set")
-		special(SPC_NOMOD)
-		extra("struct lockRecord *lset")
-		interest(4)
-	}
-	field(PRIO,DBF_MENU) {
-		prompt("Scheduling Priority")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuPriority)
-		interest(1)
-	}
-	field(TPRO,DBF_UCHAR) {
-		prompt("Trace Processing")
-	}
-	field(BKPT,DBF_NOACCESS) {
-		prompt("Break Point")
-		special(SPC_NOMOD)
-		extra("char bkpt")
-		interest(1)
-	}
-	field(UDF,DBF_UCHAR) {
-		prompt("Undefined")
-		initial("1")
-		promptgroup(GUI_COMMON)
-		pp(TRUE)
-		interest(1)
-	}
-	field(TIME,DBF_NOACCESS) {
-		prompt("Time")
-		special(SPC_NOMOD)
-		extra("epicsTimeStamp	time")
-		interest(2)
-	}
-	field(FLNK,DBF_FWDLINK) {
-		prompt("Forward Process Link")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(VAL,DBF_LONG) {
-		prompt("Desired Output")
-		promptgroup(GUI_OUTPUT)
-		pp(TRUE)
-		asl(ASL0)
-	}
-	field(OUT,DBF_OUTLINK) {
-		prompt("Output Specification")
-		promptgroup(GUI_OUTPUT)
-		interest(1)
-	}
-	field(DOL,DBF_INLINK) {
-		prompt("Desired Output Loc")
-		promptgroup(GUI_OUTPUT)
-		interest(1)
-	}
-	field(OMSL,DBF_MENU) {
-		prompt("Output Mode Select")
-		promptgroup(GUI_OUTPUT)
-		menu(menuOmsl)
-		interest(1)
-	}
-	field(EGU,DBF_STRING) {
-		prompt("Units name")
-		promptgroup(GUI_DISPLAY)
-		size(16)
-		interest(1)
-	}
-	field(DRVH,DBF_LONG) {
-		prompt("Drive High Limit")
-		promptgroup(GUI_OUTPUT)
-		pp(TRUE)
-		interest(1)
-	}
-	field(DRVL,DBF_LONG) {
-		prompt("Drive Low Limit")
-		promptgroup(GUI_OUTPUT)
-		pp(TRUE)
-		interest(1)
-	}
-	field(HOPR,DBF_LONG) {
-		prompt("High Operating Range")
-		promptgroup(GUI_DISPLAY)
-		interest(1)
-	}
-	field(LOPR,DBF_LONG) {
-		prompt("Low Operating Range")
-		promptgroup(GUI_DISPLAY)
-		interest(1)
-	}
-	field(HIHI,DBF_LONG) {
-		prompt("Hihi Alarm Limit")
-		promptgroup(GUI_ALARMS)
-		pp(TRUE)
-		interest(1)
-	}
-	field(LOLO,DBF_LONG) {
-		prompt("Lolo Alarm Limit")
-		promptgroup(GUI_ALARMS)
-		pp(TRUE)
-		interest(1)
-	}
-	field(HIGH,DBF_LONG) {
-		prompt("High Alarm Limit")
-		promptgroup(GUI_ALARMS)
-		pp(TRUE)
-		interest(1)
-	}
-	field(LOW,DBF_LONG) {
-		prompt("Low Alarm Limit")
-		promptgroup(GUI_ALARMS)
-		pp(TRUE)
-		interest(1)
-	}
-	field(HHSV,DBF_MENU) {
-		prompt("Hihi Severity")
-		promptgroup(GUI_ALARMS)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(LLSV,DBF_MENU) {
-		prompt("Lolo Severity")
-		promptgroup(GUI_ALARMS)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(HSV,DBF_MENU) {
-		prompt("High Severity")
-		promptgroup(GUI_ALARMS)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(LSV,DBF_MENU) {
-		prompt("Low Severity")
-		promptgroup(GUI_ALARMS)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(HYST,DBF_LONG) {
-		prompt("Alarm Deadband")
-		promptgroup(GUI_ALARMS)
-		interest(1)
-	}
-	field(ADEL,DBF_LONG) {
-		prompt("Archive Deadband")
-		promptgroup(GUI_DISPLAY)
-		interest(1)
-	}
-	field(MDEL,DBF_LONG) {
-		prompt("Monitor Deadband")
-		promptgroup(GUI_DISPLAY)
-		interest(1)
-	}
-	field(LALM,DBF_LONG) {
-		prompt("Last Value Alarmed")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(ALST,DBF_LONG) {
-		prompt("Last Value Archived")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(MLST,DBF_LONG) {
-		prompt("Last Val Monitored")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(SIOL,DBF_OUTLINK) {
-		prompt("Sim Output Specifctn")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(SIML,DBF_INLINK) {
-		prompt("Sim Mode Location")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(SIMM,DBF_MENU) {
-		prompt("Simulation Mode")
-		menu(menuYesNo)
-		interest(1)
-	}
-	field(SIMS,DBF_MENU) {
-		prompt("Sim mode Alarm Svrty")
-		promptgroup(GUI_INPUTS)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(IVOA,DBF_MENU) {
-		prompt("INVALID output action")
-		promptgroup(GUI_OUTPUT)
-		menu(menuIvoa)
-		interest(2)
-	}
-	field(IVOV,DBF_LONG) {
-		prompt("INVALID output value")
-		promptgroup(GUI_OUTPUT)
-		interest(2)
-	}
-}
-recordtype(mbbi) {
-	field(NAME,DBF_STRING) {
-		prompt("Record Name")
-		special(SPC_NOMOD)
-		size(61)
-	}
-	field(DESC,DBF_STRING) {
-		prompt("Descriptor")
-		promptgroup(GUI_COMMON)
-		size(41)
-	}
-	field(ASG,DBF_STRING) {
-		prompt("Access Security Group")
-		promptgroup(GUI_COMMON)
-		special(SPC_AS)
-		size(29)
-	}
-	field(SCAN,DBF_MENU) {
-		prompt("Scan Mechanism")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuScan)
-		interest(1)
-	}
-	field(PINI,DBF_MENU) {
-		prompt("Process at iocInit")
-		promptgroup(GUI_SCAN)
-		menu(menuPini)
-		interest(1)
-	}
-	field(PHAS,DBF_SHORT) {
-		prompt("Scan Phase")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(EVNT,DBF_SHORT) {
-		prompt("Event Number")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(TSE,DBF_SHORT) {
-		prompt("Time Stamp Event")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(TSEL,DBF_INLINK) {
-		prompt("Time Stamp Link")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(DTYP,DBF_DEVICE) {
-		prompt("Device Type")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(DISV,DBF_SHORT) {
-		prompt("Disable Value")
-		initial("1")
-		promptgroup(GUI_SCAN)
-	}
-	field(DISA,DBF_SHORT) {
-		prompt("Disable")
-	}
-	field(SDIS,DBF_INLINK) {
-		prompt("Scanning Disable")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(MLOK,DBF_NOACCESS) {
-		prompt("Monitor lock")
-		special(SPC_NOMOD)
-		extra("epicsMutexId	mlok")
-		interest(4)
-	}
-	field(MLIS,DBF_NOACCESS) {
-		prompt("Monitor List")
-		special(SPC_NOMOD)
-		extra("ELLLIST		mlis")
-		interest(4)
-	}
-	field(DISP,DBF_UCHAR) {
-		prompt("Disable putField")
-	}
-	field(PROC,DBF_UCHAR) {
-		prompt("Force Processing")
-		pp(TRUE)
-		interest(3)
-	}
-	field(STAT,DBF_MENU) {
-		prompt("Alarm Status")
-		initial("UDF")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-	}
-	field(SEVR,DBF_MENU) {
-		prompt("Alarm Severity")
-		initial("INVALID")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-	}
-	field(NSTA,DBF_MENU) {
-		prompt("New Alarm Status")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-		interest(2)
-	}
-	field(NSEV,DBF_MENU) {
-		prompt("New Alarm Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKS,DBF_MENU) {
-		prompt("Alarm Ack Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKT,DBF_MENU) {
-		prompt("Alarm Ack Transient")
-		initial("YES")
-		promptgroup(GUI_ALARMS)
-		special(SPC_NOMOD)
-		menu(menuYesNo)
-		interest(2)
-	}
-	field(DISS,DBF_MENU) {
-		prompt("Disable Alarm Sevrty")
-		promptgroup(GUI_SCAN)
-		menu(menuAlarmSevr)
-		interest(1)
-	}
-	field(LCNT,DBF_UCHAR) {
-		prompt("Lock Count")
-		special(SPC_NOMOD)
-		interest(2)
-	}
-	field(PACT,DBF_UCHAR) {
-		prompt("Record active")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(PUTF,DBF_UCHAR) {
-		prompt("dbPutField process")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(RPRO,DBF_UCHAR) {
-		prompt("Reprocess ")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(ASP,DBF_NOACCESS) {
-		prompt("Access Security Pvt")
-		special(SPC_NOMOD)
-		extra("struct asgMember *asp")
-		interest(4)
-	}
-	field(PPN,DBF_NOACCESS) {
-		prompt("addr of PUTNOTIFY")
-		special(SPC_NOMOD)
-		extra("struct putNotify *ppn")
-		interest(4)
-	}
-	field(PPNR,DBF_NOACCESS) {
-		prompt("pputNotifyRecord")
-		special(SPC_NOMOD)
-		extra("struct putNotifyRecord *ppnr")
-		interest(4)
-	}
-	field(SPVT,DBF_NOACCESS) {
-		prompt("Scan Private")
-		special(SPC_NOMOD)
-		extra("struct scan_element *spvt")
-		interest(4)
-	}
-	field(RSET,DBF_NOACCESS) {
-		prompt("Address of RSET")
-		special(SPC_NOMOD)
-		extra("struct rset	*rset")
-		interest(4)
-	}
-	field(DSET,DBF_NOACCESS) {
-		prompt("DSET address")
-		special(SPC_NOMOD)
-		extra("struct dset	*dset")
-		interest(4)
-	}
-	field(DPVT,DBF_NOACCESS) {
-		prompt("Device Private")
-		special(SPC_NOMOD)
-		extra("void		*dpvt")
-		interest(4)
-	}
-	field(RDES,DBF_NOACCESS) {
-		prompt("Address of dbRecordType")
-		special(SPC_NOMOD)
-		extra("struct dbRecordType *rdes")
-		interest(4)
-	}
-	field(LSET,DBF_NOACCESS) {
-		prompt("Lock Set")
-		special(SPC_NOMOD)
-		extra("struct lockRecord *lset")
-		interest(4)
-	}
-	field(PRIO,DBF_MENU) {
-		prompt("Scheduling Priority")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuPriority)
-		interest(1)
-	}
-	field(TPRO,DBF_UCHAR) {
-		prompt("Trace Processing")
-	}
-	field(BKPT,DBF_NOACCESS) {
-		prompt("Break Point")
-		special(SPC_NOMOD)
-		extra("char bkpt")
-		interest(1)
-	}
-	field(UDF,DBF_UCHAR) {
-		prompt("Undefined")
-		initial("1")
-		promptgroup(GUI_COMMON)
-		pp(TRUE)
-		interest(1)
-	}
-	field(TIME,DBF_NOACCESS) {
-		prompt("Time")
-		special(SPC_NOMOD)
-		extra("epicsTimeStamp	time")
-		interest(2)
-	}
-	field(FLNK,DBF_FWDLINK) {
-		prompt("Forward Process Link")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(VAL,DBF_ENUM) {
-		prompt("Current Value")
-		promptgroup(GUI_INPUTS)
-		pp(TRUE)
-		asl(ASL0)
-	}
-	field(NOBT,DBF_SHORT) {
-		prompt("Number of Bits")
-		promptgroup(GUI_MBB)
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(INP,DBF_INLINK) {
-		prompt("Input Specification")
-		promptgroup(GUI_MBB)
-		interest(1)
-	}
-	field(ZRVL,DBF_ULONG) {
-		prompt("Zero Value")
-		promptgroup(GUI_BITS1)
-		special(100)
-		pp(TRUE)
-		base(HEX)
-		interest(1)
-	}
-	field(ONVL,DBF_ULONG) {
-		prompt("One Value")
-		promptgroup(GUI_BITS1)
-		special(100)
-		pp(TRUE)
-		base(HEX)
-		interest(1)
-	}
-	field(TWVL,DBF_ULONG) {
-		prompt("Two Value")
-		promptgroup(GUI_BITS1)
-		special(100)
-		pp(TRUE)
-		base(HEX)
-		interest(1)
-	}
-	field(THVL,DBF_ULONG) {
-		prompt("Three Value")
-		promptgroup(GUI_BITS1)
-		special(100)
-		pp(TRUE)
-		base(HEX)
-		interest(1)
-	}
-	field(FRVL,DBF_ULONG) {
-		prompt("Four Value")
-		promptgroup(GUI_BITS1)
-		special(100)
-		pp(TRUE)
-		base(HEX)
-		interest(1)
-	}
-	field(FVVL,DBF_ULONG) {
-		prompt("Five Value")
-		promptgroup(GUI_BITS1)
-		special(100)
-		pp(TRUE)
-		base(HEX)
-		interest(1)
-	}
-	field(SXVL,DBF_ULONG) {
-		prompt("Six Value")
-		promptgroup(GUI_BITS1)
-		special(100)
-		pp(TRUE)
-		base(HEX)
-		interest(1)
-	}
-	field(SVVL,DBF_ULONG) {
-		prompt("Seven Value")
-		promptgroup(GUI_BITS1)
-		special(100)
-		pp(TRUE)
-		base(HEX)
-		interest(1)
-	}
-	field(EIVL,DBF_ULONG) {
-		prompt("Eight Value")
-		promptgroup(GUI_BITS2)
-		special(100)
-		pp(TRUE)
-		base(HEX)
-		interest(1)
-	}
-	field(NIVL,DBF_ULONG) {
-		prompt("Nine Value")
-		promptgroup(GUI_BITS2)
-		special(100)
-		pp(TRUE)
-		base(HEX)
-		interest(1)
-	}
-	field(TEVL,DBF_ULONG) {
-		prompt("Ten Value")
-		promptgroup(GUI_BITS2)
-		special(100)
-		pp(TRUE)
-		base(HEX)
-		interest(1)
-	}
-	field(ELVL,DBF_ULONG) {
-		prompt("Eleven Value")
-		promptgroup(GUI_BITS2)
-		special(100)
-		pp(TRUE)
-		base(HEX)
-		interest(1)
-	}
-	field(TVVL,DBF_ULONG) {
-		prompt("Twelve Value")
-		promptgroup(GUI_BITS2)
-		special(100)
-		pp(TRUE)
-		base(HEX)
-		interest(1)
-	}
-	field(TTVL,DBF_ULONG) {
-		prompt("Thirteen Value")
-		promptgroup(GUI_BITS2)
-		special(100)
-		pp(TRUE)
-		base(HEX)
-		interest(1)
-	}
-	field(FTVL,DBF_ULONG) {
-		prompt("Fourteen Value")
-		promptgroup(GUI_BITS2)
-		special(100)
-		pp(TRUE)
-		base(HEX)
-		interest(1)
-	}
-	field(FFVL,DBF_ULONG) {
-		prompt("Fifteen Value")
-		promptgroup(GUI_BITS2)
-		special(100)
-		pp(TRUE)
-		base(HEX)
-		interest(1)
-	}
-	field(ZRST,DBF_STRING) {
-		prompt("Zero String")
-		promptgroup(GUI_BITS1)
-		special(100)
-		size(26)
-		pp(TRUE)
-		interest(1)
-	}
-	field(ONST,DBF_STRING) {
-		prompt("One String")
-		promptgroup(GUI_BITS1)
-		special(100)
-		size(26)
-		pp(TRUE)
-		interest(1)
-	}
-	field(TWST,DBF_STRING) {
-		prompt("Two String")
-		promptgroup(GUI_BITS1)
-		special(100)
-		size(26)
-		pp(TRUE)
-		interest(1)
-	}
-	field(THST,DBF_STRING) {
-		prompt("Three String")
-		promptgroup(GUI_BITS1)
-		special(100)
-		size(26)
-		pp(TRUE)
-		interest(1)
-	}
-	field(FRST,DBF_STRING) {
-		prompt("Four String")
-		promptgroup(GUI_BITS1)
-		special(100)
-		size(26)
-		pp(TRUE)
-		interest(1)
-	}
-	field(FVST,DBF_STRING) {
-		prompt("Five String")
-		promptgroup(GUI_BITS1)
-		special(100)
-		size(26)
-		pp(TRUE)
-		interest(1)
-	}
-	field(SXST,DBF_STRING) {
-		prompt("Six String")
-		promptgroup(GUI_BITS1)
-		special(100)
-		size(26)
-		pp(TRUE)
-		interest(1)
-	}
-	field(SVST,DBF_STRING) {
-		prompt("Seven String")
-		promptgroup(GUI_BITS1)
-		special(100)
-		size(26)
-		pp(TRUE)
-		interest(1)
-	}
-	field(EIST,DBF_STRING) {
-		prompt("Eight String")
-		promptgroup(GUI_BITS2)
-		special(100)
-		size(26)
-		pp(TRUE)
-		interest(1)
-	}
-	field(NIST,DBF_STRING) {
-		prompt("Nine String")
-		promptgroup(GUI_BITS2)
-		special(100)
-		size(26)
-		pp(TRUE)
-		interest(1)
-	}
-	field(TEST,DBF_STRING) {
-		prompt("Ten String")
-		promptgroup(GUI_BITS2)
-		special(100)
-		size(26)
-		pp(TRUE)
-		interest(1)
-	}
-	field(ELST,DBF_STRING) {
-		prompt("Eleven String")
-		promptgroup(GUI_BITS2)
-		special(100)
-		size(26)
-		pp(TRUE)
-		interest(1)
-	}
-	field(TVST,DBF_STRING) {
-		prompt("Twelve String")
-		promptgroup(GUI_BITS2)
-		special(100)
-		size(26)
-		pp(TRUE)
-		interest(1)
-	}
-	field(TTST,DBF_STRING) {
-		prompt("Thirteen String")
-		promptgroup(GUI_BITS2)
-		special(100)
-		size(26)
-		pp(TRUE)
-		interest(1)
-	}
-	field(FTST,DBF_STRING) {
-		prompt("Fourteen String")
-		promptgroup(GUI_BITS2)
-		special(100)
-		size(26)
-		pp(TRUE)
-		interest(1)
-	}
-	field(FFST,DBF_STRING) {
-		prompt("Fifteen String")
-		promptgroup(GUI_BITS2)
-		special(100)
-		size(26)
-		pp(TRUE)
-		interest(1)
-	}
-	field(ZRSV,DBF_MENU) {
-		prompt("State Zero Severity")
-		promptgroup(GUI_BITS1)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(ONSV,DBF_MENU) {
-		prompt("State One Severity")
-		promptgroup(GUI_BITS1)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(TWSV,DBF_MENU) {
-		prompt("State Two Severity")
-		promptgroup(GUI_BITS1)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(THSV,DBF_MENU) {
-		prompt("State Three Severity")
-		promptgroup(GUI_BITS1)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(FRSV,DBF_MENU) {
-		prompt("State Four Severity")
-		promptgroup(GUI_BITS1)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(FVSV,DBF_MENU) {
-		prompt("State Five Severity")
-		promptgroup(GUI_BITS1)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(SXSV,DBF_MENU) {
-		prompt("State Six Severity")
-		promptgroup(GUI_BITS1)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(SVSV,DBF_MENU) {
-		prompt("State Seven Severity")
-		promptgroup(GUI_BITS1)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(EISV,DBF_MENU) {
-		prompt("State Eight Severity")
-		promptgroup(GUI_BITS2)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(NISV,DBF_MENU) {
-		prompt("State Nine Severity")
-		promptgroup(GUI_BITS2)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(TESV,DBF_MENU) {
-		prompt("State Ten Severity")
-		promptgroup(GUI_BITS2)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(ELSV,DBF_MENU) {
-		prompt("State Eleven Severity")
-		promptgroup(GUI_BITS2)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(TVSV,DBF_MENU) {
-		prompt("State Twelve Severity")
-		promptgroup(GUI_BITS2)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(TTSV,DBF_MENU) {
-		prompt("State Thirteen Sevr")
-		promptgroup(GUI_BITS2)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(FTSV,DBF_MENU) {
-		prompt("State Fourteen Sevr")
-		promptgroup(GUI_BITS2)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(FFSV,DBF_MENU) {
-		prompt("State Fifteen Severity")
-		promptgroup(GUI_BITS2)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(UNSV,DBF_MENU) {
-		prompt("Unknown State Severity")
-		promptgroup(GUI_MBB)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(COSV,DBF_MENU) {
-		prompt("Change of State Svr")
-		promptgroup(GUI_MBB)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(RVAL,DBF_ULONG) {
-		prompt("Raw Value")
-		pp(TRUE)
-	}
-	field(ORAW,DBF_ULONG) {
-		prompt("Prev Raw Value")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(MASK,DBF_ULONG) {
-		prompt("Hardware Mask")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(MLST,DBF_USHORT) {
-		prompt("Last Value Monitored")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(LALM,DBF_USHORT) {
-		prompt("Last Value Alarmed")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(SDEF,DBF_SHORT) {
-		prompt("States Defined")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(SHFT,DBF_USHORT) {
-		prompt("Shift")
-		promptgroup(GUI_MBB)
-		interest(1)
-	}
-	field(SIOL,DBF_INLINK) {
-		prompt("Sim Input Specifctn")
-		promptgroup(GUI_MBB)
-		interest(1)
-	}
-	field(SVAL,DBF_ULONG) {
-		prompt("Simulation Value")
-	}
-	field(SIML,DBF_INLINK) {
-		prompt("Sim Mode Location")
-		promptgroup(GUI_MBB)
-		interest(1)
-	}
-	field(SIMM,DBF_MENU) {
-		prompt("Simulation Mode")
-		menu(menuSimm)
-		interest(1)
-	}
-	field(SIMS,DBF_MENU) {
-		prompt("Sim mode Alarm Svrty")
-		promptgroup(GUI_MBB)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-}
-recordtype(mbbiDirect) {
-	field(NAME,DBF_STRING) {
-		prompt("Record Name")
-		special(SPC_NOMOD)
-		size(61)
-	}
-	field(DESC,DBF_STRING) {
-		prompt("Descriptor")
-		promptgroup(GUI_COMMON)
-		size(41)
-	}
-	field(ASG,DBF_STRING) {
-		prompt("Access Security Group")
-		promptgroup(GUI_COMMON)
-		special(SPC_AS)
-		size(29)
-	}
-	field(SCAN,DBF_MENU) {
-		prompt("Scan Mechanism")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuScan)
-		interest(1)
-	}
-	field(PINI,DBF_MENU) {
-		prompt("Process at iocInit")
-		promptgroup(GUI_SCAN)
-		menu(menuPini)
-		interest(1)
-	}
-	field(PHAS,DBF_SHORT) {
-		prompt("Scan Phase")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(EVNT,DBF_SHORT) {
-		prompt("Event Number")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(TSE,DBF_SHORT) {
-		prompt("Time Stamp Event")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(TSEL,DBF_INLINK) {
-		prompt("Time Stamp Link")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(DTYP,DBF_DEVICE) {
-		prompt("Device Type")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(DISV,DBF_SHORT) {
-		prompt("Disable Value")
-		initial("1")
-		promptgroup(GUI_SCAN)
-	}
-	field(DISA,DBF_SHORT) {
-		prompt("Disable")
-	}
-	field(SDIS,DBF_INLINK) {
-		prompt("Scanning Disable")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(MLOK,DBF_NOACCESS) {
-		prompt("Monitor lock")
-		special(SPC_NOMOD)
-		extra("epicsMutexId	mlok")
-		interest(4)
-	}
-	field(MLIS,DBF_NOACCESS) {
-		prompt("Monitor List")
-		special(SPC_NOMOD)
-		extra("ELLLIST		mlis")
-		interest(4)
-	}
-	field(DISP,DBF_UCHAR) {
-		prompt("Disable putField")
-	}
-	field(PROC,DBF_UCHAR) {
-		prompt("Force Processing")
-		pp(TRUE)
-		interest(3)
-	}
-	field(STAT,DBF_MENU) {
-		prompt("Alarm Status")
-		initial("UDF")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-	}
-	field(SEVR,DBF_MENU) {
-		prompt("Alarm Severity")
-		initial("INVALID")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-	}
-	field(NSTA,DBF_MENU) {
-		prompt("New Alarm Status")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-		interest(2)
-	}
-	field(NSEV,DBF_MENU) {
-		prompt("New Alarm Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKS,DBF_MENU) {
-		prompt("Alarm Ack Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKT,DBF_MENU) {
-		prompt("Alarm Ack Transient")
-		initial("YES")
-		promptgroup(GUI_ALARMS)
-		special(SPC_NOMOD)
-		menu(menuYesNo)
-		interest(2)
-	}
-	field(DISS,DBF_MENU) {
-		prompt("Disable Alarm Sevrty")
-		promptgroup(GUI_SCAN)
-		menu(menuAlarmSevr)
-		interest(1)
-	}
-	field(LCNT,DBF_UCHAR) {
-		prompt("Lock Count")
-		special(SPC_NOMOD)
-		interest(2)
-	}
-	field(PACT,DBF_UCHAR) {
-		prompt("Record active")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(PUTF,DBF_UCHAR) {
-		prompt("dbPutField process")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(RPRO,DBF_UCHAR) {
-		prompt("Reprocess ")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(ASP,DBF_NOACCESS) {
-		prompt("Access Security Pvt")
-		special(SPC_NOMOD)
-		extra("struct asgMember *asp")
-		interest(4)
-	}
-	field(PPN,DBF_NOACCESS) {
-		prompt("addr of PUTNOTIFY")
-		special(SPC_NOMOD)
-		extra("struct putNotify *ppn")
-		interest(4)
-	}
-	field(PPNR,DBF_NOACCESS) {
-		prompt("pputNotifyRecord")
-		special(SPC_NOMOD)
-		extra("struct putNotifyRecord *ppnr")
-		interest(4)
-	}
-	field(SPVT,DBF_NOACCESS) {
-		prompt("Scan Private")
-		special(SPC_NOMOD)
-		extra("struct scan_element *spvt")
-		interest(4)
-	}
-	field(RSET,DBF_NOACCESS) {
-		prompt("Address of RSET")
-		special(SPC_NOMOD)
-		extra("struct rset	*rset")
-		interest(4)
-	}
-	field(DSET,DBF_NOACCESS) {
-		prompt("DSET address")
-		special(SPC_NOMOD)
-		extra("struct dset	*dset")
-		interest(4)
-	}
-	field(DPVT,DBF_NOACCESS) {
-		prompt("Device Private")
-		special(SPC_NOMOD)
-		extra("void		*dpvt")
-		interest(4)
-	}
-	field(RDES,DBF_NOACCESS) {
-		prompt("Address of dbRecordType")
-		special(SPC_NOMOD)
-		extra("struct dbRecordType *rdes")
-		interest(4)
-	}
-	field(LSET,DBF_NOACCESS) {
-		prompt("Lock Set")
-		special(SPC_NOMOD)
-		extra("struct lockRecord *lset")
-		interest(4)
-	}
-	field(PRIO,DBF_MENU) {
-		prompt("Scheduling Priority")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuPriority)
-		interest(1)
-	}
-	field(TPRO,DBF_UCHAR) {
-		prompt("Trace Processing")
-	}
-	field(BKPT,DBF_NOACCESS) {
-		prompt("Break Point")
-		special(SPC_NOMOD)
-		extra("char bkpt")
-		interest(1)
-	}
-	field(UDF,DBF_UCHAR) {
-		prompt("Undefined")
-		initial("1")
-		promptgroup(GUI_COMMON)
-		pp(TRUE)
-		interest(1)
-	}
-	field(TIME,DBF_NOACCESS) {
-		prompt("Time")
-		special(SPC_NOMOD)
-		extra("epicsTimeStamp	time")
-		interest(2)
-	}
-	field(FLNK,DBF_FWDLINK) {
-		prompt("Forward Process Link")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(VAL,DBF_USHORT) {
-		prompt("Current Value")
-		promptgroup(GUI_INPUTS)
-		pp(TRUE)
-		asl(ASL0)
-	}
-	field(NOBT,DBF_SHORT) {
-		prompt("Number of Bits")
-		promptgroup(GUI_MBB)
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(INP,DBF_INLINK) {
-		prompt("Input Specification")
-		promptgroup(GUI_MBB)
-		interest(1)
-	}
-	field(RVAL,DBF_ULONG) {
-		prompt("Raw Value")
-		pp(TRUE)
-	}
-	field(ORAW,DBF_ULONG) {
-		prompt("Prev Raw Value")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(MASK,DBF_ULONG) {
-		prompt("Hardware Mask")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(MLST,DBF_USHORT) {
-		prompt("Last Value Monitored")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(LALM,DBF_USHORT) {
-		prompt("Last Value Alarmed")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(SDEF,DBF_SHORT) {
-		prompt("States Defined")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(SHFT,DBF_USHORT) {
-		prompt("Shift")
-		promptgroup(GUI_MBB)
-		interest(1)
-	}
-	field(SIOL,DBF_INLINK) {
-		prompt("Sim Input Specifctn")
-		promptgroup(GUI_MBB)
-		interest(1)
-	}
-	field(SVAL,DBF_ULONG) {
-		prompt("Simulation Value")
-	}
-	field(SIML,DBF_INLINK) {
-		prompt("Sim Mode Location")
-		promptgroup(GUI_MBB)
-		interest(1)
-	}
-	field(SIMM,DBF_MENU) {
-		prompt("Simulation Mode")
-		menu(menuSimm)
-		interest(1)
-	}
-	field(SIMS,DBF_MENU) {
-		prompt("Sim mode Alarm Svrty")
-		promptgroup(GUI_MBB)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(B0,DBF_UCHAR) {
-		prompt("Bit 0")
-		pp(TRUE)
-		interest(1)
-	}
-	field(B1,DBF_UCHAR) {
-		prompt("Bit 1")
-		pp(TRUE)
-		interest(1)
-	}
-	field(B2,DBF_UCHAR) {
-		prompt("Bit 2")
-		pp(TRUE)
-		interest(1)
-	}
-	field(B3,DBF_UCHAR) {
-		prompt("Bit 3")
-		pp(TRUE)
-		interest(1)
-	}
-	field(B4,DBF_UCHAR) {
-		prompt("Bit 4")
-		pp(TRUE)
-		interest(1)
-	}
-	field(B5,DBF_UCHAR) {
-		prompt("Bit 5")
-		pp(TRUE)
-		interest(1)
-	}
-	field(B6,DBF_UCHAR) {
-		prompt("Bit 6")
-		pp(TRUE)
-		interest(1)
-	}
-	field(B7,DBF_UCHAR) {
-		prompt("Bit 7")
-		pp(TRUE)
-		interest(1)
-	}
-	field(B8,DBF_UCHAR) {
-		prompt("Bit 8")
-		pp(TRUE)
-		interest(1)
-	}
-	field(B9,DBF_UCHAR) {
-		prompt("Bit 9")
-		pp(TRUE)
-		interest(1)
-	}
-	field(BA,DBF_UCHAR) {
-		prompt("Bit A")
-		pp(TRUE)
-		interest(1)
-	}
-	field(BB,DBF_UCHAR) {
-		prompt("Bit B")
-		pp(TRUE)
-		interest(1)
-	}
-	field(BC,DBF_UCHAR) {
-		prompt("Bit C")
-		pp(TRUE)
-		interest(1)
-	}
-	field(BD,DBF_UCHAR) {
-		prompt("Bit D")
-		pp(TRUE)
-		interest(1)
-	}
-	field(BE,DBF_UCHAR) {
-		prompt("Bit E")
-		pp(TRUE)
-		interest(1)
-	}
-	field(BF,DBF_UCHAR) {
-		prompt("Bit F")
-		pp(TRUE)
-		interest(1)
-	}
-}
-recordtype(mbbo) {
-	field(NAME,DBF_STRING) {
-		prompt("Record Name")
-		special(SPC_NOMOD)
-		size(61)
-	}
-	field(DESC,DBF_STRING) {
-		prompt("Descriptor")
-		promptgroup(GUI_COMMON)
-		size(41)
-	}
-	field(ASG,DBF_STRING) {
-		prompt("Access Security Group")
-		promptgroup(GUI_COMMON)
-		special(SPC_AS)
-		size(29)
-	}
-	field(SCAN,DBF_MENU) {
-		prompt("Scan Mechanism")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuScan)
-		interest(1)
-	}
-	field(PINI,DBF_MENU) {
-		prompt("Process at iocInit")
-		promptgroup(GUI_SCAN)
-		menu(menuPini)
-		interest(1)
-	}
-	field(PHAS,DBF_SHORT) {
-		prompt("Scan Phase")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(EVNT,DBF_SHORT) {
-		prompt("Event Number")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(TSE,DBF_SHORT) {
-		prompt("Time Stamp Event")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(TSEL,DBF_INLINK) {
-		prompt("Time Stamp Link")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(DTYP,DBF_DEVICE) {
-		prompt("Device Type")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(DISV,DBF_SHORT) {
-		prompt("Disable Value")
-		initial("1")
-		promptgroup(GUI_SCAN)
-	}
-	field(DISA,DBF_SHORT) {
-		prompt("Disable")
-	}
-	field(SDIS,DBF_INLINK) {
-		prompt("Scanning Disable")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(MLOK,DBF_NOACCESS) {
-		prompt("Monitor lock")
-		special(SPC_NOMOD)
-		extra("epicsMutexId	mlok")
-		interest(4)
-	}
-	field(MLIS,DBF_NOACCESS) {
-		prompt("Monitor List")
-		special(SPC_NOMOD)
-		extra("ELLLIST		mlis")
-		interest(4)
-	}
-	field(DISP,DBF_UCHAR) {
-		prompt("Disable putField")
-	}
-	field(PROC,DBF_UCHAR) {
-		prompt("Force Processing")
-		pp(TRUE)
-		interest(3)
-	}
-	field(STAT,DBF_MENU) {
-		prompt("Alarm Status")
-		initial("UDF")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-	}
-	field(SEVR,DBF_MENU) {
-		prompt("Alarm Severity")
-		initial("INVALID")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-	}
-	field(NSTA,DBF_MENU) {
-		prompt("New Alarm Status")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-		interest(2)
-	}
-	field(NSEV,DBF_MENU) {
-		prompt("New Alarm Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKS,DBF_MENU) {
-		prompt("Alarm Ack Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKT,DBF_MENU) {
-		prompt("Alarm Ack Transient")
-		initial("YES")
-		promptgroup(GUI_ALARMS)
-		special(SPC_NOMOD)
-		menu(menuYesNo)
-		interest(2)
-	}
-	field(DISS,DBF_MENU) {
-		prompt("Disable Alarm Sevrty")
-		promptgroup(GUI_SCAN)
-		menu(menuAlarmSevr)
-		interest(1)
-	}
-	field(LCNT,DBF_UCHAR) {
-		prompt("Lock Count")
-		special(SPC_NOMOD)
-		interest(2)
-	}
-	field(PACT,DBF_UCHAR) {
-		prompt("Record active")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(PUTF,DBF_UCHAR) {
-		prompt("dbPutField process")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(RPRO,DBF_UCHAR) {
-		prompt("Reprocess ")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(ASP,DBF_NOACCESS) {
-		prompt("Access Security Pvt")
-		special(SPC_NOMOD)
-		extra("struct asgMember *asp")
-		interest(4)
-	}
-	field(PPN,DBF_NOACCESS) {
-		prompt("addr of PUTNOTIFY")
-		special(SPC_NOMOD)
-		extra("struct putNotify *ppn")
-		interest(4)
-	}
-	field(PPNR,DBF_NOACCESS) {
-		prompt("pputNotifyRecord")
-		special(SPC_NOMOD)
-		extra("struct putNotifyRecord *ppnr")
-		interest(4)
-	}
-	field(SPVT,DBF_NOACCESS) {
-		prompt("Scan Private")
-		special(SPC_NOMOD)
-		extra("struct scan_element *spvt")
-		interest(4)
-	}
-	field(RSET,DBF_NOACCESS) {
-		prompt("Address of RSET")
-		special(SPC_NOMOD)
-		extra("struct rset	*rset")
-		interest(4)
-	}
-	field(DSET,DBF_NOACCESS) {
-		prompt("DSET address")
-		special(SPC_NOMOD)
-		extra("struct dset	*dset")
-		interest(4)
-	}
-	field(DPVT,DBF_NOACCESS) {
-		prompt("Device Private")
-		special(SPC_NOMOD)
-		extra("void		*dpvt")
-		interest(4)
-	}
-	field(RDES,DBF_NOACCESS) {
-		prompt("Address of dbRecordType")
-		special(SPC_NOMOD)
-		extra("struct dbRecordType *rdes")
-		interest(4)
-	}
-	field(LSET,DBF_NOACCESS) {
-		prompt("Lock Set")
-		special(SPC_NOMOD)
-		extra("struct lockRecord *lset")
-		interest(4)
-	}
-	field(PRIO,DBF_MENU) {
-		prompt("Scheduling Priority")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuPriority)
-		interest(1)
-	}
-	field(TPRO,DBF_UCHAR) {
-		prompt("Trace Processing")
-	}
-	field(BKPT,DBF_NOACCESS) {
-		prompt("Break Point")
-		special(SPC_NOMOD)
-		extra("char bkpt")
-		interest(1)
-	}
-	field(UDF,DBF_UCHAR) {
-		prompt("Undefined")
-		initial("1")
-		promptgroup(GUI_COMMON)
-		pp(TRUE)
-		interest(1)
-	}
-	field(TIME,DBF_NOACCESS) {
-		prompt("Time")
-		special(SPC_NOMOD)
-		extra("epicsTimeStamp	time")
-		interest(2)
-	}
-	field(FLNK,DBF_FWDLINK) {
-		prompt("Forward Process Link")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(VAL,DBF_ENUM) {
-		prompt("Desired Value")
-		promptgroup(GUI_OUTPUT)
-		special(SPC_DBADDR)
-		pp(TRUE)
-		asl(ASL0)
-	}
-	field(DOL,DBF_INLINK) {
-		prompt("Desired Output Loc")
-		promptgroup(GUI_MBB)
-		interest(1)
-	}
-	field(OMSL,DBF_MENU) {
-		prompt("Output Mode Select")
-		promptgroup(GUI_MBB)
-		menu(menuOmsl)
-		interest(1)
-	}
-	field(NOBT,DBF_SHORT) {
-		prompt("Number of Bits")
-		promptgroup(GUI_MBB)
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(OUT,DBF_OUTLINK) {
-		prompt("Output Specification")
-		promptgroup(GUI_MBB)
-		interest(1)
-	}
-	field(ZRVL,DBF_ULONG) {
-		prompt("Zero Value")
-		promptgroup(GUI_BITS1)
-		special(100)
-		pp(TRUE)
-		base(HEX)
-		interest(1)
-	}
-	field(ONVL,DBF_ULONG) {
-		prompt("One Value")
-		promptgroup(GUI_BITS1)
-		special(100)
-		pp(TRUE)
-		base(HEX)
-		interest(1)
-	}
-	field(TWVL,DBF_ULONG) {
-		prompt("Two Value")
-		promptgroup(GUI_BITS1)
-		special(100)
-		pp(TRUE)
-		base(HEX)
-		interest(1)
-	}
-	field(THVL,DBF_ULONG) {
-		prompt("Three Value")
-		promptgroup(GUI_BITS1)
-		special(100)
-		pp(TRUE)
-		base(HEX)
-		interest(1)
-	}
-	field(FRVL,DBF_ULONG) {
-		prompt("Four Value")
-		promptgroup(GUI_BITS1)
-		special(100)
-		pp(TRUE)
-		base(HEX)
-		interest(1)
-	}
-	field(FVVL,DBF_ULONG) {
-		prompt("Five Value")
-		promptgroup(GUI_BITS1)
-		special(100)
-		pp(TRUE)
-		base(HEX)
-		interest(1)
-	}
-	field(SXVL,DBF_ULONG) {
-		prompt("Six Value")
-		promptgroup(GUI_BITS1)
-		special(100)
-		pp(TRUE)
-		base(HEX)
-		interest(1)
-	}
-	field(SVVL,DBF_ULONG) {
-		prompt("Seven Value")
-		promptgroup(GUI_BITS1)
-		special(100)
-		pp(TRUE)
-		base(HEX)
-		interest(1)
-	}
-	field(EIVL,DBF_ULONG) {
-		prompt("Eight Value")
-		promptgroup(GUI_BITS2)
-		special(100)
-		pp(TRUE)
-		base(HEX)
-		interest(1)
-	}
-	field(NIVL,DBF_ULONG) {
-		prompt("Nine Value")
-		promptgroup(GUI_BITS2)
-		special(100)
-		pp(TRUE)
-		base(HEX)
-		interest(1)
-	}
-	field(TEVL,DBF_ULONG) {
-		prompt("Ten Value")
-		promptgroup(GUI_BITS2)
-		special(100)
-		pp(TRUE)
-		base(HEX)
-		interest(1)
-	}
-	field(ELVL,DBF_ULONG) {
-		prompt("Eleven Value")
-		promptgroup(GUI_BITS2)
-		special(100)
-		pp(TRUE)
-		base(HEX)
-		interest(1)
-	}
-	field(TVVL,DBF_ULONG) {
-		prompt("Twelve Value")
-		promptgroup(GUI_BITS2)
-		special(100)
-		pp(TRUE)
-		base(HEX)
-		interest(1)
-	}
-	field(TTVL,DBF_ULONG) {
-		prompt("Thirteen Value")
-		promptgroup(GUI_BITS2)
-		special(100)
-		pp(TRUE)
-		base(HEX)
-		interest(1)
-	}
-	field(FTVL,DBF_ULONG) {
-		prompt("Fourteen Value")
-		promptgroup(GUI_BITS2)
-		special(100)
-		pp(TRUE)
-		base(HEX)
-		interest(1)
-	}
-	field(FFVL,DBF_ULONG) {
-		prompt("Fifteen Value")
-		promptgroup(GUI_BITS2)
-		special(100)
-		pp(TRUE)
-		base(HEX)
-		interest(1)
-	}
-	field(ZRST,DBF_STRING) {
-		prompt("Zero String")
-		promptgroup(GUI_BITS1)
-		special(100)
-		size(26)
-		pp(TRUE)
-		interest(1)
-	}
-	field(ONST,DBF_STRING) {
-		prompt("One String")
-		promptgroup(GUI_BITS1)
-		special(100)
-		size(26)
-		pp(TRUE)
-		interest(1)
-	}
-	field(TWST,DBF_STRING) {
-		prompt("Two String")
-		promptgroup(GUI_BITS1)
-		special(100)
-		size(26)
-		pp(TRUE)
-		interest(1)
-	}
-	field(THST,DBF_STRING) {
-		prompt("Three String")
-		promptgroup(GUI_BITS1)
-		special(100)
-		size(26)
-		pp(TRUE)
-		interest(1)
-	}
-	field(FRST,DBF_STRING) {
-		prompt("Four String")
-		promptgroup(GUI_BITS1)
-		special(100)
-		size(26)
-		pp(TRUE)
-		interest(1)
-	}
-	field(FVST,DBF_STRING) {
-		prompt("Five String")
-		promptgroup(GUI_BITS1)
-		special(100)
-		size(26)
-		pp(TRUE)
-		interest(1)
-	}
-	field(SXST,DBF_STRING) {
-		prompt("Six String")
-		promptgroup(GUI_BITS1)
-		special(100)
-		size(26)
-		pp(TRUE)
-		interest(1)
-	}
-	field(SVST,DBF_STRING) {
-		prompt("Seven String")
-		promptgroup(GUI_BITS1)
-		special(100)
-		size(26)
-		pp(TRUE)
-		interest(1)
-	}
-	field(EIST,DBF_STRING) {
-		prompt("Eight String")
-		promptgroup(GUI_BITS2)
-		special(100)
-		size(26)
-		pp(TRUE)
-		interest(1)
-	}
-	field(NIST,DBF_STRING) {
-		prompt("Nine String")
-		promptgroup(GUI_BITS2)
-		special(100)
-		size(26)
-		pp(TRUE)
-		interest(1)
-	}
-	field(TEST,DBF_STRING) {
-		prompt("Ten String")
-		promptgroup(GUI_BITS2)
-		special(100)
-		size(26)
-		pp(TRUE)
-		interest(1)
-	}
-	field(ELST,DBF_STRING) {
-		prompt("Eleven String")
-		promptgroup(GUI_BITS2)
-		special(100)
-		size(26)
-		pp(TRUE)
-		interest(1)
-	}
-	field(TVST,DBF_STRING) {
-		prompt("Twelve String")
-		promptgroup(GUI_BITS2)
-		special(100)
-		size(26)
-		pp(TRUE)
-		interest(1)
-	}
-	field(TTST,DBF_STRING) {
-		prompt("Thirteen String")
-		promptgroup(GUI_BITS2)
-		special(100)
-		size(26)
-		pp(TRUE)
-		interest(1)
-	}
-	field(FTST,DBF_STRING) {
-		prompt("Fourteen String")
-		promptgroup(GUI_BITS2)
-		special(100)
-		size(26)
-		pp(TRUE)
-		interest(1)
-	}
-	field(FFST,DBF_STRING) {
-		prompt("Fifteen String")
-		promptgroup(GUI_BITS2)
-		special(100)
-		size(26)
-		pp(TRUE)
-		interest(1)
-	}
-	field(ZRSV,DBF_MENU) {
-		prompt("State Zero Severity")
-		promptgroup(GUI_BITS1)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(ONSV,DBF_MENU) {
-		prompt("State One Severity")
-		promptgroup(GUI_BITS1)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(TWSV,DBF_MENU) {
-		prompt("State Two Severity")
-		promptgroup(GUI_BITS1)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(THSV,DBF_MENU) {
-		prompt("State Three Severity")
-		promptgroup(GUI_BITS1)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(FRSV,DBF_MENU) {
-		prompt("State Four Severity")
-		promptgroup(GUI_BITS1)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(FVSV,DBF_MENU) {
-		prompt("State Five Severity")
-		promptgroup(GUI_BITS1)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(SXSV,DBF_MENU) {
-		prompt("State Six Severity")
-		promptgroup(GUI_BITS1)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(SVSV,DBF_MENU) {
-		prompt("State Seven Severity")
-		promptgroup(GUI_BITS1)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(EISV,DBF_MENU) {
-		prompt("State Eight Severity")
-		promptgroup(GUI_BITS2)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(NISV,DBF_MENU) {
-		prompt("State Nine Severity")
-		promptgroup(GUI_BITS2)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(TESV,DBF_MENU) {
-		prompt("State Ten Severity")
-		promptgroup(GUI_BITS2)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(ELSV,DBF_MENU) {
-		prompt("State Eleven Severity")
-		promptgroup(GUI_BITS2)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(TVSV,DBF_MENU) {
-		prompt("State Twelve Severity")
-		promptgroup(GUI_BITS2)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(TTSV,DBF_MENU) {
-		prompt("State Thirteen Sevr")
-		promptgroup(GUI_BITS2)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(FTSV,DBF_MENU) {
-		prompt("State Fourteen Sevr")
-		promptgroup(GUI_BITS2)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(FFSV,DBF_MENU) {
-		prompt("State Fifteen Sevr")
-		promptgroup(GUI_BITS2)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(UNSV,DBF_MENU) {
-		prompt("Unknown State Sevr")
-		promptgroup(GUI_MBB)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(COSV,DBF_MENU) {
-		prompt("Change of State Sevr")
-		promptgroup(GUI_MBB)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(RVAL,DBF_ULONG) {
-		prompt("Raw Value")
-		pp(TRUE)
-	}
-	field(ORAW,DBF_ULONG) {
-		prompt("Prev Raw Value")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(RBV,DBF_ULONG) {
-		prompt("Readback Value")
-		special(SPC_NOMOD)
-	}
-	field(ORBV,DBF_ULONG) {
-		prompt("Prev Readback Value")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(MASK,DBF_ULONG) {
-		prompt("Hardware Mask")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(MLST,DBF_USHORT) {
-		prompt("Last Value Monitored")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(LALM,DBF_USHORT) {
-		prompt("Last Value Alarmed")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(SDEF,DBF_SHORT) {
-		prompt("States Defined")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(SHFT,DBF_USHORT) {
-		prompt("Shift")
-		promptgroup(GUI_MBB)
-		interest(1)
-	}
-	field(SIOL,DBF_OUTLINK) {
-		prompt("Sim Output Specifctn")
-		promptgroup(GUI_MBB)
-		interest(1)
-	}
-	field(SIML,DBF_INLINK) {
-		prompt("Sim Mode Location")
-		promptgroup(GUI_MBB)
-		interest(1)
-	}
-	field(SIMM,DBF_MENU) {
-		prompt("Simulation Mode")
-		menu(menuYesNo)
-		interest(1)
-	}
-	field(SIMS,DBF_MENU) {
-		prompt("Sim mode Alarm Svrty")
-		promptgroup(GUI_MBB)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(IVOA,DBF_MENU) {
-		prompt("INVALID outpt action")
-		promptgroup(GUI_MBB)
-		menu(menuIvoa)
-		interest(2)
-	}
-	field(IVOV,DBF_USHORT) {
-		prompt("INVALID output value")
-		promptgroup(GUI_MBB)
-		interest(2)
-	}
-}
-recordtype(mbboDirect) {
-	field(NAME,DBF_STRING) {
-		prompt("Record Name")
-		special(SPC_NOMOD)
-		size(61)
-	}
-	field(DESC,DBF_STRING) {
-		prompt("Descriptor")
-		promptgroup(GUI_COMMON)
-		size(41)
-	}
-	field(ASG,DBF_STRING) {
-		prompt("Access Security Group")
-		promptgroup(GUI_COMMON)
-		special(SPC_AS)
-		size(29)
-	}
-	field(SCAN,DBF_MENU) {
-		prompt("Scan Mechanism")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuScan)
-		interest(1)
-	}
-	field(PINI,DBF_MENU) {
-		prompt("Process at iocInit")
-		promptgroup(GUI_SCAN)
-		menu(menuPini)
-		interest(1)
-	}
-	field(PHAS,DBF_SHORT) {
-		prompt("Scan Phase")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(EVNT,DBF_SHORT) {
-		prompt("Event Number")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(TSE,DBF_SHORT) {
-		prompt("Time Stamp Event")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(TSEL,DBF_INLINK) {
-		prompt("Time Stamp Link")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(DTYP,DBF_DEVICE) {
-		prompt("Device Type")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(DISV,DBF_SHORT) {
-		prompt("Disable Value")
-		initial("1")
-		promptgroup(GUI_SCAN)
-	}
-	field(DISA,DBF_SHORT) {
-		prompt("Disable")
-	}
-	field(SDIS,DBF_INLINK) {
-		prompt("Scanning Disable")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(MLOK,DBF_NOACCESS) {
-		prompt("Monitor lock")
-		special(SPC_NOMOD)
-		extra("epicsMutexId	mlok")
-		interest(4)
-	}
-	field(MLIS,DBF_NOACCESS) {
-		prompt("Monitor List")
-		special(SPC_NOMOD)
-		extra("ELLLIST		mlis")
-		interest(4)
-	}
-	field(DISP,DBF_UCHAR) {
-		prompt("Disable putField")
-	}
-	field(PROC,DBF_UCHAR) {
-		prompt("Force Processing")
-		pp(TRUE)
-		interest(3)
-	}
-	field(STAT,DBF_MENU) {
-		prompt("Alarm Status")
-		initial("UDF")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-	}
-	field(SEVR,DBF_MENU) {
-		prompt("Alarm Severity")
-		initial("INVALID")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-	}
-	field(NSTA,DBF_MENU) {
-		prompt("New Alarm Status")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-		interest(2)
-	}
-	field(NSEV,DBF_MENU) {
-		prompt("New Alarm Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKS,DBF_MENU) {
-		prompt("Alarm Ack Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKT,DBF_MENU) {
-		prompt("Alarm Ack Transient")
-		initial("YES")
-		promptgroup(GUI_ALARMS)
-		special(SPC_NOMOD)
-		menu(menuYesNo)
-		interest(2)
-	}
-	field(DISS,DBF_MENU) {
-		prompt("Disable Alarm Sevrty")
-		promptgroup(GUI_SCAN)
-		menu(menuAlarmSevr)
-		interest(1)
-	}
-	field(LCNT,DBF_UCHAR) {
-		prompt("Lock Count")
-		special(SPC_NOMOD)
-		interest(2)
-	}
-	field(PACT,DBF_UCHAR) {
-		prompt("Record active")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(PUTF,DBF_UCHAR) {
-		prompt("dbPutField process")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(RPRO,DBF_UCHAR) {
-		prompt("Reprocess ")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(ASP,DBF_NOACCESS) {
-		prompt("Access Security Pvt")
-		special(SPC_NOMOD)
-		extra("struct asgMember *asp")
-		interest(4)
-	}
-	field(PPN,DBF_NOACCESS) {
-		prompt("addr of PUTNOTIFY")
-		special(SPC_NOMOD)
-		extra("struct putNotify *ppn")
-		interest(4)
-	}
-	field(PPNR,DBF_NOACCESS) {
-		prompt("pputNotifyRecord")
-		special(SPC_NOMOD)
-		extra("struct putNotifyRecord *ppnr")
-		interest(4)
-	}
-	field(SPVT,DBF_NOACCESS) {
-		prompt("Scan Private")
-		special(SPC_NOMOD)
-		extra("struct scan_element *spvt")
-		interest(4)
-	}
-	field(RSET,DBF_NOACCESS) {
-		prompt("Address of RSET")
-		special(SPC_NOMOD)
-		extra("struct rset	*rset")
-		interest(4)
-	}
-	field(DSET,DBF_NOACCESS) {
-		prompt("DSET address")
-		special(SPC_NOMOD)
-		extra("struct dset	*dset")
-		interest(4)
-	}
-	field(DPVT,DBF_NOACCESS) {
-		prompt("Device Private")
-		special(SPC_NOMOD)
-		extra("void		*dpvt")
-		interest(4)
-	}
-	field(RDES,DBF_NOACCESS) {
-		prompt("Address of dbRecordType")
-		special(SPC_NOMOD)
-		extra("struct dbRecordType *rdes")
-		interest(4)
-	}
-	field(LSET,DBF_NOACCESS) {
-		prompt("Lock Set")
-		special(SPC_NOMOD)
-		extra("struct lockRecord *lset")
-		interest(4)
-	}
-	field(PRIO,DBF_MENU) {
-		prompt("Scheduling Priority")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuPriority)
-		interest(1)
-	}
-	field(TPRO,DBF_UCHAR) {
-		prompt("Trace Processing")
-	}
-	field(BKPT,DBF_NOACCESS) {
-		prompt("Break Point")
-		special(SPC_NOMOD)
-		extra("char bkpt")
-		interest(1)
-	}
-	field(UDF,DBF_UCHAR) {
-		prompt("Undefined")
-		initial("1")
-		promptgroup(GUI_COMMON)
-		pp(TRUE)
-		interest(1)
-	}
-	field(TIME,DBF_NOACCESS) {
-		prompt("Time")
-		special(SPC_NOMOD)
-		extra("epicsTimeStamp	time")
-		interest(2)
-	}
-	field(FLNK,DBF_FWDLINK) {
-		prompt("Forward Process Link")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(VAL,DBF_USHORT) {
-		prompt("Word")
-		promptgroup(GUI_OUTPUT)
-		pp(TRUE)
-		asl(ASL0)
-	}
-	field(OMSL,DBF_MENU) {
-		prompt("Output Mode Select")
-		promptgroup(GUI_MBB)
-		special(101)
-		menu(menuOmsl)
-		pp(TRUE)
-		interest(1)
-	}
-	field(NOBT,DBF_SHORT) {
-		prompt("Number of Bits")
-		promptgroup(GUI_MBB)
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(DOL,DBF_INLINK) {
-		prompt("Desired Output Loc")
-		promptgroup(GUI_MBB)
-		interest(1)
-	}
-	field(OUT,DBF_OUTLINK) {
-		prompt("Output Specification")
-		promptgroup(GUI_MBB)
-		interest(1)
-	}
-	field(B0,DBF_UCHAR) {
-		prompt("Bit 0")
-		promptgroup(GUI_BITS1)
-		special(100)
-		pp(TRUE)
-		interest(1)
-	}
-	field(B1,DBF_UCHAR) {
-		prompt("Bit 1")
-		promptgroup(GUI_BITS1)
-		special(100)
-		pp(TRUE)
-		interest(1)
-	}
-	field(B2,DBF_UCHAR) {
-		prompt("Bit 2")
-		promptgroup(GUI_BITS1)
-		special(100)
-		pp(TRUE)
-		interest(1)
-	}
-	field(B3,DBF_UCHAR) {
-		prompt("Bit 3")
-		promptgroup(GUI_BITS1)
-		special(100)
-		pp(TRUE)
-		interest(1)
-	}
-	field(B4,DBF_UCHAR) {
-		prompt("Bit 4")
-		promptgroup(GUI_BITS1)
-		special(100)
-		pp(TRUE)
-		interest(1)
-	}
-	field(B5,DBF_UCHAR) {
-		prompt("Bit 5")
-		promptgroup(GUI_BITS1)
-		special(100)
-		pp(TRUE)
-		interest(1)
-	}
-	field(B6,DBF_UCHAR) {
-		prompt("Bit 6")
-		promptgroup(GUI_BITS1)
-		special(100)
-		pp(TRUE)
-		interest(1)
-	}
-	field(B7,DBF_UCHAR) {
-		prompt("Bit 7")
-		promptgroup(GUI_BITS1)
-		special(100)
-		pp(TRUE)
-		interest(1)
-	}
-	field(B8,DBF_UCHAR) {
-		prompt("Bit 8")
-		promptgroup(GUI_BITS2)
-		special(100)
-		pp(TRUE)
-		interest(1)
-	}
-	field(B9,DBF_UCHAR) {
-		prompt("Bit 9")
-		promptgroup(GUI_BITS2)
-		special(100)
-		pp(TRUE)
-		interest(1)
-	}
-	field(BA,DBF_UCHAR) {
-		prompt("Bit 10")
-		promptgroup(GUI_BITS2)
-		special(100)
-		pp(TRUE)
-		interest(1)
-	}
-	field(BB,DBF_UCHAR) {
-		prompt("Bit 11")
-		promptgroup(GUI_BITS2)
-		special(100)
-		pp(TRUE)
-		interest(1)
-	}
-	field(BC,DBF_UCHAR) {
-		prompt("Bit 12")
-		promptgroup(GUI_BITS2)
-		special(100)
-		pp(TRUE)
-		interest(1)
-	}
-	field(BD,DBF_UCHAR) {
-		prompt("Bit 13")
-		promptgroup(GUI_BITS2)
-		special(100)
-		pp(TRUE)
-		interest(1)
-	}
-	field(BE,DBF_UCHAR) {
-		prompt("Bit 14")
-		promptgroup(GUI_BITS2)
-		special(100)
-		pp(TRUE)
-		interest(1)
-	}
-	field(BF,DBF_UCHAR) {
-		prompt("Bit 15")
-		promptgroup(GUI_BITS2)
-		special(100)
-		pp(TRUE)
-		interest(1)
-	}
-	field(RVAL,DBF_ULONG) {
-		prompt("Raw Value")
-		special(SPC_NOMOD)
-		pp(TRUE)
-	}
-	field(ORAW,DBF_ULONG) {
-		prompt("Prev Raw Value")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(RBV,DBF_ULONG) {
-		prompt("Readback Value")
-		special(SPC_NOMOD)
-	}
-	field(ORBV,DBF_ULONG) {
-		prompt("Prev Readback Value")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(MASK,DBF_ULONG) {
-		prompt("Hardware Mask")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(MLST,DBF_ULONG) {
-		prompt("Last Value Monitored")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(LALM,DBF_ULONG) {
-		prompt("Last Value Alarmed")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(SHFT,DBF_ULONG) {
-		prompt("Shift")
-		promptgroup(GUI_MBB)
-		interest(1)
-	}
-	field(SIOL,DBF_OUTLINK) {
-		prompt("Sim Output Specifctn")
-		promptgroup(GUI_MBB)
-		interest(1)
-	}
-	field(SIML,DBF_INLINK) {
-		prompt("Sim Mode Location")
-		promptgroup(GUI_MBB)
-		interest(1)
-	}
-	field(SIMM,DBF_MENU) {
-		prompt("Simulation Mode")
-		menu(menuYesNo)
-		interest(1)
-	}
-	field(SIMS,DBF_MENU) {
-		prompt("Sim mode Alarm Svrty")
-		promptgroup(GUI_MBB)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(IVOA,DBF_MENU) {
-		prompt("INVALID outpt action")
-		promptgroup(GUI_MBB)
-		menu(menuIvoa)
-		interest(2)
-	}
-	field(IVOV,DBF_USHORT) {
-		prompt("INVALID output value")
-		promptgroup(GUI_MBB)
-		interest(2)
-	}
-}
-recordtype(permissive) {
-	field(NAME,DBF_STRING) {
-		prompt("Record Name")
-		special(SPC_NOMOD)
-		size(61)
-	}
-	field(DESC,DBF_STRING) {
-		prompt("Descriptor")
-		promptgroup(GUI_COMMON)
-		size(41)
-	}
-	field(ASG,DBF_STRING) {
-		prompt("Access Security Group")
-		promptgroup(GUI_COMMON)
-		special(SPC_AS)
-		size(29)
-	}
-	field(SCAN,DBF_MENU) {
-		prompt("Scan Mechanism")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuScan)
-		interest(1)
-	}
-	field(PINI,DBF_MENU) {
-		prompt("Process at iocInit")
-		promptgroup(GUI_SCAN)
-		menu(menuPini)
-		interest(1)
-	}
-	field(PHAS,DBF_SHORT) {
-		prompt("Scan Phase")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(EVNT,DBF_SHORT) {
-		prompt("Event Number")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(TSE,DBF_SHORT) {
-		prompt("Time Stamp Event")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(TSEL,DBF_INLINK) {
-		prompt("Time Stamp Link")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(DTYP,DBF_DEVICE) {
-		prompt("Device Type")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(DISV,DBF_SHORT) {
-		prompt("Disable Value")
-		initial("1")
-		promptgroup(GUI_SCAN)
-	}
-	field(DISA,DBF_SHORT) {
-		prompt("Disable")
-	}
-	field(SDIS,DBF_INLINK) {
-		prompt("Scanning Disable")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(MLOK,DBF_NOACCESS) {
-		prompt("Monitor lock")
-		special(SPC_NOMOD)
-		extra("epicsMutexId	mlok")
-		interest(4)
-	}
-	field(MLIS,DBF_NOACCESS) {
-		prompt("Monitor List")
-		special(SPC_NOMOD)
-		extra("ELLLIST		mlis")
-		interest(4)
-	}
-	field(DISP,DBF_UCHAR) {
-		prompt("Disable putField")
-	}
-	field(PROC,DBF_UCHAR) {
-		prompt("Force Processing")
-		pp(TRUE)
-		interest(3)
-	}
-	field(STAT,DBF_MENU) {
-		prompt("Alarm Status")
-		initial("UDF")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-	}
-	field(SEVR,DBF_MENU) {
-		prompt("Alarm Severity")
-		initial("INVALID")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-	}
-	field(NSTA,DBF_MENU) {
-		prompt("New Alarm Status")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-		interest(2)
-	}
-	field(NSEV,DBF_MENU) {
-		prompt("New Alarm Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKS,DBF_MENU) {
-		prompt("Alarm Ack Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKT,DBF_MENU) {
-		prompt("Alarm Ack Transient")
-		initial("YES")
-		promptgroup(GUI_ALARMS)
-		special(SPC_NOMOD)
-		menu(menuYesNo)
-		interest(2)
-	}
-	field(DISS,DBF_MENU) {
-		prompt("Disable Alarm Sevrty")
-		promptgroup(GUI_SCAN)
-		menu(menuAlarmSevr)
-		interest(1)
-	}
-	field(LCNT,DBF_UCHAR) {
-		prompt("Lock Count")
-		special(SPC_NOMOD)
-		interest(2)
-	}
-	field(PACT,DBF_UCHAR) {
-		prompt("Record active")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(PUTF,DBF_UCHAR) {
-		prompt("dbPutField process")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(RPRO,DBF_UCHAR) {
-		prompt("Reprocess ")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(ASP,DBF_NOACCESS) {
-		prompt("Access Security Pvt")
-		special(SPC_NOMOD)
-		extra("struct asgMember *asp")
-		interest(4)
-	}
-	field(PPN,DBF_NOACCESS) {
-		prompt("addr of PUTNOTIFY")
-		special(SPC_NOMOD)
-		extra("struct putNotify *ppn")
-		interest(4)
-	}
-	field(PPNR,DBF_NOACCESS) {
-		prompt("pputNotifyRecord")
-		special(SPC_NOMOD)
-		extra("struct putNotifyRecord *ppnr")
-		interest(4)
-	}
-	field(SPVT,DBF_NOACCESS) {
-		prompt("Scan Private")
-		special(SPC_NOMOD)
-		extra("struct scan_element *spvt")
-		interest(4)
-	}
-	field(RSET,DBF_NOACCESS) {
-		prompt("Address of RSET")
-		special(SPC_NOMOD)
-		extra("struct rset	*rset")
-		interest(4)
-	}
-	field(DSET,DBF_NOACCESS) {
-		prompt("DSET address")
-		special(SPC_NOMOD)
-		extra("struct dset	*dset")
-		interest(4)
-	}
-	field(DPVT,DBF_NOACCESS) {
-		prompt("Device Private")
-		special(SPC_NOMOD)
-		extra("void		*dpvt")
-		interest(4)
-	}
-	field(RDES,DBF_NOACCESS) {
-		prompt("Address of dbRecordType")
-		special(SPC_NOMOD)
-		extra("struct dbRecordType *rdes")
-		interest(4)
-	}
-	field(LSET,DBF_NOACCESS) {
-		prompt("Lock Set")
-		special(SPC_NOMOD)
-		extra("struct lockRecord *lset")
-		interest(4)
-	}
-	field(PRIO,DBF_MENU) {
-		prompt("Scheduling Priority")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuPriority)
-		interest(1)
-	}
-	field(TPRO,DBF_UCHAR) {
-		prompt("Trace Processing")
-	}
-	field(BKPT,DBF_NOACCESS) {
-		prompt("Break Point")
-		special(SPC_NOMOD)
-		extra("char bkpt")
-		interest(1)
-	}
-	field(UDF,DBF_UCHAR) {
-		prompt("Undefined")
-		initial("1")
-		promptgroup(GUI_COMMON)
-		pp(TRUE)
-		interest(1)
-	}
-	field(TIME,DBF_NOACCESS) {
-		prompt("Time")
-		special(SPC_NOMOD)
-		extra("epicsTimeStamp	time")
-		interest(2)
-	}
-	field(FLNK,DBF_FWDLINK) {
-		prompt("Forward Process Link")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(LABL,DBF_STRING) {
-		prompt("Button Label")
-		promptgroup(GUI_DISPLAY)
-		size(20)
-		pp(TRUE)
-		interest(1)
-	}
-	field(VAL,DBF_USHORT) {
-		prompt("Status")
-		pp(TRUE)
-		asl(ASL0)
-	}
-	field(OVAL,DBF_USHORT) {
-		prompt("Old Status")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(WFLG,DBF_USHORT) {
-		prompt("Wait Flag")
-		pp(TRUE)
-	}
-	field(OFLG,DBF_USHORT) {
-		prompt("Old Flag")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-}
-recordtype(sel) {
-	field(NAME,DBF_STRING) {
-		prompt("Record Name")
-		special(SPC_NOMOD)
-		size(61)
-	}
-	field(DESC,DBF_STRING) {
-		prompt("Descriptor")
-		promptgroup(GUI_COMMON)
-		size(41)
-	}
-	field(ASG,DBF_STRING) {
-		prompt("Access Security Group")
-		promptgroup(GUI_COMMON)
-		special(SPC_AS)
-		size(29)
-	}
-	field(SCAN,DBF_MENU) {
-		prompt("Scan Mechanism")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuScan)
-		interest(1)
-	}
-	field(PINI,DBF_MENU) {
-		prompt("Process at iocInit")
-		promptgroup(GUI_SCAN)
-		menu(menuPini)
-		interest(1)
-	}
-	field(PHAS,DBF_SHORT) {
-		prompt("Scan Phase")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(EVNT,DBF_SHORT) {
-		prompt("Event Number")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(TSE,DBF_SHORT) {
-		prompt("Time Stamp Event")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(TSEL,DBF_INLINK) {
-		prompt("Time Stamp Link")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(DTYP,DBF_DEVICE) {
-		prompt("Device Type")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(DISV,DBF_SHORT) {
-		prompt("Disable Value")
-		initial("1")
-		promptgroup(GUI_SCAN)
-	}
-	field(DISA,DBF_SHORT) {
-		prompt("Disable")
-	}
-	field(SDIS,DBF_INLINK) {
-		prompt("Scanning Disable")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(MLOK,DBF_NOACCESS) {
-		prompt("Monitor lock")
-		special(SPC_NOMOD)
-		extra("epicsMutexId	mlok")
-		interest(4)
-	}
-	field(MLIS,DBF_NOACCESS) {
-		prompt("Monitor List")
-		special(SPC_NOMOD)
-		extra("ELLLIST		mlis")
-		interest(4)
-	}
-	field(DISP,DBF_UCHAR) {
-		prompt("Disable putField")
-	}
-	field(PROC,DBF_UCHAR) {
-		prompt("Force Processing")
-		pp(TRUE)
-		interest(3)
-	}
-	field(STAT,DBF_MENU) {
-		prompt("Alarm Status")
-		initial("UDF")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-	}
-	field(SEVR,DBF_MENU) {
-		prompt("Alarm Severity")
-		initial("INVALID")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-	}
-	field(NSTA,DBF_MENU) {
-		prompt("New Alarm Status")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-		interest(2)
-	}
-	field(NSEV,DBF_MENU) {
-		prompt("New Alarm Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKS,DBF_MENU) {
-		prompt("Alarm Ack Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKT,DBF_MENU) {
-		prompt("Alarm Ack Transient")
-		initial("YES")
-		promptgroup(GUI_ALARMS)
-		special(SPC_NOMOD)
-		menu(menuYesNo)
-		interest(2)
-	}
-	field(DISS,DBF_MENU) {
-		prompt("Disable Alarm Sevrty")
-		promptgroup(GUI_SCAN)
-		menu(menuAlarmSevr)
-		interest(1)
-	}
-	field(LCNT,DBF_UCHAR) {
-		prompt("Lock Count")
-		special(SPC_NOMOD)
-		interest(2)
-	}
-	field(PACT,DBF_UCHAR) {
-		prompt("Record active")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(PUTF,DBF_UCHAR) {
-		prompt("dbPutField process")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(RPRO,DBF_UCHAR) {
-		prompt("Reprocess ")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(ASP,DBF_NOACCESS) {
-		prompt("Access Security Pvt")
-		special(SPC_NOMOD)
-		extra("struct asgMember *asp")
-		interest(4)
-	}
-	field(PPN,DBF_NOACCESS) {
-		prompt("addr of PUTNOTIFY")
-		special(SPC_NOMOD)
-		extra("struct putNotify *ppn")
-		interest(4)
-	}
-	field(PPNR,DBF_NOACCESS) {
-		prompt("pputNotifyRecord")
-		special(SPC_NOMOD)
-		extra("struct putNotifyRecord *ppnr")
-		interest(4)
-	}
-	field(SPVT,DBF_NOACCESS) {
-		prompt("Scan Private")
-		special(SPC_NOMOD)
-		extra("struct scan_element *spvt")
-		interest(4)
-	}
-	field(RSET,DBF_NOACCESS) {
-		prompt("Address of RSET")
-		special(SPC_NOMOD)
-		extra("struct rset	*rset")
-		interest(4)
-	}
-	field(DSET,DBF_NOACCESS) {
-		prompt("DSET address")
-		special(SPC_NOMOD)
-		extra("struct dset	*dset")
-		interest(4)
-	}
-	field(DPVT,DBF_NOACCESS) {
-		prompt("Device Private")
-		special(SPC_NOMOD)
-		extra("void		*dpvt")
-		interest(4)
-	}
-	field(RDES,DBF_NOACCESS) {
-		prompt("Address of dbRecordType")
-		special(SPC_NOMOD)
-		extra("struct dbRecordType *rdes")
-		interest(4)
-	}
-	field(LSET,DBF_NOACCESS) {
-		prompt("Lock Set")
-		special(SPC_NOMOD)
-		extra("struct lockRecord *lset")
-		interest(4)
-	}
-	field(PRIO,DBF_MENU) {
-		prompt("Scheduling Priority")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuPriority)
-		interest(1)
-	}
-	field(TPRO,DBF_UCHAR) {
-		prompt("Trace Processing")
-	}
-	field(BKPT,DBF_NOACCESS) {
-		prompt("Break Point")
-		special(SPC_NOMOD)
-		extra("char bkpt")
-		interest(1)
-	}
-	field(UDF,DBF_UCHAR) {
-		prompt("Undefined")
-		initial("1")
-		promptgroup(GUI_COMMON)
-		pp(TRUE)
-		interest(1)
-	}
-	field(TIME,DBF_NOACCESS) {
-		prompt("Time")
-		special(SPC_NOMOD)
-		extra("epicsTimeStamp	time")
-		interest(2)
-	}
-	field(FLNK,DBF_FWDLINK) {
-		prompt("Forward Process Link")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(VAL,DBF_DOUBLE) {
-		prompt("Result")
-		special(SPC_NOMOD)
-		asl(ASL0)
-	}
-	field(SELM,DBF_MENU) {
-		prompt("Select Mechanism")
-		promptgroup(GUI_INPUTS)
-		menu(selSELM)
-	}
-	field(SELN,DBF_USHORT) {
-		prompt("Index value")
-	}
-	field(PREC,DBF_SHORT) {
-		prompt("Display Precision")
-		promptgroup(GUI_DISPLAY)
-		interest(1)
-	}
-	field(NVL,DBF_INLINK) {
-		prompt("Index Value Location")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(INPA,DBF_INLINK) {
-		prompt("Input A")
-		promptgroup(GUI_SELECT)
-		interest(1)
-	}
-	field(INPB,DBF_INLINK) {
-		prompt("Input B")
-		promptgroup(GUI_SELECT)
-		interest(1)
-	}
-	field(INPC,DBF_INLINK) {
-		prompt("Input C")
-		promptgroup(GUI_SELECT)
-		interest(1)
-	}
-	field(INPD,DBF_INLINK) {
-		prompt("Input D")
-		promptgroup(GUI_SELECT)
-		interest(1)
-	}
-	field(INPE,DBF_INLINK) {
-		prompt("Input E")
-		promptgroup(GUI_SELECT)
-		interest(1)
-	}
-	field(INPF,DBF_INLINK) {
-		prompt("Input F")
-		promptgroup(GUI_SELECT)
-		interest(1)
-	}
-	field(INPG,DBF_INLINK) {
-		prompt("Input G")
-		promptgroup(GUI_SELECT)
-		interest(1)
-	}
-	field(INPH,DBF_INLINK) {
-		prompt("Input H")
-		promptgroup(GUI_SELECT)
-		interest(1)
-	}
-	field(INPI,DBF_INLINK) {
-		prompt("Input I")
-		promptgroup(GUI_SELECT)
-		interest(1)
-	}
-	field(INPJ,DBF_INLINK) {
-		prompt("Input J")
-		promptgroup(GUI_SELECT)
-		interest(1)
-	}
-	field(INPK,DBF_INLINK) {
-		prompt("Input K")
-		promptgroup(GUI_SELECT)
-		interest(1)
-	}
-	field(INPL,DBF_INLINK) {
-		prompt("Input L")
-		promptgroup(GUI_SELECT)
-		interest(1)
-	}
-	field(EGU,DBF_STRING) {
-		prompt("Units Name")
-		promptgroup(GUI_DISPLAY)
-		size(16)
-		interest(1)
-	}
-	field(HOPR,DBF_DOUBLE) {
-		prompt("High Operating Rng")
-		promptgroup(GUI_DISPLAY)
-		interest(1)
-	}
-	field(LOPR,DBF_DOUBLE) {
-		prompt("Low Operating Range")
-		promptgroup(GUI_DISPLAY)
-		interest(1)
-	}
-	field(HIHI,DBF_DOUBLE) {
-		prompt("Hihi Alarm Limit")
-		promptgroup(GUI_ALARMS)
-		pp(TRUE)
-		interest(1)
-	}
-	field(LOLO,DBF_DOUBLE) {
-		prompt("Lolo Alarm Limit")
-		promptgroup(GUI_ALARMS)
-		pp(TRUE)
-		interest(1)
-	}
-	field(HIGH,DBF_DOUBLE) {
-		prompt("High Alarm Limit")
-		promptgroup(GUI_ALARMS)
-		pp(TRUE)
-		interest(1)
-	}
-	field(LOW,DBF_DOUBLE) {
-		prompt("Low Alarm Limit")
-		promptgroup(GUI_ALARMS)
-		pp(TRUE)
-		interest(1)
-	}
-	field(HHSV,DBF_MENU) {
-		prompt("Hihi Severity")
-		promptgroup(GUI_ALARMS)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(LLSV,DBF_MENU) {
-		prompt("Lolo Severity")
-		promptgroup(GUI_ALARMS)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(HSV,DBF_MENU) {
-		prompt("High Severity")
-		promptgroup(GUI_ALARMS)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(LSV,DBF_MENU) {
-		prompt("Low Severity")
-		promptgroup(GUI_ALARMS)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(HYST,DBF_DOUBLE) {
-		prompt("Alarm Deadband")
-		promptgroup(GUI_ALARMS)
-		interest(1)
-	}
-	field(ADEL,DBF_DOUBLE) {
-		prompt("Archive Deadband")
-		promptgroup(GUI_DISPLAY)
-		interest(1)
-	}
-	field(MDEL,DBF_DOUBLE) {
-		prompt("Monitor Deadband")
-		promptgroup(GUI_DISPLAY)
-		interest(1)
-	}
-	field(A,DBF_DOUBLE) {
-		prompt("Value of Input A")
-		pp(TRUE)
-	}
-	field(B,DBF_DOUBLE) {
-		prompt("Value of Input B")
-		pp(TRUE)
-	}
-	field(C,DBF_DOUBLE) {
-		prompt("Value of Input C")
-		pp(TRUE)
-	}
-	field(D,DBF_DOUBLE) {
-		prompt("Value of Input D")
-		pp(TRUE)
-	}
-	field(E,DBF_DOUBLE) {
-		prompt("Value of Input E")
-		pp(TRUE)
-	}
-	field(F,DBF_DOUBLE) {
-		prompt("Value of Input F")
-		pp(TRUE)
-	}
-	field(G,DBF_DOUBLE) {
-		prompt("Value of Input G")
-		pp(TRUE)
-	}
-	field(H,DBF_DOUBLE) {
-		prompt("Value of Input H")
-		pp(TRUE)
-	}
-	field(I,DBF_DOUBLE) {
-		prompt("Value of Input I")
-		pp(TRUE)
-	}
-	field(J,DBF_DOUBLE) {
-		prompt("Value of Input J")
-		pp(TRUE)
-	}
-	field(K,DBF_DOUBLE) {
-		prompt("Value of Input K")
-		pp(TRUE)
-	}
-	field(L,DBF_DOUBLE) {
-		prompt("Value of Input L")
-		pp(TRUE)
-	}
-	field(LA,DBF_DOUBLE) {
-		prompt("Prev Value of A")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(LB,DBF_DOUBLE) {
-		prompt("Prev Value of B")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(LC,DBF_DOUBLE) {
-		prompt("Prev Value of C")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(LD,DBF_DOUBLE) {
-		prompt("Prev Value of D")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(LE,DBF_DOUBLE) {
-		prompt("Prev Value of E")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(LF,DBF_DOUBLE) {
-		prompt("Prev Value of F")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(LG,DBF_DOUBLE) {
-		prompt("Prev Value of G")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(LH,DBF_DOUBLE) {
-		prompt("Prev Value of H")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(LI,DBF_DOUBLE) {
-		prompt("Prev Value of I")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(LJ,DBF_DOUBLE) {
-		prompt("Prev Value of J")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(LK,DBF_DOUBLE) {
-		prompt("Prev Value of K")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(LL,DBF_DOUBLE) {
-		prompt("Prev Value of L")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(LALM,DBF_DOUBLE) {
-		prompt("Last Value Alarmed")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(ALST,DBF_DOUBLE) {
-		prompt("Last Value Archived")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(MLST,DBF_DOUBLE) {
-		prompt("Last Val Monitored")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(NLST,DBF_USHORT) {
-		prompt("Last Index Monitored")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-}
-recordtype(seq) {
-	field(NAME,DBF_STRING) {
-		prompt("Record Name")
-		special(SPC_NOMOD)
-		size(61)
-	}
-	field(DESC,DBF_STRING) {
-		prompt("Descriptor")
-		promptgroup(GUI_COMMON)
-		size(41)
-	}
-	field(ASG,DBF_STRING) {
-		prompt("Access Security Group")
-		promptgroup(GUI_COMMON)
-		special(SPC_AS)
-		size(29)
-	}
-	field(SCAN,DBF_MENU) {
-		prompt("Scan Mechanism")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuScan)
-		interest(1)
-	}
-	field(PINI,DBF_MENU) {
-		prompt("Process at iocInit")
-		promptgroup(GUI_SCAN)
-		menu(menuPini)
-		interest(1)
-	}
-	field(PHAS,DBF_SHORT) {
-		prompt("Scan Phase")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(EVNT,DBF_SHORT) {
-		prompt("Event Number")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(TSE,DBF_SHORT) {
-		prompt("Time Stamp Event")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(TSEL,DBF_INLINK) {
-		prompt("Time Stamp Link")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(DTYP,DBF_DEVICE) {
-		prompt("Device Type")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(DISV,DBF_SHORT) {
-		prompt("Disable Value")
-		initial("1")
-		promptgroup(GUI_SCAN)
-	}
-	field(DISA,DBF_SHORT) {
-		prompt("Disable")
-	}
-	field(SDIS,DBF_INLINK) {
-		prompt("Scanning Disable")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(MLOK,DBF_NOACCESS) {
-		prompt("Monitor lock")
-		special(SPC_NOMOD)
-		extra("epicsMutexId	mlok")
-		interest(4)
-	}
-	field(MLIS,DBF_NOACCESS) {
-		prompt("Monitor List")
-		special(SPC_NOMOD)
-		extra("ELLLIST		mlis")
-		interest(4)
-	}
-	field(DISP,DBF_UCHAR) {
-		prompt("Disable putField")
-	}
-	field(PROC,DBF_UCHAR) {
-		prompt("Force Processing")
-		pp(TRUE)
-		interest(3)
-	}
-	field(STAT,DBF_MENU) {
-		prompt("Alarm Status")
-		initial("UDF")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-	}
-	field(SEVR,DBF_MENU) {
-		prompt("Alarm Severity")
-		initial("INVALID")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-	}
-	field(NSTA,DBF_MENU) {
-		prompt("New Alarm Status")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-		interest(2)
-	}
-	field(NSEV,DBF_MENU) {
-		prompt("New Alarm Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKS,DBF_MENU) {
-		prompt("Alarm Ack Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKT,DBF_MENU) {
-		prompt("Alarm Ack Transient")
-		initial("YES")
-		promptgroup(GUI_ALARMS)
-		special(SPC_NOMOD)
-		menu(menuYesNo)
-		interest(2)
-	}
-	field(DISS,DBF_MENU) {
-		prompt("Disable Alarm Sevrty")
-		promptgroup(GUI_SCAN)
-		menu(menuAlarmSevr)
-		interest(1)
-	}
-	field(LCNT,DBF_UCHAR) {
-		prompt("Lock Count")
-		special(SPC_NOMOD)
-		interest(2)
-	}
-	field(PACT,DBF_UCHAR) {
-		prompt("Record active")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(PUTF,DBF_UCHAR) {
-		prompt("dbPutField process")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(RPRO,DBF_UCHAR) {
-		prompt("Reprocess ")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(ASP,DBF_NOACCESS) {
-		prompt("Access Security Pvt")
-		special(SPC_NOMOD)
-		extra("struct asgMember *asp")
-		interest(4)
-	}
-	field(PPN,DBF_NOACCESS) {
-		prompt("addr of PUTNOTIFY")
-		special(SPC_NOMOD)
-		extra("struct putNotify *ppn")
-		interest(4)
-	}
-	field(PPNR,DBF_NOACCESS) {
-		prompt("pputNotifyRecord")
-		special(SPC_NOMOD)
-		extra("struct putNotifyRecord *ppnr")
-		interest(4)
-	}
-	field(SPVT,DBF_NOACCESS) {
-		prompt("Scan Private")
-		special(SPC_NOMOD)
-		extra("struct scan_element *spvt")
-		interest(4)
-	}
-	field(RSET,DBF_NOACCESS) {
-		prompt("Address of RSET")
-		special(SPC_NOMOD)
-		extra("struct rset	*rset")
-		interest(4)
-	}
-	field(DSET,DBF_NOACCESS) {
-		prompt("DSET address")
-		special(SPC_NOMOD)
-		extra("struct dset	*dset")
-		interest(4)
-	}
-	field(DPVT,DBF_NOACCESS) {
-		prompt("Device Private")
-		special(SPC_NOMOD)
-		extra("void		*dpvt")
-		interest(4)
-	}
-	field(RDES,DBF_NOACCESS) {
-		prompt("Address of dbRecordType")
-		special(SPC_NOMOD)
-		extra("struct dbRecordType *rdes")
-		interest(4)
-	}
-	field(LSET,DBF_NOACCESS) {
-		prompt("Lock Set")
-		special(SPC_NOMOD)
-		extra("struct lockRecord *lset")
-		interest(4)
-	}
-	field(PRIO,DBF_MENU) {
-		prompt("Scheduling Priority")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuPriority)
-		interest(1)
-	}
-	field(TPRO,DBF_UCHAR) {
-		prompt("Trace Processing")
-	}
-	field(BKPT,DBF_NOACCESS) {
-		prompt("Break Point")
-		special(SPC_NOMOD)
-		extra("char bkpt")
-		interest(1)
-	}
-	field(UDF,DBF_UCHAR) {
-		prompt("Undefined")
-		initial("1")
-		promptgroup(GUI_COMMON)
-		pp(TRUE)
-		interest(1)
-	}
-	field(TIME,DBF_NOACCESS) {
-		prompt("Time")
-		special(SPC_NOMOD)
-		extra("epicsTimeStamp	time")
-		interest(2)
-	}
-	field(FLNK,DBF_FWDLINK) {
-		prompt("Forward Process Link")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(VAL,DBF_LONG) {
-		prompt("Used to trigger")
-		pp(TRUE)
-		asl(ASL0)
-	}
-	field(SELM,DBF_MENU) {
-		prompt("Select Mechanism")
-		promptgroup(GUI_INPUTS)
-		menu(seqSELM)
-		interest(1)
-	}
-	field(SELN,DBF_USHORT) {
-		prompt("Link Selection")
-		initial("1")
-		interest(1)
-	}
-	field(SELL,DBF_INLINK) {
-		prompt("Link Selection Loc")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(PREC,DBF_SHORT) {
-		prompt("Display Precision")
-		promptgroup(GUI_DISPLAY)
-		interest(1)
-	}
-	field(DLY1,DBF_DOUBLE) {
-		prompt("Delay 1")
-		promptgroup(GUI_SEQ1)
-		interest(1)
-	}
-	field(DOL1,DBF_INLINK) {
-		prompt("Input link1")
-		promptgroup(GUI_SEQ1)
-		interest(1)
-	}
-	field(DO1,DBF_DOUBLE) {
-		prompt("Constant input 1")
-		interest(1)
-	}
-	field(LNK1,DBF_OUTLINK) {
-		prompt("Output Link 1")
-		promptgroup(GUI_SEQ1)
-		interest(1)
-	}
-	field(DLY2,DBF_DOUBLE) {
-		prompt("Delay 2")
-		promptgroup(GUI_SEQ1)
-		interest(1)
-	}
-	field(DOL2,DBF_INLINK) {
-		prompt("Input link 2")
-		promptgroup(GUI_SEQ1)
-		interest(1)
-	}
-	field(DO2,DBF_DOUBLE) {
-		prompt("Constant input 2")
-		interest(1)
-	}
-	field(LNK2,DBF_OUTLINK) {
-		prompt("Output Link 2")
-		promptgroup(GUI_SEQ1)
-		interest(1)
-	}
-	field(DLY3,DBF_DOUBLE) {
-		prompt("Delay 3")
-		promptgroup(GUI_SEQ1)
-		interest(1)
-	}
-	field(DOL3,DBF_INLINK) {
-		prompt("Input link 3")
-		promptgroup(GUI_SEQ1)
-		interest(1)
-	}
-	field(DO3,DBF_DOUBLE) {
-		prompt("Constant input 3")
-		interest(1)
-	}
-	field(LNK3,DBF_OUTLINK) {
-		prompt("Output Link 3")
-		promptgroup(GUI_SEQ1)
-		interest(1)
-	}
-	field(DLY4,DBF_DOUBLE) {
-		prompt("Delay 4")
-		promptgroup(GUI_SEQ2)
-		interest(1)
-	}
-	field(DOL4,DBF_INLINK) {
-		prompt("Input link 4")
-		promptgroup(GUI_SEQ2)
-		interest(1)
-	}
-	field(DO4,DBF_DOUBLE) {
-		prompt("Constant input 4")
-		interest(1)
-	}
-	field(LNK4,DBF_OUTLINK) {
-		prompt("Output Link 4")
-		promptgroup(GUI_SEQ2)
-		interest(1)
-	}
-	field(DLY5,DBF_DOUBLE) {
-		prompt("Delay 5")
-		promptgroup(GUI_SEQ2)
-		interest(1)
-	}
-	field(DOL5,DBF_INLINK) {
-		prompt("Input link 5")
-		promptgroup(GUI_SEQ2)
-		interest(1)
-	}
-	field(DO5,DBF_DOUBLE) {
-		prompt("Constant input 5")
-		interest(1)
-	}
-	field(LNK5,DBF_OUTLINK) {
-		prompt("Output Link 5")
-		promptgroup(GUI_SEQ2)
-		interest(1)
-	}
-	field(DLY6,DBF_DOUBLE) {
-		prompt("Delay 6")
-		promptgroup(GUI_SEQ2)
-		interest(1)
-	}
-	field(DOL6,DBF_INLINK) {
-		prompt("Input link 6")
-		promptgroup(GUI_SEQ2)
-		interest(1)
-	}
-	field(DO6,DBF_DOUBLE) {
-		prompt("Constant input 6")
-		interest(1)
-	}
-	field(LNK6,DBF_OUTLINK) {
-		prompt("Output Link 6")
-		promptgroup(GUI_SEQ2)
-		interest(1)
-	}
-	field(DLY7,DBF_DOUBLE) {
-		prompt("Delay 7")
-		promptgroup(GUI_SEQ3)
-		interest(1)
-	}
-	field(DOL7,DBF_INLINK) {
-		prompt("Input link 7")
-		promptgroup(GUI_SEQ3)
-		interest(1)
-	}
-	field(DO7,DBF_DOUBLE) {
-		prompt("Constant input 7")
-		interest(1)
-	}
-	field(LNK7,DBF_OUTLINK) {
-		prompt("Output Link 7")
-		promptgroup(GUI_SEQ3)
-		interest(1)
-	}
-	field(DLY8,DBF_DOUBLE) {
-		prompt("Delay 8")
-		promptgroup(GUI_SEQ3)
-		interest(1)
-	}
-	field(DOL8,DBF_INLINK) {
-		prompt("Input link 8")
-		promptgroup(GUI_SEQ3)
-		interest(1)
-	}
-	field(DO8,DBF_DOUBLE) {
-		prompt("Constant input 8")
-		interest(1)
-	}
-	field(LNK8,DBF_OUTLINK) {
-		prompt("Output Link 8")
-		promptgroup(GUI_SEQ3)
-		interest(1)
-	}
-	field(DLY9,DBF_DOUBLE) {
-		prompt("Delay 9")
-		promptgroup(GUI_SEQ3)
-		interest(1)
-	}
-	field(DOL9,DBF_INLINK) {
-		prompt("Input link 9")
-		promptgroup(GUI_SEQ3)
-		interest(1)
-	}
-	field(DO9,DBF_DOUBLE) {
-		prompt("Constant input 9")
-		interest(1)
-	}
-	field(LNK9,DBF_OUTLINK) {
-		prompt("Output Link 9")
-		promptgroup(GUI_SEQ3)
-		interest(1)
-	}
-	field(DLYA,DBF_DOUBLE) {
-		prompt("Delay 10")
-		promptgroup(GUI_SEQ3)
-		interest(1)
-	}
-	field(DOLA,DBF_INLINK) {
-		prompt("Input link 10")
-		promptgroup(GUI_SEQ3)
-		interest(1)
-	}
-	field(DOA,DBF_DOUBLE) {
-		prompt("Constant input 10")
-		interest(1)
-	}
-	field(LNKA,DBF_OUTLINK) {
-		prompt("Output Link 10")
-		promptgroup(GUI_SEQ3)
-		interest(1)
-	}
-}
+device(calcout, CONSTANT, devCalcoutSoft, "Soft Channel")
+device(calcout, CONSTANT, devCalcoutSoftCallback, "Async Soft Channel")
 recordtype(state) {
-	field(NAME,DBF_STRING) {
-		prompt("Record Name")
-		special(SPC_NOMOD)
-		size(61)
-	}
-	field(DESC,DBF_STRING) {
-		prompt("Descriptor")
-		promptgroup(GUI_COMMON)
-		size(41)
-	}
-	field(ASG,DBF_STRING) {
-		prompt("Access Security Group")
-		promptgroup(GUI_COMMON)
-		special(SPC_AS)
-		size(29)
-	}
-	field(SCAN,DBF_MENU) {
-		prompt("Scan Mechanism")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuScan)
-		interest(1)
-	}
-	field(PINI,DBF_MENU) {
-		prompt("Process at iocInit")
-		promptgroup(GUI_SCAN)
-		menu(menuPini)
-		interest(1)
-	}
-	field(PHAS,DBF_SHORT) {
-		prompt("Scan Phase")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(EVNT,DBF_SHORT) {
-		prompt("Event Number")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(TSE,DBF_SHORT) {
-		prompt("Time Stamp Event")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(TSEL,DBF_INLINK) {
-		prompt("Time Stamp Link")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(DTYP,DBF_DEVICE) {
-		prompt("Device Type")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(DISV,DBF_SHORT) {
-		prompt("Disable Value")
-		initial("1")
-		promptgroup(GUI_SCAN)
-	}
-	field(DISA,DBF_SHORT) {
-		prompt("Disable")
-	}
-	field(SDIS,DBF_INLINK) {
-		prompt("Scanning Disable")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(MLOK,DBF_NOACCESS) {
-		prompt("Monitor lock")
-		special(SPC_NOMOD)
-		extra("epicsMutexId	mlok")
-		interest(4)
-	}
-	field(MLIS,DBF_NOACCESS) {
-		prompt("Monitor List")
-		special(SPC_NOMOD)
-		extra("ELLLIST		mlis")
-		interest(4)
-	}
-	field(DISP,DBF_UCHAR) {
-		prompt("Disable putField")
-	}
-	field(PROC,DBF_UCHAR) {
-		prompt("Force Processing")
-		pp(TRUE)
-		interest(3)
-	}
-	field(STAT,DBF_MENU) {
-		prompt("Alarm Status")
-		initial("UDF")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-	}
-	field(SEVR,DBF_MENU) {
-		prompt("Alarm Severity")
-		initial("INVALID")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-	}
-	field(NSTA,DBF_MENU) {
-		prompt("New Alarm Status")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-		interest(2)
-	}
-	field(NSEV,DBF_MENU) {
-		prompt("New Alarm Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKS,DBF_MENU) {
-		prompt("Alarm Ack Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKT,DBF_MENU) {
-		prompt("Alarm Ack Transient")
-		initial("YES")
-		promptgroup(GUI_ALARMS)
-		special(SPC_NOMOD)
-		menu(menuYesNo)
-		interest(2)
-	}
-	field(DISS,DBF_MENU) {
-		prompt("Disable Alarm Sevrty")
-		promptgroup(GUI_SCAN)
-		menu(menuAlarmSevr)
-		interest(1)
-	}
-	field(LCNT,DBF_UCHAR) {
-		prompt("Lock Count")
-		special(SPC_NOMOD)
-		interest(2)
-	}
-	field(PACT,DBF_UCHAR) {
-		prompt("Record active")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(PUTF,DBF_UCHAR) {
-		prompt("dbPutField process")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(RPRO,DBF_UCHAR) {
-		prompt("Reprocess ")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(ASP,DBF_NOACCESS) {
-		prompt("Access Security Pvt")
-		special(SPC_NOMOD)
-		extra("struct asgMember *asp")
-		interest(4)
-	}
-	field(PPN,DBF_NOACCESS) {
-		prompt("addr of PUTNOTIFY")
-		special(SPC_NOMOD)
-		extra("struct putNotify *ppn")
-		interest(4)
-	}
-	field(PPNR,DBF_NOACCESS) {
-		prompt("pputNotifyRecord")
-		special(SPC_NOMOD)
-		extra("struct putNotifyRecord *ppnr")
-		interest(4)
-	}
-	field(SPVT,DBF_NOACCESS) {
-		prompt("Scan Private")
-		special(SPC_NOMOD)
-		extra("struct scan_element *spvt")
-		interest(4)
-	}
-	field(RSET,DBF_NOACCESS) {
-		prompt("Address of RSET")
-		special(SPC_NOMOD)
-		extra("struct rset	*rset")
-		interest(4)
-	}
-	field(DSET,DBF_NOACCESS) {
-		prompt("DSET address")
-		special(SPC_NOMOD)
-		extra("struct dset	*dset")
-		interest(4)
-	}
-	field(DPVT,DBF_NOACCESS) {
-		prompt("Device Private")
-		special(SPC_NOMOD)
-		extra("void		*dpvt")
-		interest(4)
-	}
-	field(RDES,DBF_NOACCESS) {
-		prompt("Address of dbRecordType")
-		special(SPC_NOMOD)
-		extra("struct dbRecordType *rdes")
-		interest(4)
-	}
-	field(LSET,DBF_NOACCESS) {
-		prompt("Lock Set")
-		special(SPC_NOMOD)
-		extra("struct lockRecord *lset")
-		interest(4)
-	}
-	field(PRIO,DBF_MENU) {
-		prompt("Scheduling Priority")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuPriority)
-		interest(1)
-	}
-	field(TPRO,DBF_UCHAR) {
-		prompt("Trace Processing")
-	}
-	field(BKPT,DBF_NOACCESS) {
-		prompt("Break Point")
-		special(SPC_NOMOD)
-		extra("char bkpt")
-		interest(1)
-	}
-	field(UDF,DBF_UCHAR) {
-		prompt("Undefined")
-		initial("1")
-		promptgroup(GUI_COMMON)
-		pp(TRUE)
-		interest(1)
-	}
-	field(TIME,DBF_NOACCESS) {
-		prompt("Time")
-		special(SPC_NOMOD)
-		extra("epicsTimeStamp	time")
-		interest(2)
-	}
-	field(FLNK,DBF_FWDLINK) {
-		prompt("Forward Process Link")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(VAL,DBF_STRING) {
-		prompt("Value")
-		promptgroup(GUI_DISPLAY)
-		size(20)
-		pp(TRUE)
-		asl(ASL0)
-	}
-	field(OVAL,DBF_STRING) {
-		prompt("Prev Value")
-		special(SPC_NOMOD)
-		size(20)
-		interest(3)
-	}
+    %#include "epicsTypes.h"
+    %#include "link.h"
+    %#include "epicsMutex.h"
+    %#include "ellLib.h"
+    %#include "epicsTime.h"
+    field(NAME, DBF_STRING) {
+        special(SPC_NOMOD)
+        size(61)
+        prompt("Record Name")
+    }
+    field(DESC, DBF_STRING) {
+        promptgroup("10 - Common")
+        size(41)
+        prompt("Descriptor")
+    }
+    field(ASG, DBF_STRING) {
+        promptgroup("10 - Common")
+        special(SPC_AS)
+        size(29)
+        prompt("Access Security Group")
+    }
+    field(SCAN, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuScan)
+        interest(1)
+        prompt("Scan Mechanism")
+    }
+    field(PINI, DBF_MENU) {
+        promptgroup("20 - Scan")
+        menu(menuPini)
+        interest(1)
+        prompt("Process at iocInit")
+    }
+    field(PHAS, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        prompt("Scan Phase")
+    }
+    field(EVNT, DBF_STRING) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        size(40)
+        prompt("Event Name")
+    }
+    field(TSE, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Event")
+    }
+    field(TSEL, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Link")
+    }
+    field(DTYP, DBF_DEVICE) {
+        promptgroup("10 - Common")
+        interest(1)
+        prompt("Device Type")
+    }
+    field(DISV, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        initial("1")
+        prompt("Disable Value")
+    }
+    field(DISA, DBF_SHORT) {
+        prompt("Disable")
+    }
+    field(SDIS, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Scanning Disable")
+    }
+    field(MLOK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsMutexId        mlok")
+        interest(4)
+        prompt("Monitor lock")
+    }
+    field(MLIS, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             mlis")
+        interest(4)
+        prompt("Monitor List")
+    }
+    field(BKLNK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             bklnk")
+        interest(4)
+        prompt("Backwards link tracking")
+    }
+    field(DISP, DBF_UCHAR) {
+        prompt("Disable putField")
+    }
+    field(PROC, DBF_UCHAR) {
+        interest(3)
+        pp(TRUE)
+        prompt("Force Processing")
+    }
+    field(STAT, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        initial("UDF")
+        prompt("Alarm Status")
+    }
+    field(SEVR, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        prompt("Alarm Severity")
+    }
+    field(NSTA, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        interest(2)
+        prompt("New Alarm Status")
+    }
+    field(NSEV, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("New Alarm Severity")
+    }
+    field(ACKS, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("Alarm Ack Severity")
+    }
+    field(ACKT, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        special(SPC_NOMOD)
+        menu(menuYesNo)
+        initial("YES")
+        interest(2)
+        prompt("Alarm Ack Transient")
+    }
+    field(DISS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        prompt("Disable Alarm Sevrty")
+    }
+    field(LCNT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(2)
+        prompt("Lock Count")
+    }
+    field(PACT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Record active")
+    }
+    field(PUTF, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("dbPutField process")
+    }
+    field(RPRO, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Reprocess ")
+    }
+    field(ASP, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct asgMember    *asp")
+        interest(4)
+        prompt("Access Security Pvt")
+    }
+    field(PPN, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotify *ppn")
+        interest(4)
+        prompt("pprocessNotify")
+    }
+    field(PPNR, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotifyRecord *ppnr")
+        interest(4)
+        prompt("pprocessNotifyRecord")
+    }
+    field(SPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct scan_element *spvt")
+        interest(4)
+        prompt("Scan Private")
+    }
+    field(RSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct typed_rset   *rset")
+        interest(4)
+        prompt("Address of RSET")
+    }
+    field(DSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dset         *dset")
+        interest(4)
+        prompt("DSET address")
+    }
+    field(DPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("void                *dpvt")
+        interest(4)
+        prompt("Device Private")
+    }
+    field(RDES, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dbRecordType *rdes")
+        interest(4)
+        prompt("Address of dbRecordType")
+    }
+    field(LSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct lockRecord   *lset")
+        interest(4)
+        prompt("Lock Set")
+    }
+    field(PRIO, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuPriority)
+        interest(1)
+        prompt("Scheduling Priority")
+    }
+    field(TPRO, DBF_UCHAR) {
+        prompt("Trace Processing")
+    }
+    field(BKPT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("char                bkpt")
+        interest(1)
+        prompt("Break Point")
+    }
+    field(UDF, DBF_UCHAR) {
+        promptgroup("10 - Common")
+        initial("1")
+        interest(1)
+        pp(TRUE)
+        prompt("Undefined")
+    }
+    field(UDFS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        initial("INVALID")
+        interest(1)
+        prompt("Undefined Alarm Sevrty")
+    }
+    field(TIME, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsTimeStamp      time")
+        interest(2)
+        prompt("Time")
+    }
+    field(FLNK, DBF_FWDLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Forward Process Link")
+    }
+    field(VAL, DBF_STRING) {
+        promptgroup("40 - Input")
+        asl(ASL0)
+        pp(TRUE)
+        size(20)
+        prompt("Value")
+    }
+    field(OVAL, DBF_STRING) {
+        special(SPC_NOMOD)
+        interest(3)
+        size(20)
+        prompt("Prev Value")
+    }
 }
-recordtype(stringin) {
-	field(NAME,DBF_STRING) {
-		prompt("Record Name")
-		special(SPC_NOMOD)
-		size(61)
-	}
-	field(DESC,DBF_STRING) {
-		prompt("Descriptor")
-		promptgroup(GUI_COMMON)
-		size(41)
-	}
-	field(ASG,DBF_STRING) {
-		prompt("Access Security Group")
-		promptgroup(GUI_COMMON)
-		special(SPC_AS)
-		size(29)
-	}
-	field(SCAN,DBF_MENU) {
-		prompt("Scan Mechanism")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuScan)
-		interest(1)
-	}
-	field(PINI,DBF_MENU) {
-		prompt("Process at iocInit")
-		promptgroup(GUI_SCAN)
-		menu(menuPini)
-		interest(1)
-	}
-	field(PHAS,DBF_SHORT) {
-		prompt("Scan Phase")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(EVNT,DBF_SHORT) {
-		prompt("Event Number")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(TSE,DBF_SHORT) {
-		prompt("Time Stamp Event")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(TSEL,DBF_INLINK) {
-		prompt("Time Stamp Link")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(DTYP,DBF_DEVICE) {
-		prompt("Device Type")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(DISV,DBF_SHORT) {
-		prompt("Disable Value")
-		initial("1")
-		promptgroup(GUI_SCAN)
-	}
-	field(DISA,DBF_SHORT) {
-		prompt("Disable")
-	}
-	field(SDIS,DBF_INLINK) {
-		prompt("Scanning Disable")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(MLOK,DBF_NOACCESS) {
-		prompt("Monitor lock")
-		special(SPC_NOMOD)
-		extra("epicsMutexId	mlok")
-		interest(4)
-	}
-	field(MLIS,DBF_NOACCESS) {
-		prompt("Monitor List")
-		special(SPC_NOMOD)
-		extra("ELLLIST		mlis")
-		interest(4)
-	}
-	field(DISP,DBF_UCHAR) {
-		prompt("Disable putField")
-	}
-	field(PROC,DBF_UCHAR) {
-		prompt("Force Processing")
-		pp(TRUE)
-		interest(3)
-	}
-	field(STAT,DBF_MENU) {
-		prompt("Alarm Status")
-		initial("UDF")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-	}
-	field(SEVR,DBF_MENU) {
-		prompt("Alarm Severity")
-		initial("INVALID")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-	}
-	field(NSTA,DBF_MENU) {
-		prompt("New Alarm Status")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-		interest(2)
-	}
-	field(NSEV,DBF_MENU) {
-		prompt("New Alarm Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKS,DBF_MENU) {
-		prompt("Alarm Ack Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKT,DBF_MENU) {
-		prompt("Alarm Ack Transient")
-		initial("YES")
-		promptgroup(GUI_ALARMS)
-		special(SPC_NOMOD)
-		menu(menuYesNo)
-		interest(2)
-	}
-	field(DISS,DBF_MENU) {
-		prompt("Disable Alarm Sevrty")
-		promptgroup(GUI_SCAN)
-		menu(menuAlarmSevr)
-		interest(1)
-	}
-	field(LCNT,DBF_UCHAR) {
-		prompt("Lock Count")
-		special(SPC_NOMOD)
-		interest(2)
-	}
-	field(PACT,DBF_UCHAR) {
-		prompt("Record active")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(PUTF,DBF_UCHAR) {
-		prompt("dbPutField process")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(RPRO,DBF_UCHAR) {
-		prompt("Reprocess ")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(ASP,DBF_NOACCESS) {
-		prompt("Access Security Pvt")
-		special(SPC_NOMOD)
-		extra("struct asgMember *asp")
-		interest(4)
-	}
-	field(PPN,DBF_NOACCESS) {
-		prompt("addr of PUTNOTIFY")
-		special(SPC_NOMOD)
-		extra("struct putNotify *ppn")
-		interest(4)
-	}
-	field(PPNR,DBF_NOACCESS) {
-		prompt("pputNotifyRecord")
-		special(SPC_NOMOD)
-		extra("struct putNotifyRecord *ppnr")
-		interest(4)
-	}
-	field(SPVT,DBF_NOACCESS) {
-		prompt("Scan Private")
-		special(SPC_NOMOD)
-		extra("struct scan_element *spvt")
-		interest(4)
-	}
-	field(RSET,DBF_NOACCESS) {
-		prompt("Address of RSET")
-		special(SPC_NOMOD)
-		extra("struct rset	*rset")
-		interest(4)
-	}
-	field(DSET,DBF_NOACCESS) {
-		prompt("DSET address")
-		special(SPC_NOMOD)
-		extra("struct dset	*dset")
-		interest(4)
-	}
-	field(DPVT,DBF_NOACCESS) {
-		prompt("Device Private")
-		special(SPC_NOMOD)
-		extra("void		*dpvt")
-		interest(4)
-	}
-	field(RDES,DBF_NOACCESS) {
-		prompt("Address of dbRecordType")
-		special(SPC_NOMOD)
-		extra("struct dbRecordType *rdes")
-		interest(4)
-	}
-	field(LSET,DBF_NOACCESS) {
-		prompt("Lock Set")
-		special(SPC_NOMOD)
-		extra("struct lockRecord *lset")
-		interest(4)
-	}
-	field(PRIO,DBF_MENU) {
-		prompt("Scheduling Priority")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuPriority)
-		interest(1)
-	}
-	field(TPRO,DBF_UCHAR) {
-		prompt("Trace Processing")
-	}
-	field(BKPT,DBF_NOACCESS) {
-		prompt("Break Point")
-		special(SPC_NOMOD)
-		extra("char bkpt")
-		interest(1)
-	}
-	field(UDF,DBF_UCHAR) {
-		prompt("Undefined")
-		initial("1")
-		promptgroup(GUI_COMMON)
-		pp(TRUE)
-		interest(1)
-	}
-	field(TIME,DBF_NOACCESS) {
-		prompt("Time")
-		special(SPC_NOMOD)
-		extra("epicsTimeStamp	time")
-		interest(2)
-	}
-	field(FLNK,DBF_FWDLINK) {
-		prompt("Forward Process Link")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(VAL,DBF_STRING) {
-		prompt("Current Value")
-		promptgroup(GUI_INPUTS)
-		size(40)
-		pp(TRUE)
-		asl(ASL0)
-	}
-	field(OVAL,DBF_STRING) {
-		prompt("Previous Value")
-		special(SPC_NOMOD)
-		size(40)
-		interest(3)
-	}
-	field(INP,DBF_INLINK) {
-		prompt("Input Specification")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(MPST,DBF_MENU) {
-		prompt("Post Value Monitors")
-		promptgroup(GUI_DISPLAY)
-		menu(stringinPOST)
-		interest(1)
-	}
-	field(APST,DBF_MENU) {
-		prompt("Post Archive Monitors")
-		promptgroup(GUI_DISPLAY)
-		menu(stringinPOST)
-		interest(1)
-	}
-	field(SIOL,DBF_INLINK) {
-		prompt("Sim Input Specifctn")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(SVAL,DBF_STRING) {
-		prompt("Simulation Value")
-		size(40)
-		pp(TRUE)
-	}
-	field(SIML,DBF_INLINK) {
-		prompt("Sim Mode Location")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(SIMM,DBF_MENU) {
-		prompt("Simulation Mode")
-		menu(menuYesNo)
-		interest(1)
-	}
-	field(SIMS,DBF_MENU) {
-		prompt("Sim mode Alarm Svrty")
-		promptgroup(GUI_INPUTS)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
+recordtype(histogram) {
+    %#include "epicsTypes.h"
+    %#include "link.h"
+    %#include "epicsMutex.h"
+    %#include "ellLib.h"
+    %#include "epicsTime.h"
+    %#include "callback.h"
+    field(NAME, DBF_STRING) {
+        special(SPC_NOMOD)
+        size(61)
+        prompt("Record Name")
+    }
+    field(DESC, DBF_STRING) {
+        promptgroup("10 - Common")
+        size(41)
+        prompt("Descriptor")
+    }
+    field(ASG, DBF_STRING) {
+        promptgroup("10 - Common")
+        special(SPC_AS)
+        size(29)
+        prompt("Access Security Group")
+    }
+    field(SCAN, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuScan)
+        interest(1)
+        prompt("Scan Mechanism")
+    }
+    field(PINI, DBF_MENU) {
+        promptgroup("20 - Scan")
+        menu(menuPini)
+        interest(1)
+        prompt("Process at iocInit")
+    }
+    field(PHAS, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        prompt("Scan Phase")
+    }
+    field(EVNT, DBF_STRING) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        size(40)
+        prompt("Event Name")
+    }
+    field(TSE, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Event")
+    }
+    field(TSEL, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Link")
+    }
+    field(DTYP, DBF_DEVICE) {
+        promptgroup("10 - Common")
+        interest(1)
+        prompt("Device Type")
+    }
+    field(DISV, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        initial("1")
+        prompt("Disable Value")
+    }
+    field(DISA, DBF_SHORT) {
+        prompt("Disable")
+    }
+    field(SDIS, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Scanning Disable")
+    }
+    field(MLOK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsMutexId        mlok")
+        interest(4)
+        prompt("Monitor lock")
+    }
+    field(MLIS, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             mlis")
+        interest(4)
+        prompt("Monitor List")
+    }
+    field(BKLNK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             bklnk")
+        interest(4)
+        prompt("Backwards link tracking")
+    }
+    field(DISP, DBF_UCHAR) {
+        prompt("Disable putField")
+    }
+    field(PROC, DBF_UCHAR) {
+        interest(3)
+        pp(TRUE)
+        prompt("Force Processing")
+    }
+    field(STAT, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        initial("UDF")
+        prompt("Alarm Status")
+    }
+    field(SEVR, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        prompt("Alarm Severity")
+    }
+    field(NSTA, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        interest(2)
+        prompt("New Alarm Status")
+    }
+    field(NSEV, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("New Alarm Severity")
+    }
+    field(ACKS, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("Alarm Ack Severity")
+    }
+    field(ACKT, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        special(SPC_NOMOD)
+        menu(menuYesNo)
+        initial("YES")
+        interest(2)
+        prompt("Alarm Ack Transient")
+    }
+    field(DISS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        prompt("Disable Alarm Sevrty")
+    }
+    field(LCNT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(2)
+        prompt("Lock Count")
+    }
+    field(PACT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Record active")
+    }
+    field(PUTF, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("dbPutField process")
+    }
+    field(RPRO, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Reprocess ")
+    }
+    field(ASP, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct asgMember    *asp")
+        interest(4)
+        prompt("Access Security Pvt")
+    }
+    field(PPN, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotify *ppn")
+        interest(4)
+        prompt("pprocessNotify")
+    }
+    field(PPNR, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotifyRecord *ppnr")
+        interest(4)
+        prompt("pprocessNotifyRecord")
+    }
+    field(SPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct scan_element *spvt")
+        interest(4)
+        prompt("Scan Private")
+    }
+    field(RSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct typed_rset   *rset")
+        interest(4)
+        prompt("Address of RSET")
+    }
+    field(DSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dset         *dset")
+        interest(4)
+        prompt("DSET address")
+    }
+    field(DPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("void                *dpvt")
+        interest(4)
+        prompt("Device Private")
+    }
+    field(RDES, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dbRecordType *rdes")
+        interest(4)
+        prompt("Address of dbRecordType")
+    }
+    field(LSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct lockRecord   *lset")
+        interest(4)
+        prompt("Lock Set")
+    }
+    field(PRIO, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuPriority)
+        interest(1)
+        prompt("Scheduling Priority")
+    }
+    field(TPRO, DBF_UCHAR) {
+        prompt("Trace Processing")
+    }
+    field(BKPT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("char                bkpt")
+        interest(1)
+        prompt("Break Point")
+    }
+    field(UDF, DBF_UCHAR) {
+        promptgroup("10 - Common")
+        initial("1")
+        interest(1)
+        pp(TRUE)
+        prompt("Undefined")
+    }
+    field(UDFS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        initial("INVALID")
+        interest(1)
+        prompt("Undefined Alarm Sevrty")
+    }
+    field(TIME, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsTimeStamp      time")
+        interest(2)
+        prompt("Time")
+    }
+    field(FLNK, DBF_FWDLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Forward Process Link")
+    }
+    field(VAL, DBF_NOACCESS) {
+        special(SPC_DBADDR)
+        asl(ASL0)
+        extra("void *	val")
+        prompt("Value")
+    }
+    field(NELM, DBF_USHORT) {
+        promptgroup("30 - Action")
+        special(SPC_NOMOD)
+        initial("1")
+        interest(1)
+        prompt("Num of Array Elements")
+    }
+    field(CSTA, DBF_SHORT) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(1)
+        prompt("Collection Status")
+    }
+    field(CMD, DBF_MENU) {
+        special(SPC_CALC)
+        asl(ASL0)
+        menu(histogramCMD)
+        interest(1)
+        prompt("Collection Control")
+    }
+    field(ULIM, DBF_DOUBLE) {
+        prop(YES)
+        promptgroup("30 - Action")
+        special(SPC_RESET)
+        interest(1)
+        prompt("Upper Signal Limit")
+    }
+    field(LLIM, DBF_DOUBLE) {
+        prop(YES)
+        promptgroup("30 - Action")
+        special(SPC_RESET)
+        interest(1)
+        prompt("Lower Signal Limit ")
+    }
+    field(WDTH, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Element Width")
+    }
+    field(SGNL, DBF_DOUBLE) {
+        special(SPC_MOD)
+        prompt("Signal Value")
+    }
+    field(PREC, DBF_SHORT) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("Display Precision")
+    }
+    field(SVL, DBF_INLINK) {
+        promptgroup("40 - Input")
+        interest(1)
+        prompt("Signal Value Location")
+    }
+    field(BPTR, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsUInt32 *bptr")
+        interest(4)
+        prompt("Buffer Pointer")
+    }
+    field(WDOG, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("void *  wdog")
+        interest(4)
+        prompt("Watchdog callback")
+    }
+    field(MDEL, DBF_SHORT) {
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("Monitor Count Deadband")
+    }
+    field(MCNT, DBF_SHORT) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Counts Since Monitor")
+    }
+    field(SDEL, DBF_DOUBLE) {
+        promptgroup("80 - Display")
+        special(SPC_RESET)
+        interest(1)
+        prompt("Monitor Seconds Dband")
+    }
+    field(SIOL, DBF_INLINK) {
+        promptgroup("90 - Simulate")
+        interest(1)
+        prompt("Simulation Input Link")
+    }
+    field(SVAL, DBF_DOUBLE) {
+        prompt("Simulation Value")
+    }
+    field(SIML, DBF_INLINK) {
+        promptgroup("90 - Simulate")
+        interest(1)
+        prompt("Simulation Mode Link")
+    }
+    field(SIMM, DBF_MENU) {
+        special(SPC_MOD)
+        menu(menuYesNo)
+        interest(1)
+        prompt("Simulation Mode")
+    }
+    field(SIMS, DBF_MENU) {
+        promptgroup("90 - Simulate")
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("Simulation Mode Severity")
+    }
+    field(OLDSIMM, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuSimm)
+        interest(4)
+        prompt("Prev. Simulation Mode")
+    }
+    field(SSCN, DBF_MENU) {
+        promptgroup("90 - Simulate")
+        menu(menuScan)
+        initial("65535")
+        interest(1)
+        prompt("Sim. Mode Scan")
+    }
+    field(SDLY, DBF_DOUBLE) {
+        promptgroup("90 - Simulate")
+        initial("-1.0")
+        interest(2)
+        prompt("Sim. Mode Async Delay")
+    }
+    field(SIMPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("CALLBACK            *simpvt")
+        interest(4)
+        prompt("Sim. Mode Private")
+    }
+    field(HOPR, DBF_ULONG) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("High Operating Range")
+    }
+    field(LOPR, DBF_ULONG) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("Low Operating Range")
+    }
+}
+device(histogram, CONSTANT, devHistogramSoft, "Soft Channel")
+recordtype(lsi) {
+    %#include "epicsTypes.h"
+    %#include "link.h"
+    %#include "epicsMutex.h"
+    %#include "ellLib.h"
+    %#include "epicsTime.h"
+    %#include "devSup.h"
+    %
+    %/* Declare Device Support Entry Table */
+    %typedef struct lsidset {
+    %    long number;
+    %    DEVSUPFUN report;
+    %    DEVSUPFUN init;
+    %    DEVSUPFUN init_record;
+    %    DEVSUPFUN get_ioint_info;
+    %    DEVSUPFUN read_string;
+    %} lsidset;
+    %
+    %#include "callback.h"
+    field(NAME, DBF_STRING) {
+        special(SPC_NOMOD)
+        size(61)
+        prompt("Record Name")
+    }
+    field(DESC, DBF_STRING) {
+        promptgroup("10 - Common")
+        size(41)
+        prompt("Descriptor")
+    }
+    field(ASG, DBF_STRING) {
+        promptgroup("10 - Common")
+        special(SPC_AS)
+        size(29)
+        prompt("Access Security Group")
+    }
+    field(SCAN, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuScan)
+        interest(1)
+        prompt("Scan Mechanism")
+    }
+    field(PINI, DBF_MENU) {
+        promptgroup("20 - Scan")
+        menu(menuPini)
+        interest(1)
+        prompt("Process at iocInit")
+    }
+    field(PHAS, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        prompt("Scan Phase")
+    }
+    field(EVNT, DBF_STRING) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        size(40)
+        prompt("Event Name")
+    }
+    field(TSE, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Event")
+    }
+    field(TSEL, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Link")
+    }
+    field(DTYP, DBF_DEVICE) {
+        promptgroup("10 - Common")
+        interest(1)
+        prompt("Device Type")
+    }
+    field(DISV, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        initial("1")
+        prompt("Disable Value")
+    }
+    field(DISA, DBF_SHORT) {
+        prompt("Disable")
+    }
+    field(SDIS, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Scanning Disable")
+    }
+    field(MLOK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsMutexId        mlok")
+        interest(4)
+        prompt("Monitor lock")
+    }
+    field(MLIS, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             mlis")
+        interest(4)
+        prompt("Monitor List")
+    }
+    field(BKLNK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             bklnk")
+        interest(4)
+        prompt("Backwards link tracking")
+    }
+    field(DISP, DBF_UCHAR) {
+        prompt("Disable putField")
+    }
+    field(PROC, DBF_UCHAR) {
+        interest(3)
+        pp(TRUE)
+        prompt("Force Processing")
+    }
+    field(STAT, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        initial("UDF")
+        prompt("Alarm Status")
+    }
+    field(SEVR, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        prompt("Alarm Severity")
+    }
+    field(NSTA, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        interest(2)
+        prompt("New Alarm Status")
+    }
+    field(NSEV, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("New Alarm Severity")
+    }
+    field(ACKS, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("Alarm Ack Severity")
+    }
+    field(ACKT, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        special(SPC_NOMOD)
+        menu(menuYesNo)
+        initial("YES")
+        interest(2)
+        prompt("Alarm Ack Transient")
+    }
+    field(DISS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        prompt("Disable Alarm Sevrty")
+    }
+    field(LCNT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(2)
+        prompt("Lock Count")
+    }
+    field(PACT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Record active")
+    }
+    field(PUTF, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("dbPutField process")
+    }
+    field(RPRO, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Reprocess ")
+    }
+    field(ASP, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct asgMember    *asp")
+        interest(4)
+        prompt("Access Security Pvt")
+    }
+    field(PPN, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotify *ppn")
+        interest(4)
+        prompt("pprocessNotify")
+    }
+    field(PPNR, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotifyRecord *ppnr")
+        interest(4)
+        prompt("pprocessNotifyRecord")
+    }
+    field(SPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct scan_element *spvt")
+        interest(4)
+        prompt("Scan Private")
+    }
+    field(RSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct typed_rset   *rset")
+        interest(4)
+        prompt("Address of RSET")
+    }
+    field(DSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dset         *dset")
+        interest(4)
+        prompt("DSET address")
+    }
+    field(DPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("void                *dpvt")
+        interest(4)
+        prompt("Device Private")
+    }
+    field(RDES, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dbRecordType *rdes")
+        interest(4)
+        prompt("Address of dbRecordType")
+    }
+    field(LSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct lockRecord   *lset")
+        interest(4)
+        prompt("Lock Set")
+    }
+    field(PRIO, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuPriority)
+        interest(1)
+        prompt("Scheduling Priority")
+    }
+    field(TPRO, DBF_UCHAR) {
+        prompt("Trace Processing")
+    }
+    field(BKPT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("char                bkpt")
+        interest(1)
+        prompt("Break Point")
+    }
+    field(UDF, DBF_UCHAR) {
+        promptgroup("10 - Common")
+        initial("1")
+        interest(1)
+        pp(TRUE)
+        prompt("Undefined")
+    }
+    field(UDFS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        initial("INVALID")
+        interest(1)
+        prompt("Undefined Alarm Sevrty")
+    }
+    field(TIME, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsTimeStamp      time")
+        interest(2)
+        prompt("Time")
+    }
+    field(FLNK, DBF_FWDLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Forward Process Link")
+    }
+    field(VAL, DBF_NOACCESS) {
+        special(SPC_DBADDR)
+        asl(ASL0)
+        extra("char *val")
+        pp(TRUE)
+        prompt("Current Value")
+    }
+    field(OVAL, DBF_NOACCESS) {
+        special(SPC_DBADDR)
+        extra("char *oval")
+        interest(3)
+        prompt("Old Value")
+    }
+    field(SIZV, DBF_USHORT) {
+        promptgroup("40 - Input")
+        special(SPC_NOMOD)
+        initial("41")
+        interest(1)
+        prompt("Size of buffers")
+    }
+    field(LEN, DBF_ULONG) {
+        special(SPC_NOMOD)
+        prompt("Length of VAL")
+    }
+    field(OLEN, DBF_ULONG) {
+        special(SPC_NOMOD)
+        prompt("Length of OVAL")
+    }
+    field(INP, DBF_INLINK) {
+        promptgroup("40 - Input")
+        interest(1)
+        prompt("Input Specification")
+    }
+    field(MPST, DBF_MENU) {
+        promptgroup("80 - Display")
+        menu(menuPost)
+        interest(1)
+        prompt("Post Value Monitors")
+    }
+    field(APST, DBF_MENU) {
+        promptgroup("80 - Display")
+        menu(menuPost)
+        interest(1)
+        prompt("Post Archive Monitors")
+    }
+    field(SIML, DBF_INLINK) {
+        promptgroup("90 - Simulate")
+        interest(1)
+        prompt("Simulation Mode Link")
+    }
+    field(SIMM, DBF_MENU) {
+        special(SPC_MOD)
+        menu(menuYesNo)
+        interest(1)
+        prompt("Simulation Mode")
+    }
+    field(SIMS, DBF_MENU) {
+        promptgroup("90 - Simulate")
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("Simulation Mode Severity")
+    }
+    field(SIOL, DBF_INLINK) {
+        promptgroup("90 - Simulate")
+        interest(1)
+        prompt("Simulation Input Link")
+    }
+    field(OLDSIMM, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuSimm)
+        interest(4)
+        prompt("Prev. Simulation Mode")
+    }
+    field(SSCN, DBF_MENU) {
+        promptgroup("90 - Simulate")
+        menu(menuScan)
+        initial("65535")
+        interest(1)
+        prompt("Sim. Mode Scan")
+    }
+    field(SDLY, DBF_DOUBLE) {
+        promptgroup("90 - Simulate")
+        initial("-1.0")
+        interest(2)
+        prompt("Sim. Mode Async Delay")
+    }
+    field(SIMPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("CALLBACK            *simpvt")
+        interest(4)
+        prompt("Sim. Mode Private")
+    }
+}
+device(lsi, CONSTANT, devLsiSoft, "Soft Channel")
+device(lsi, INST_IO, devLsiEnviron, "getenv")
+recordtype(int64out) {
+    %#include "epicsTypes.h"
+    %#include "link.h"
+    %#include "epicsMutex.h"
+    %#include "ellLib.h"
+    %#include "epicsTime.h"
+    %#include "callback.h"
+    field(NAME, DBF_STRING) {
+        special(SPC_NOMOD)
+        size(61)
+        prompt("Record Name")
+    }
+    field(DESC, DBF_STRING) {
+        promptgroup("10 - Common")
+        size(41)
+        prompt("Descriptor")
+    }
+    field(ASG, DBF_STRING) {
+        promptgroup("10 - Common")
+        special(SPC_AS)
+        size(29)
+        prompt("Access Security Group")
+    }
+    field(SCAN, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuScan)
+        interest(1)
+        prompt("Scan Mechanism")
+    }
+    field(PINI, DBF_MENU) {
+        promptgroup("20 - Scan")
+        menu(menuPini)
+        interest(1)
+        prompt("Process at iocInit")
+    }
+    field(PHAS, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        prompt("Scan Phase")
+    }
+    field(EVNT, DBF_STRING) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        size(40)
+        prompt("Event Name")
+    }
+    field(TSE, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Event")
+    }
+    field(TSEL, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Link")
+    }
+    field(DTYP, DBF_DEVICE) {
+        promptgroup("10 - Common")
+        interest(1)
+        prompt("Device Type")
+    }
+    field(DISV, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        initial("1")
+        prompt("Disable Value")
+    }
+    field(DISA, DBF_SHORT) {
+        prompt("Disable")
+    }
+    field(SDIS, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Scanning Disable")
+    }
+    field(MLOK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsMutexId        mlok")
+        interest(4)
+        prompt("Monitor lock")
+    }
+    field(MLIS, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             mlis")
+        interest(4)
+        prompt("Monitor List")
+    }
+    field(BKLNK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             bklnk")
+        interest(4)
+        prompt("Backwards link tracking")
+    }
+    field(DISP, DBF_UCHAR) {
+        prompt("Disable putField")
+    }
+    field(PROC, DBF_UCHAR) {
+        interest(3)
+        pp(TRUE)
+        prompt("Force Processing")
+    }
+    field(STAT, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        initial("UDF")
+        prompt("Alarm Status")
+    }
+    field(SEVR, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        prompt("Alarm Severity")
+    }
+    field(NSTA, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        interest(2)
+        prompt("New Alarm Status")
+    }
+    field(NSEV, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("New Alarm Severity")
+    }
+    field(ACKS, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("Alarm Ack Severity")
+    }
+    field(ACKT, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        special(SPC_NOMOD)
+        menu(menuYesNo)
+        initial("YES")
+        interest(2)
+        prompt("Alarm Ack Transient")
+    }
+    field(DISS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        prompt("Disable Alarm Sevrty")
+    }
+    field(LCNT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(2)
+        prompt("Lock Count")
+    }
+    field(PACT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Record active")
+    }
+    field(PUTF, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("dbPutField process")
+    }
+    field(RPRO, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Reprocess ")
+    }
+    field(ASP, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct asgMember    *asp")
+        interest(4)
+        prompt("Access Security Pvt")
+    }
+    field(PPN, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotify *ppn")
+        interest(4)
+        prompt("pprocessNotify")
+    }
+    field(PPNR, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotifyRecord *ppnr")
+        interest(4)
+        prompt("pprocessNotifyRecord")
+    }
+    field(SPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct scan_element *spvt")
+        interest(4)
+        prompt("Scan Private")
+    }
+    field(RSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct typed_rset   *rset")
+        interest(4)
+        prompt("Address of RSET")
+    }
+    field(DSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dset         *dset")
+        interest(4)
+        prompt("DSET address")
+    }
+    field(DPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("void                *dpvt")
+        interest(4)
+        prompt("Device Private")
+    }
+    field(RDES, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dbRecordType *rdes")
+        interest(4)
+        prompt("Address of dbRecordType")
+    }
+    field(LSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct lockRecord   *lset")
+        interest(4)
+        prompt("Lock Set")
+    }
+    field(PRIO, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuPriority)
+        interest(1)
+        prompt("Scheduling Priority")
+    }
+    field(TPRO, DBF_UCHAR) {
+        prompt("Trace Processing")
+    }
+    field(BKPT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("char                bkpt")
+        interest(1)
+        prompt("Break Point")
+    }
+    field(UDF, DBF_UCHAR) {
+        promptgroup("10 - Common")
+        initial("1")
+        interest(1)
+        pp(TRUE)
+        prompt("Undefined")
+    }
+    field(UDFS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        initial("INVALID")
+        interest(1)
+        prompt("Undefined Alarm Sevrty")
+    }
+    field(TIME, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsTimeStamp      time")
+        interest(2)
+        prompt("Time")
+    }
+    field(FLNK, DBF_FWDLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Forward Process Link")
+    }
+    field(VAL, DBF_INT64) {
+        promptgroup("50 - Output")
+        asl(ASL0)
+        pp(TRUE)
+        prompt("Desired Output")
+    }
+    field(OUT, DBF_OUTLINK) {
+        promptgroup("50 - Output")
+        interest(1)
+        prompt("Output Specification")
+    }
+    field(DOL, DBF_INLINK) {
+        promptgroup("40 - Input")
+        interest(1)
+        prompt("Desired Output Loc")
+    }
+    field(OMSL, DBF_MENU) {
+        promptgroup("50 - Output")
+        menu(menuOmsl)
+        interest(1)
+        prompt("Output Mode Select")
+    }
+    field(EGU, DBF_STRING) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        size(16)
+        prompt("Units name")
+    }
+    field(DRVH, DBF_INT64) {
+        prop(YES)
+        promptgroup("30 - Action")
+        interest(1)
+        pp(TRUE)
+        prompt("Drive High Limit")
+    }
+    field(DRVL, DBF_INT64) {
+        prop(YES)
+        promptgroup("30 - Action")
+        interest(1)
+        pp(TRUE)
+        prompt("Drive Low Limit")
+    }
+    field(HOPR, DBF_INT64) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("High Operating Range")
+    }
+    field(LOPR, DBF_INT64) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("Low Operating Range")
+    }
+    field(HIHI, DBF_INT64) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        interest(1)
+        pp(TRUE)
+        prompt("Hihi Alarm Limit")
+    }
+    field(LOLO, DBF_INT64) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        interest(1)
+        pp(TRUE)
+        prompt("Lolo Alarm Limit")
+    }
+    field(HIGH, DBF_INT64) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        interest(1)
+        pp(TRUE)
+        prompt("High Alarm Limit")
+    }
+    field(LOW, DBF_INT64) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        interest(1)
+        pp(TRUE)
+        prompt("Low Alarm Limit")
+    }
+    field(HHSV, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("Hihi Severity")
+    }
+    field(LLSV, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("Lolo Severity")
+    }
+    field(HSV, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("High Severity")
+    }
+    field(LSV, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("Low Severity")
+    }
+    field(HYST, DBF_INT64) {
+        promptgroup("70 - Alarm")
+        interest(1)
+        prompt("Alarm Deadband")
+    }
+    field(ADEL, DBF_INT64) {
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("Archive Deadband")
+    }
+    field(MDEL, DBF_INT64) {
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("Monitor Deadband")
+    }
+    field(LALM, DBF_INT64) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Last Value Alarmed")
+    }
+    field(ALST, DBF_INT64) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Last Value Archived")
+    }
+    field(MLST, DBF_INT64) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Last Val Monitored")
+    }
+    field(SIOL, DBF_OUTLINK) {
+        promptgroup("90 - Simulate")
+        interest(1)
+        prompt("Simulation Output Link")
+    }
+    field(SIML, DBF_INLINK) {
+        promptgroup("90 - Simulate")
+        interest(1)
+        prompt("Simulation Mode Link")
+    }
+    field(SIMM, DBF_MENU) {
+        special(SPC_MOD)
+        menu(menuYesNo)
+        interest(1)
+        prompt("Simulation Mode")
+    }
+    field(SIMS, DBF_MENU) {
+        promptgroup("90 - Simulate")
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("Simulation Mode Severity")
+    }
+    field(OLDSIMM, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuSimm)
+        interest(4)
+        prompt("Prev. Simulation Mode")
+    }
+    field(SSCN, DBF_MENU) {
+        promptgroup("90 - Simulate")
+        menu(menuScan)
+        initial("65535")
+        interest(1)
+        prompt("Sim. Mode Scan")
+    }
+    field(SDLY, DBF_DOUBLE) {
+        promptgroup("90 - Simulate")
+        initial("-1.0")
+        interest(2)
+        prompt("Sim. Mode Async Delay")
+    }
+    field(SIMPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("CALLBACK            *simpvt")
+        interest(4)
+        prompt("Sim. Mode Private")
+    }
+    field(IVOA, DBF_MENU) {
+        promptgroup("50 - Output")
+        menu(menuIvoa)
+        interest(2)
+        prompt("INVALID output action")
+    }
+    field(IVOV, DBF_INT64) {
+        promptgroup("50 - Output")
+        interest(2)
+        prompt("INVALID output value")
+    }
+}
+device(int64out, CONSTANT, devI64outSoft, "Soft Channel")
+device(int64out, CONSTANT, devI64outSoftCallback, "Async Soft Channel")
+recordtype(seq) {
+    %#include "epicsTypes.h"
+    %#include "link.h"
+    %#include "epicsMutex.h"
+    %#include "ellLib.h"
+    %#include "epicsTime.h"
+    field(NAME, DBF_STRING) {
+        special(SPC_NOMOD)
+        size(61)
+        prompt("Record Name")
+    }
+    field(DESC, DBF_STRING) {
+        promptgroup("10 - Common")
+        size(41)
+        prompt("Descriptor")
+    }
+    field(ASG, DBF_STRING) {
+        promptgroup("10 - Common")
+        special(SPC_AS)
+        size(29)
+        prompt("Access Security Group")
+    }
+    field(SCAN, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuScan)
+        interest(1)
+        prompt("Scan Mechanism")
+    }
+    field(PINI, DBF_MENU) {
+        promptgroup("20 - Scan")
+        menu(menuPini)
+        interest(1)
+        prompt("Process at iocInit")
+    }
+    field(PHAS, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        prompt("Scan Phase")
+    }
+    field(EVNT, DBF_STRING) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        size(40)
+        prompt("Event Name")
+    }
+    field(TSE, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Event")
+    }
+    field(TSEL, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Link")
+    }
+    field(DTYP, DBF_DEVICE) {
+        promptgroup("10 - Common")
+        interest(1)
+        prompt("Device Type")
+    }
+    field(DISV, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        initial("1")
+        prompt("Disable Value")
+    }
+    field(DISA, DBF_SHORT) {
+        prompt("Disable")
+    }
+    field(SDIS, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Scanning Disable")
+    }
+    field(MLOK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsMutexId        mlok")
+        interest(4)
+        prompt("Monitor lock")
+    }
+    field(MLIS, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             mlis")
+        interest(4)
+        prompt("Monitor List")
+    }
+    field(BKLNK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             bklnk")
+        interest(4)
+        prompt("Backwards link tracking")
+    }
+    field(DISP, DBF_UCHAR) {
+        prompt("Disable putField")
+    }
+    field(PROC, DBF_UCHAR) {
+        interest(3)
+        pp(TRUE)
+        prompt("Force Processing")
+    }
+    field(STAT, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        initial("UDF")
+        prompt("Alarm Status")
+    }
+    field(SEVR, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        prompt("Alarm Severity")
+    }
+    field(NSTA, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        interest(2)
+        prompt("New Alarm Status")
+    }
+    field(NSEV, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("New Alarm Severity")
+    }
+    field(ACKS, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("Alarm Ack Severity")
+    }
+    field(ACKT, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        special(SPC_NOMOD)
+        menu(menuYesNo)
+        initial("YES")
+        interest(2)
+        prompt("Alarm Ack Transient")
+    }
+    field(DISS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        prompt("Disable Alarm Sevrty")
+    }
+    field(LCNT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(2)
+        prompt("Lock Count")
+    }
+    field(PACT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Record active")
+    }
+    field(PUTF, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("dbPutField process")
+    }
+    field(RPRO, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Reprocess ")
+    }
+    field(ASP, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct asgMember    *asp")
+        interest(4)
+        prompt("Access Security Pvt")
+    }
+    field(PPN, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotify *ppn")
+        interest(4)
+        prompt("pprocessNotify")
+    }
+    field(PPNR, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotifyRecord *ppnr")
+        interest(4)
+        prompt("pprocessNotifyRecord")
+    }
+    field(SPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct scan_element *spvt")
+        interest(4)
+        prompt("Scan Private")
+    }
+    field(RSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct typed_rset   *rset")
+        interest(4)
+        prompt("Address of RSET")
+    }
+    field(DSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dset         *dset")
+        interest(4)
+        prompt("DSET address")
+    }
+    field(DPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("void                *dpvt")
+        interest(4)
+        prompt("Device Private")
+    }
+    field(RDES, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dbRecordType *rdes")
+        interest(4)
+        prompt("Address of dbRecordType")
+    }
+    field(LSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct lockRecord   *lset")
+        interest(4)
+        prompt("Lock Set")
+    }
+    field(PRIO, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuPriority)
+        interest(1)
+        prompt("Scheduling Priority")
+    }
+    field(TPRO, DBF_UCHAR) {
+        prompt("Trace Processing")
+    }
+    field(BKPT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("char                bkpt")
+        interest(1)
+        prompt("Break Point")
+    }
+    field(UDF, DBF_UCHAR) {
+        promptgroup("10 - Common")
+        initial("1")
+        interest(1)
+        pp(TRUE)
+        prompt("Undefined")
+    }
+    field(UDFS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        initial("INVALID")
+        interest(1)
+        prompt("Undefined Alarm Sevrty")
+    }
+    field(TIME, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsTimeStamp      time")
+        interest(2)
+        prompt("Time")
+    }
+    field(FLNK, DBF_FWDLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Forward Process Link")
+    }
+    field(VAL, DBF_LONG) {
+        asl(ASL0)
+        pp(TRUE)
+        prompt("Used to trigger")
+    }
+    field(SELM, DBF_MENU) {
+        promptgroup("30 - Action")
+        menu(seqSELM)
+        interest(1)
+        prompt("Select Mechanism")
+    }
+    field(SELN, DBF_USHORT) {
+        initial("1")
+        interest(1)
+        prompt("Link Selection")
+    }
+    field(SELL, DBF_INLINK) {
+        promptgroup("30 - Action")
+        interest(1)
+        prompt("Link Selection Loc")
+    }
+    field(OFFS, DBF_SHORT) {
+        promptgroup("30 - Action")
+        initial("0")
+        interest(1)
+        prompt("Offset for Specified")
+    }
+    field(SHFT, DBF_SHORT) {
+        promptgroup("30 - Action")
+        initial("-1")
+        interest(1)
+        prompt("Shift for Mask mode")
+    }
+    field(OLDN, DBF_USHORT) {
+        interest(4)
+        prompt("Old Selection")
+    }
+    field(PREC, DBF_SHORT) {
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("Display Precision")
+    }
+    field(DLY0, DBF_DOUBLE) {
+        promptgroup("41 - Link 0-7")
+        interest(1)
+        prompt("Delay 0")
+    }
+    field(DOL0, DBF_INLINK) {
+        promptgroup("41 - Link 0-7")
+        interest(1)
+        prompt("Input link 0")
+    }
+    field(DO0, DBF_DOUBLE) {
+        interest(1)
+        prompt("Value 0")
+    }
+    field(LNK0, DBF_OUTLINK) {
+        promptgroup("41 - Link 0-7")
+        interest(1)
+        prompt("Output Link 0")
+    }
+    field(DLY1, DBF_DOUBLE) {
+        promptgroup("41 - Link 0-7")
+        interest(1)
+        prompt("Delay 1")
+    }
+    field(DOL1, DBF_INLINK) {
+        promptgroup("41 - Link 0-7")
+        interest(1)
+        prompt("Input link1")
+    }
+    field(DO1, DBF_DOUBLE) {
+        interest(1)
+        prompt("Value 1")
+    }
+    field(LNK1, DBF_OUTLINK) {
+        promptgroup("41 - Link 0-7")
+        interest(1)
+        prompt("Output Link 1")
+    }
+    field(DLY2, DBF_DOUBLE) {
+        promptgroup("41 - Link 0-7")
+        interest(1)
+        prompt("Delay 2")
+    }
+    field(DOL2, DBF_INLINK) {
+        promptgroup("41 - Link 0-7")
+        interest(1)
+        prompt("Input link 2")
+    }
+    field(DO2, DBF_DOUBLE) {
+        interest(1)
+        prompt("Value 2")
+    }
+    field(LNK2, DBF_OUTLINK) {
+        promptgroup("41 - Link 0-7")
+        interest(1)
+        prompt("Output Link 2")
+    }
+    field(DLY3, DBF_DOUBLE) {
+        promptgroup("41 - Link 0-7")
+        interest(1)
+        prompt("Delay 3")
+    }
+    field(DOL3, DBF_INLINK) {
+        promptgroup("41 - Link 0-7")
+        interest(1)
+        prompt("Input link 3")
+    }
+    field(DO3, DBF_DOUBLE) {
+        interest(1)
+        prompt("Value 3")
+    }
+    field(LNK3, DBF_OUTLINK) {
+        promptgroup("41 - Link 0-7")
+        interest(1)
+        prompt("Output Link 3")
+    }
+    field(DLY4, DBF_DOUBLE) {
+        promptgroup("41 - Link 0-7")
+        interest(1)
+        prompt("Delay 4")
+    }
+    field(DOL4, DBF_INLINK) {
+        promptgroup("41 - Link 0-7")
+        interest(1)
+        prompt("Input link 4")
+    }
+    field(DO4, DBF_DOUBLE) {
+        interest(1)
+        prompt("Value 4")
+    }
+    field(LNK4, DBF_OUTLINK) {
+        promptgroup("41 - Link 0-7")
+        interest(1)
+        prompt("Output Link 4")
+    }
+    field(DLY5, DBF_DOUBLE) {
+        promptgroup("41 - Link 0-7")
+        interest(1)
+        prompt("Delay 5")
+    }
+    field(DOL5, DBF_INLINK) {
+        promptgroup("41 - Link 0-7")
+        interest(1)
+        prompt("Input link 5")
+    }
+    field(DO5, DBF_DOUBLE) {
+        interest(1)
+        prompt("Value 5")
+    }
+    field(LNK5, DBF_OUTLINK) {
+        promptgroup("41 - Link 0-7")
+        interest(1)
+        prompt("Output Link 5")
+    }
+    field(DLY6, DBF_DOUBLE) {
+        promptgroup("41 - Link 0-7")
+        interest(1)
+        prompt("Delay 6")
+    }
+    field(DOL6, DBF_INLINK) {
+        promptgroup("41 - Link 0-7")
+        interest(1)
+        prompt("Input link 6")
+    }
+    field(DO6, DBF_DOUBLE) {
+        interest(1)
+        prompt("Value 6")
+    }
+    field(LNK6, DBF_OUTLINK) {
+        promptgroup("41 - Link 0-7")
+        interest(1)
+        prompt("Output Link 6")
+    }
+    field(DLY7, DBF_DOUBLE) {
+        promptgroup("41 - Link 0-7")
+        interest(1)
+        prompt("Delay 7")
+    }
+    field(DOL7, DBF_INLINK) {
+        promptgroup("41 - Link 0-7")
+        interest(1)
+        prompt("Input link 7")
+    }
+    field(DO7, DBF_DOUBLE) {
+        interest(1)
+        prompt("Value 7")
+    }
+    field(LNK7, DBF_OUTLINK) {
+        promptgroup("41 - Link 0-7")
+        interest(1)
+        prompt("Output Link 7")
+    }
+    field(DLY8, DBF_DOUBLE) {
+        promptgroup("42 - Link 8-F")
+        interest(1)
+        prompt("Delay 8")
+    }
+    field(DOL8, DBF_INLINK) {
+        promptgroup("42 - Link 8-F")
+        interest(1)
+        prompt("Input link 8")
+    }
+    field(DO8, DBF_DOUBLE) {
+        interest(1)
+        prompt("Value 8")
+    }
+    field(LNK8, DBF_OUTLINK) {
+        promptgroup("42 - Link 8-F")
+        interest(1)
+        prompt("Output Link 8")
+    }
+    field(DLY9, DBF_DOUBLE) {
+        promptgroup("42 - Link 8-F")
+        interest(1)
+        prompt("Delay 9")
+    }
+    field(DOL9, DBF_INLINK) {
+        promptgroup("42 - Link 8-F")
+        interest(1)
+        prompt("Input link 9")
+    }
+    field(DO9, DBF_DOUBLE) {
+        interest(1)
+        prompt("Value 9")
+    }
+    field(LNK9, DBF_OUTLINK) {
+        promptgroup("42 - Link 8-F")
+        interest(1)
+        prompt("Output Link 9")
+    }
+    field(DLYA, DBF_DOUBLE) {
+        promptgroup("42 - Link 8-F")
+        interest(1)
+        prompt("Delay 10")
+    }
+    field(DOLA, DBF_INLINK) {
+        promptgroup("42 - Link 8-F")
+        interest(1)
+        prompt("Input link 10")
+    }
+    field(DOA, DBF_DOUBLE) {
+        interest(1)
+        prompt("Value 10")
+    }
+    field(LNKA, DBF_OUTLINK) {
+        promptgroup("42 - Link 8-F")
+        interest(1)
+        prompt("Output Link 10")
+    }
+    field(DLYB, DBF_DOUBLE) {
+        promptgroup("42 - Link 8-F")
+        interest(1)
+        prompt("Delay 11")
+    }
+    field(DOLB, DBF_INLINK) {
+        promptgroup("42 - Link 8-F")
+        interest(1)
+        prompt("Input link 11")
+    }
+    field(DOB, DBF_DOUBLE) {
+        interest(1)
+        prompt("Value 11")
+    }
+    field(LNKB, DBF_OUTLINK) {
+        promptgroup("42 - Link 8-F")
+        interest(1)
+        prompt("Output Link 11")
+    }
+    field(DLYC, DBF_DOUBLE) {
+        promptgroup("42 - Link 8-F")
+        interest(1)
+        prompt("Delay 12")
+    }
+    field(DOLC, DBF_INLINK) {
+        promptgroup("42 - Link 8-F")
+        interest(1)
+        prompt("Input link 12")
+    }
+    field(DOC, DBF_DOUBLE) {
+        interest(1)
+        prompt("Value 12")
+    }
+    field(LNKC, DBF_OUTLINK) {
+        promptgroup("42 - Link 8-F")
+        interest(1)
+        prompt("Output Link 12")
+    }
+    field(DLYD, DBF_DOUBLE) {
+        promptgroup("42 - Link 8-F")
+        interest(1)
+        prompt("Delay 13")
+    }
+    field(DOLD, DBF_INLINK) {
+        promptgroup("42 - Link 8-F")
+        interest(1)
+        prompt("Input link 13")
+    }
+    field(DOD, DBF_DOUBLE) {
+        interest(1)
+        prompt("Value 13")
+    }
+    field(LNKD, DBF_OUTLINK) {
+        promptgroup("42 - Link 8-F")
+        interest(1)
+        prompt("Output Link 13")
+    }
+    field(DLYE, DBF_DOUBLE) {
+        promptgroup("42 - Link 8-F")
+        interest(1)
+        prompt("Delay 14")
+    }
+    field(DOLE, DBF_INLINK) {
+        promptgroup("42 - Link 8-F")
+        interest(1)
+        prompt("Input link 14")
+    }
+    field(DOE, DBF_DOUBLE) {
+        interest(1)
+        prompt("Value 14")
+    }
+    field(LNKE, DBF_OUTLINK) {
+        promptgroup("42 - Link 8-F")
+        interest(1)
+        prompt("Output Link 14")
+    }
+    field(DLYF, DBF_DOUBLE) {
+        promptgroup("42 - Link 8-F")
+        interest(1)
+        prompt("Delay 15")
+    }
+    field(DOLF, DBF_INLINK) {
+        promptgroup("42 - Link 8-F")
+        interest(1)
+        prompt("Input link 15")
+    }
+    field(DOF, DBF_DOUBLE) {
+        interest(1)
+        prompt("Value 15")
+    }
+    field(LNKF, DBF_OUTLINK) {
+        promptgroup("42 - Link 8-F")
+        interest(1)
+        prompt("Output Link 15")
+    }
 }
 recordtype(stringout) {
-	field(NAME,DBF_STRING) {
-		prompt("Record Name")
-		special(SPC_NOMOD)
-		size(61)
-	}
-	field(DESC,DBF_STRING) {
-		prompt("Descriptor")
-		promptgroup(GUI_COMMON)
-		size(41)
-	}
-	field(ASG,DBF_STRING) {
-		prompt("Access Security Group")
-		promptgroup(GUI_COMMON)
-		special(SPC_AS)
-		size(29)
-	}
-	field(SCAN,DBF_MENU) {
-		prompt("Scan Mechanism")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuScan)
-		interest(1)
-	}
-	field(PINI,DBF_MENU) {
-		prompt("Process at iocInit")
-		promptgroup(GUI_SCAN)
-		menu(menuPini)
-		interest(1)
-	}
-	field(PHAS,DBF_SHORT) {
-		prompt("Scan Phase")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(EVNT,DBF_SHORT) {
-		prompt("Event Number")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(TSE,DBF_SHORT) {
-		prompt("Time Stamp Event")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(TSEL,DBF_INLINK) {
-		prompt("Time Stamp Link")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(DTYP,DBF_DEVICE) {
-		prompt("Device Type")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(DISV,DBF_SHORT) {
-		prompt("Disable Value")
-		initial("1")
-		promptgroup(GUI_SCAN)
-	}
-	field(DISA,DBF_SHORT) {
-		prompt("Disable")
-	}
-	field(SDIS,DBF_INLINK) {
-		prompt("Scanning Disable")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(MLOK,DBF_NOACCESS) {
-		prompt("Monitor lock")
-		special(SPC_NOMOD)
-		extra("epicsMutexId	mlok")
-		interest(4)
-	}
-	field(MLIS,DBF_NOACCESS) {
-		prompt("Monitor List")
-		special(SPC_NOMOD)
-		extra("ELLLIST		mlis")
-		interest(4)
-	}
-	field(DISP,DBF_UCHAR) {
-		prompt("Disable putField")
-	}
-	field(PROC,DBF_UCHAR) {
-		prompt("Force Processing")
-		pp(TRUE)
-		interest(3)
-	}
-	field(STAT,DBF_MENU) {
-		prompt("Alarm Status")
-		initial("UDF")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-	}
-	field(SEVR,DBF_MENU) {
-		prompt("Alarm Severity")
-		initial("INVALID")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-	}
-	field(NSTA,DBF_MENU) {
-		prompt("New Alarm Status")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-		interest(2)
-	}
-	field(NSEV,DBF_MENU) {
-		prompt("New Alarm Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKS,DBF_MENU) {
-		prompt("Alarm Ack Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKT,DBF_MENU) {
-		prompt("Alarm Ack Transient")
-		initial("YES")
-		promptgroup(GUI_ALARMS)
-		special(SPC_NOMOD)
-		menu(menuYesNo)
-		interest(2)
-	}
-	field(DISS,DBF_MENU) {
-		prompt("Disable Alarm Sevrty")
-		promptgroup(GUI_SCAN)
-		menu(menuAlarmSevr)
-		interest(1)
-	}
-	field(LCNT,DBF_UCHAR) {
-		prompt("Lock Count")
-		special(SPC_NOMOD)
-		interest(2)
-	}
-	field(PACT,DBF_UCHAR) {
-		prompt("Record active")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(PUTF,DBF_UCHAR) {
-		prompt("dbPutField process")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(RPRO,DBF_UCHAR) {
-		prompt("Reprocess ")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(ASP,DBF_NOACCESS) {
-		prompt("Access Security Pvt")
-		special(SPC_NOMOD)
-		extra("struct asgMember *asp")
-		interest(4)
-	}
-	field(PPN,DBF_NOACCESS) {
-		prompt("addr of PUTNOTIFY")
-		special(SPC_NOMOD)
-		extra("struct putNotify *ppn")
-		interest(4)
-	}
-	field(PPNR,DBF_NOACCESS) {
-		prompt("pputNotifyRecord")
-		special(SPC_NOMOD)
-		extra("struct putNotifyRecord *ppnr")
-		interest(4)
-	}
-	field(SPVT,DBF_NOACCESS) {
-		prompt("Scan Private")
-		special(SPC_NOMOD)
-		extra("struct scan_element *spvt")
-		interest(4)
-	}
-	field(RSET,DBF_NOACCESS) {
-		prompt("Address of RSET")
-		special(SPC_NOMOD)
-		extra("struct rset	*rset")
-		interest(4)
-	}
-	field(DSET,DBF_NOACCESS) {
-		prompt("DSET address")
-		special(SPC_NOMOD)
-		extra("struct dset	*dset")
-		interest(4)
-	}
-	field(DPVT,DBF_NOACCESS) {
-		prompt("Device Private")
-		special(SPC_NOMOD)
-		extra("void		*dpvt")
-		interest(4)
-	}
-	field(RDES,DBF_NOACCESS) {
-		prompt("Address of dbRecordType")
-		special(SPC_NOMOD)
-		extra("struct dbRecordType *rdes")
-		interest(4)
-	}
-	field(LSET,DBF_NOACCESS) {
-		prompt("Lock Set")
-		special(SPC_NOMOD)
-		extra("struct lockRecord *lset")
-		interest(4)
-	}
-	field(PRIO,DBF_MENU) {
-		prompt("Scheduling Priority")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuPriority)
-		interest(1)
-	}
-	field(TPRO,DBF_UCHAR) {
-		prompt("Trace Processing")
-	}
-	field(BKPT,DBF_NOACCESS) {
-		prompt("Break Point")
-		special(SPC_NOMOD)
-		extra("char bkpt")
-		interest(1)
-	}
-	field(UDF,DBF_UCHAR) {
-		prompt("Undefined")
-		initial("1")
-		promptgroup(GUI_COMMON)
-		pp(TRUE)
-		interest(1)
-	}
-	field(TIME,DBF_NOACCESS) {
-		prompt("Time")
-		special(SPC_NOMOD)
-		extra("epicsTimeStamp	time")
-		interest(2)
-	}
-	field(FLNK,DBF_FWDLINK) {
-		prompt("Forward Process Link")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(VAL,DBF_STRING) {
-		prompt("Current Value")
-		promptgroup(GUI_OUTPUT)
-		size(40)
-		pp(TRUE)
-		asl(ASL0)
-	}
-	field(OVAL,DBF_STRING) {
-		prompt("Previous Value")
-		special(SPC_NOMOD)
-		size(40)
-		interest(3)
-	}
-	field(DOL,DBF_INLINK) {
-		prompt("Desired Output Loc")
-		promptgroup(GUI_OUTPUT)
-		interest(1)
-	}
-	field(OMSL,DBF_MENU) {
-		prompt("Output Mode Select")
-		promptgroup(GUI_OUTPUT)
-		menu(menuOmsl)
-		interest(1)
-	}
-	field(OUT,DBF_OUTLINK) {
-		prompt("Output Specification")
-		promptgroup(GUI_OUTPUT)
-		interest(1)
-	}
-	field(MPST,DBF_MENU) {
-		prompt("Post Value Monitors")
-		promptgroup(GUI_DISPLAY)
-		menu(stringoutPOST)
-		interest(1)
-	}
-	field(APST,DBF_MENU) {
-		prompt("Post Archive Monitors")
-		promptgroup(GUI_DISPLAY)
-		menu(stringoutPOST)
-		interest(1)
-	}
-	field(SIOL,DBF_OUTLINK) {
-		prompt("Sim Output Specifctn")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(SIML,DBF_INLINK) {
-		prompt("Sim Mode Location")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(SIMM,DBF_MENU) {
-		prompt("Simulation Mode")
-		menu(menuYesNo)
-		interest(1)
-	}
-	field(SIMS,DBF_MENU) {
-		prompt("Sim mode Alarm Svrty")
-		promptgroup(GUI_INPUTS)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(IVOA,DBF_MENU) {
-		prompt("INVALID output action")
-		promptgroup(GUI_OUTPUT)
-		menu(menuIvoa)
-		interest(2)
-	}
-	field(IVOV,DBF_STRING) {
-		prompt("INVALID output value")
-		promptgroup(GUI_OUTPUT)
-		size(40)
-		interest(2)
-	}
+    %#include "epicsTypes.h"
+    %#include "link.h"
+    %#include "epicsMutex.h"
+    %#include "ellLib.h"
+    %#include "epicsTime.h"
+    %#include "callback.h"
+    field(NAME, DBF_STRING) {
+        special(SPC_NOMOD)
+        size(61)
+        prompt("Record Name")
+    }
+    field(DESC, DBF_STRING) {
+        promptgroup("10 - Common")
+        size(41)
+        prompt("Descriptor")
+    }
+    field(ASG, DBF_STRING) {
+        promptgroup("10 - Common")
+        special(SPC_AS)
+        size(29)
+        prompt("Access Security Group")
+    }
+    field(SCAN, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuScan)
+        interest(1)
+        prompt("Scan Mechanism")
+    }
+    field(PINI, DBF_MENU) {
+        promptgroup("20 - Scan")
+        menu(menuPini)
+        interest(1)
+        prompt("Process at iocInit")
+    }
+    field(PHAS, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        prompt("Scan Phase")
+    }
+    field(EVNT, DBF_STRING) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        size(40)
+        prompt("Event Name")
+    }
+    field(TSE, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Event")
+    }
+    field(TSEL, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Link")
+    }
+    field(DTYP, DBF_DEVICE) {
+        promptgroup("10 - Common")
+        interest(1)
+        prompt("Device Type")
+    }
+    field(DISV, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        initial("1")
+        prompt("Disable Value")
+    }
+    field(DISA, DBF_SHORT) {
+        prompt("Disable")
+    }
+    field(SDIS, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Scanning Disable")
+    }
+    field(MLOK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsMutexId        mlok")
+        interest(4)
+        prompt("Monitor lock")
+    }
+    field(MLIS, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             mlis")
+        interest(4)
+        prompt("Monitor List")
+    }
+    field(BKLNK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             bklnk")
+        interest(4)
+        prompt("Backwards link tracking")
+    }
+    field(DISP, DBF_UCHAR) {
+        prompt("Disable putField")
+    }
+    field(PROC, DBF_UCHAR) {
+        interest(3)
+        pp(TRUE)
+        prompt("Force Processing")
+    }
+    field(STAT, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        initial("UDF")
+        prompt("Alarm Status")
+    }
+    field(SEVR, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        prompt("Alarm Severity")
+    }
+    field(NSTA, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        interest(2)
+        prompt("New Alarm Status")
+    }
+    field(NSEV, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("New Alarm Severity")
+    }
+    field(ACKS, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("Alarm Ack Severity")
+    }
+    field(ACKT, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        special(SPC_NOMOD)
+        menu(menuYesNo)
+        initial("YES")
+        interest(2)
+        prompt("Alarm Ack Transient")
+    }
+    field(DISS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        prompt("Disable Alarm Sevrty")
+    }
+    field(LCNT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(2)
+        prompt("Lock Count")
+    }
+    field(PACT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Record active")
+    }
+    field(PUTF, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("dbPutField process")
+    }
+    field(RPRO, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Reprocess ")
+    }
+    field(ASP, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct asgMember    *asp")
+        interest(4)
+        prompt("Access Security Pvt")
+    }
+    field(PPN, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotify *ppn")
+        interest(4)
+        prompt("pprocessNotify")
+    }
+    field(PPNR, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotifyRecord *ppnr")
+        interest(4)
+        prompt("pprocessNotifyRecord")
+    }
+    field(SPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct scan_element *spvt")
+        interest(4)
+        prompt("Scan Private")
+    }
+    field(RSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct typed_rset   *rset")
+        interest(4)
+        prompt("Address of RSET")
+    }
+    field(DSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dset         *dset")
+        interest(4)
+        prompt("DSET address")
+    }
+    field(DPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("void                *dpvt")
+        interest(4)
+        prompt("Device Private")
+    }
+    field(RDES, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dbRecordType *rdes")
+        interest(4)
+        prompt("Address of dbRecordType")
+    }
+    field(LSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct lockRecord   *lset")
+        interest(4)
+        prompt("Lock Set")
+    }
+    field(PRIO, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuPriority)
+        interest(1)
+        prompt("Scheduling Priority")
+    }
+    field(TPRO, DBF_UCHAR) {
+        prompt("Trace Processing")
+    }
+    field(BKPT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("char                bkpt")
+        interest(1)
+        prompt("Break Point")
+    }
+    field(UDF, DBF_UCHAR) {
+        promptgroup("10 - Common")
+        initial("1")
+        interest(1)
+        pp(TRUE)
+        prompt("Undefined")
+    }
+    field(UDFS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        initial("INVALID")
+        interest(1)
+        prompt("Undefined Alarm Sevrty")
+    }
+    field(TIME, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsTimeStamp      time")
+        interest(2)
+        prompt("Time")
+    }
+    field(FLNK, DBF_FWDLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Forward Process Link")
+    }
+    field(VAL, DBF_STRING) {
+        promptgroup("50 - Output")
+        asl(ASL0)
+        pp(TRUE)
+        size(40)
+        prompt("Current Value")
+    }
+    field(OVAL, DBF_STRING) {
+        special(SPC_NOMOD)
+        interest(3)
+        size(40)
+        prompt("Previous Value")
+    }
+    field(DOL, DBF_INLINK) {
+        promptgroup("40 - Input")
+        interest(1)
+        prompt("Desired Output Loc")
+    }
+    field(OMSL, DBF_MENU) {
+        promptgroup("50 - Output")
+        menu(menuOmsl)
+        interest(1)
+        prompt("Output Mode Select")
+    }
+    field(OUT, DBF_OUTLINK) {
+        promptgroup("50 - Output")
+        interest(1)
+        prompt("Output Specification")
+    }
+    field(MPST, DBF_MENU) {
+        promptgroup("80 - Display")
+        menu(stringoutPOST)
+        interest(1)
+        prompt("Post Value Monitors")
+    }
+    field(APST, DBF_MENU) {
+        promptgroup("80 - Display")
+        menu(stringoutPOST)
+        interest(1)
+        prompt("Post Archive Monitors")
+    }
+    field(SIOL, DBF_OUTLINK) {
+        promptgroup("90 - Simulate")
+        interest(1)
+        prompt("Simulation Output Link")
+    }
+    field(SIML, DBF_INLINK) {
+        promptgroup("90 - Simulate")
+        interest(1)
+        prompt("Simulation Mode Link")
+    }
+    field(SIMM, DBF_MENU) {
+        special(SPC_MOD)
+        menu(menuYesNo)
+        interest(1)
+        prompt("Simulation Mode")
+    }
+    field(SIMS, DBF_MENU) {
+        promptgroup("90 - Simulate")
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("Simulation Mode Severity")
+    }
+    field(OLDSIMM, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuSimm)
+        interest(4)
+        prompt("Prev. Simulation Mode")
+    }
+    field(SSCN, DBF_MENU) {
+        promptgroup("90 - Simulate")
+        menu(menuScan)
+        initial("65535")
+        interest(1)
+        prompt("Sim. Mode Scan")
+    }
+    field(SDLY, DBF_DOUBLE) {
+        promptgroup("90 - Simulate")
+        initial("-1.0")
+        interest(2)
+        prompt("Sim. Mode Async Delay")
+    }
+    field(SIMPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("CALLBACK            *simpvt")
+        interest(4)
+        prompt("Sim. Mode Private")
+    }
+    field(IVOA, DBF_MENU) {
+        promptgroup("50 - Output")
+        menu(menuIvoa)
+        interest(2)
+        prompt("INVALID output action")
+    }
+    field(IVOV, DBF_STRING) {
+        promptgroup("50 - Output")
+        interest(2)
+        size(40)
+        prompt("INVALID output value")
+    }
+}
+device(stringout, CONSTANT, devSoSoft, "Soft Channel")
+device(stringout, CONSTANT, devSoSoftCallback, "Async Soft Channel")
+device(stringout, INST_IO, devSoStdio, "stdio")
+device(stringout, INST_IO, asynSoOctetWrite, "asynOctetWrite")
+recordtype(aai) {
+    %#include "epicsTypes.h"
+    %#include "link.h"
+    %#include "epicsMutex.h"
+    %#include "ellLib.h"
+    %#include "epicsTime.h"
+    %#include "callback.h"
+    field(NAME, DBF_STRING) {
+        special(SPC_NOMOD)
+        size(61)
+        prompt("Record Name")
+    }
+    field(DESC, DBF_STRING) {
+        promptgroup("10 - Common")
+        size(41)
+        prompt("Descriptor")
+    }
+    field(ASG, DBF_STRING) {
+        promptgroup("10 - Common")
+        special(SPC_AS)
+        size(29)
+        prompt("Access Security Group")
+    }
+    field(SCAN, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuScan)
+        interest(1)
+        prompt("Scan Mechanism")
+    }
+    field(PINI, DBF_MENU) {
+        promptgroup("20 - Scan")
+        menu(menuPini)
+        interest(1)
+        prompt("Process at iocInit")
+    }
+    field(PHAS, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        prompt("Scan Phase")
+    }
+    field(EVNT, DBF_STRING) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        size(40)
+        prompt("Event Name")
+    }
+    field(TSE, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Event")
+    }
+    field(TSEL, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Link")
+    }
+    field(DTYP, DBF_DEVICE) {
+        promptgroup("10 - Common")
+        interest(1)
+        prompt("Device Type")
+    }
+    field(DISV, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        initial("1")
+        prompt("Disable Value")
+    }
+    field(DISA, DBF_SHORT) {
+        prompt("Disable")
+    }
+    field(SDIS, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Scanning Disable")
+    }
+    field(MLOK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsMutexId        mlok")
+        interest(4)
+        prompt("Monitor lock")
+    }
+    field(MLIS, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             mlis")
+        interest(4)
+        prompt("Monitor List")
+    }
+    field(BKLNK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             bklnk")
+        interest(4)
+        prompt("Backwards link tracking")
+    }
+    field(DISP, DBF_UCHAR) {
+        prompt("Disable putField")
+    }
+    field(PROC, DBF_UCHAR) {
+        interest(3)
+        pp(TRUE)
+        prompt("Force Processing")
+    }
+    field(STAT, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        initial("UDF")
+        prompt("Alarm Status")
+    }
+    field(SEVR, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        prompt("Alarm Severity")
+    }
+    field(NSTA, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        interest(2)
+        prompt("New Alarm Status")
+    }
+    field(NSEV, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("New Alarm Severity")
+    }
+    field(ACKS, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("Alarm Ack Severity")
+    }
+    field(ACKT, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        special(SPC_NOMOD)
+        menu(menuYesNo)
+        initial("YES")
+        interest(2)
+        prompt("Alarm Ack Transient")
+    }
+    field(DISS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        prompt("Disable Alarm Sevrty")
+    }
+    field(LCNT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(2)
+        prompt("Lock Count")
+    }
+    field(PACT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Record active")
+    }
+    field(PUTF, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("dbPutField process")
+    }
+    field(RPRO, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Reprocess ")
+    }
+    field(ASP, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct asgMember    *asp")
+        interest(4)
+        prompt("Access Security Pvt")
+    }
+    field(PPN, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotify *ppn")
+        interest(4)
+        prompt("pprocessNotify")
+    }
+    field(PPNR, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotifyRecord *ppnr")
+        interest(4)
+        prompt("pprocessNotifyRecord")
+    }
+    field(SPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct scan_element *spvt")
+        interest(4)
+        prompt("Scan Private")
+    }
+    field(RSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct typed_rset   *rset")
+        interest(4)
+        prompt("Address of RSET")
+    }
+    field(DSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dset         *dset")
+        interest(4)
+        prompt("DSET address")
+    }
+    field(DPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("void                *dpvt")
+        interest(4)
+        prompt("Device Private")
+    }
+    field(RDES, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dbRecordType *rdes")
+        interest(4)
+        prompt("Address of dbRecordType")
+    }
+    field(LSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct lockRecord   *lset")
+        interest(4)
+        prompt("Lock Set")
+    }
+    field(PRIO, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuPriority)
+        interest(1)
+        prompt("Scheduling Priority")
+    }
+    field(TPRO, DBF_UCHAR) {
+        prompt("Trace Processing")
+    }
+    field(BKPT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("char                bkpt")
+        interest(1)
+        prompt("Break Point")
+    }
+    field(UDF, DBF_UCHAR) {
+        promptgroup("10 - Common")
+        initial("1")
+        interest(1)
+        pp(TRUE)
+        prompt("Undefined")
+    }
+    field(UDFS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        initial("INVALID")
+        interest(1)
+        prompt("Undefined Alarm Sevrty")
+    }
+    field(TIME, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsTimeStamp      time")
+        interest(2)
+        prompt("Time")
+    }
+    field(FLNK, DBF_FWDLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Forward Process Link")
+    }
+    field(VAL, DBF_NOACCESS) {
+        special(SPC_DBADDR)
+        asl(ASL0)
+        extra("void *		val")
+        pp(TRUE)
+        prompt("Value")
+    }
+    field(PREC, DBF_SHORT) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("Display Precision")
+    }
+    field(INP, DBF_INLINK) {
+        promptgroup("40 - Input")
+        interest(1)
+        prompt("Input Specification")
+    }
+    field(EGU, DBF_STRING) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        size(16)
+        prompt("Engineering Units")
+    }
+    field(HOPR, DBF_DOUBLE) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("High Operating Range")
+    }
+    field(LOPR, DBF_DOUBLE) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("Low Operating Range")
+    }
+    field(NELM, DBF_ULONG) {
+        promptgroup("30 - Action")
+        special(SPC_NOMOD)
+        initial("1")
+        interest(1)
+        prompt("Number of Elements")
+    }
+    field(FTVL, DBF_MENU) {
+        promptgroup("30 - Action")
+        special(SPC_NOMOD)
+        menu(menuFtype)
+        interest(1)
+        prompt("Field Type of Value")
+    }
+    field(NORD, DBF_ULONG) {
+        special(SPC_NOMOD)
+        prompt("Number elements read")
+    }
+    field(BPTR, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("void *		bptr")
+        interest(4)
+        prompt("Buffer Pointer")
+    }
+    field(SIML, DBF_INLINK) {
+        promptgroup("90 - Simulate")
+        interest(1)
+        prompt("Simulation Mode Link")
+    }
+    field(SIMM, DBF_MENU) {
+        special(SPC_MOD)
+        menu(menuYesNo)
+        interest(1)
+        prompt("Simulation Mode")
+    }
+    field(SIMS, DBF_MENU) {
+        promptgroup("90 - Simulate")
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("Simulation Mode Severity")
+    }
+    field(SIOL, DBF_INLINK) {
+        promptgroup("90 - Simulate")
+        interest(1)
+        prompt("Simulation Input Link")
+    }
+    field(OLDSIMM, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuSimm)
+        interest(4)
+        prompt("Prev. Simulation Mode")
+    }
+    field(SSCN, DBF_MENU) {
+        promptgroup("90 - Simulate")
+        menu(menuScan)
+        initial("65535")
+        interest(1)
+        prompt("Sim. Mode Scan")
+    }
+    field(SDLY, DBF_DOUBLE) {
+        promptgroup("90 - Simulate")
+        initial("-1.0")
+        interest(2)
+        prompt("Sim. Mode Async Delay")
+    }
+    field(SIMPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("CALLBACK            *simpvt")
+        interest(4)
+        prompt("Sim. Mode Private")
+    }
+    field(MPST, DBF_MENU) {
+        promptgroup("80 - Display")
+        menu(aaiPOST)
+        interest(1)
+        prompt("Post Value Monitors")
+    }
+    field(APST, DBF_MENU) {
+        promptgroup("80 - Display")
+        menu(aaiPOST)
+        interest(1)
+        prompt("Post Archive Monitors")
+    }
+    field(HASH, DBF_ULONG) {
+        interest(3)
+        prompt("Hash of OnChange data.")
+    }
+}
+device(aai, CONSTANT, devAaiSoft, "Soft Channel")
+recordtype(permissive) {
+    %#include "epicsTypes.h"
+    %#include "link.h"
+    %#include "epicsMutex.h"
+    %#include "ellLib.h"
+    %#include "epicsTime.h"
+    field(NAME, DBF_STRING) {
+        special(SPC_NOMOD)
+        size(61)
+        prompt("Record Name")
+    }
+    field(DESC, DBF_STRING) {
+        promptgroup("10 - Common")
+        size(41)
+        prompt("Descriptor")
+    }
+    field(ASG, DBF_STRING) {
+        promptgroup("10 - Common")
+        special(SPC_AS)
+        size(29)
+        prompt("Access Security Group")
+    }
+    field(SCAN, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuScan)
+        interest(1)
+        prompt("Scan Mechanism")
+    }
+    field(PINI, DBF_MENU) {
+        promptgroup("20 - Scan")
+        menu(menuPini)
+        interest(1)
+        prompt("Process at iocInit")
+    }
+    field(PHAS, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        prompt("Scan Phase")
+    }
+    field(EVNT, DBF_STRING) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        size(40)
+        prompt("Event Name")
+    }
+    field(TSE, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Event")
+    }
+    field(TSEL, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Link")
+    }
+    field(DTYP, DBF_DEVICE) {
+        promptgroup("10 - Common")
+        interest(1)
+        prompt("Device Type")
+    }
+    field(DISV, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        initial("1")
+        prompt("Disable Value")
+    }
+    field(DISA, DBF_SHORT) {
+        prompt("Disable")
+    }
+    field(SDIS, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Scanning Disable")
+    }
+    field(MLOK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsMutexId        mlok")
+        interest(4)
+        prompt("Monitor lock")
+    }
+    field(MLIS, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             mlis")
+        interest(4)
+        prompt("Monitor List")
+    }
+    field(BKLNK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             bklnk")
+        interest(4)
+        prompt("Backwards link tracking")
+    }
+    field(DISP, DBF_UCHAR) {
+        prompt("Disable putField")
+    }
+    field(PROC, DBF_UCHAR) {
+        interest(3)
+        pp(TRUE)
+        prompt("Force Processing")
+    }
+    field(STAT, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        initial("UDF")
+        prompt("Alarm Status")
+    }
+    field(SEVR, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        prompt("Alarm Severity")
+    }
+    field(NSTA, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        interest(2)
+        prompt("New Alarm Status")
+    }
+    field(NSEV, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("New Alarm Severity")
+    }
+    field(ACKS, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("Alarm Ack Severity")
+    }
+    field(ACKT, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        special(SPC_NOMOD)
+        menu(menuYesNo)
+        initial("YES")
+        interest(2)
+        prompt("Alarm Ack Transient")
+    }
+    field(DISS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        prompt("Disable Alarm Sevrty")
+    }
+    field(LCNT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(2)
+        prompt("Lock Count")
+    }
+    field(PACT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Record active")
+    }
+    field(PUTF, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("dbPutField process")
+    }
+    field(RPRO, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Reprocess ")
+    }
+    field(ASP, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct asgMember    *asp")
+        interest(4)
+        prompt("Access Security Pvt")
+    }
+    field(PPN, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotify *ppn")
+        interest(4)
+        prompt("pprocessNotify")
+    }
+    field(PPNR, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotifyRecord *ppnr")
+        interest(4)
+        prompt("pprocessNotifyRecord")
+    }
+    field(SPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct scan_element *spvt")
+        interest(4)
+        prompt("Scan Private")
+    }
+    field(RSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct typed_rset   *rset")
+        interest(4)
+        prompt("Address of RSET")
+    }
+    field(DSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dset         *dset")
+        interest(4)
+        prompt("DSET address")
+    }
+    field(DPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("void                *dpvt")
+        interest(4)
+        prompt("Device Private")
+    }
+    field(RDES, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dbRecordType *rdes")
+        interest(4)
+        prompt("Address of dbRecordType")
+    }
+    field(LSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct lockRecord   *lset")
+        interest(4)
+        prompt("Lock Set")
+    }
+    field(PRIO, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuPriority)
+        interest(1)
+        prompt("Scheduling Priority")
+    }
+    field(TPRO, DBF_UCHAR) {
+        prompt("Trace Processing")
+    }
+    field(BKPT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("char                bkpt")
+        interest(1)
+        prompt("Break Point")
+    }
+    field(UDF, DBF_UCHAR) {
+        promptgroup("10 - Common")
+        initial("1")
+        interest(1)
+        pp(TRUE)
+        prompt("Undefined")
+    }
+    field(UDFS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        initial("INVALID")
+        interest(1)
+        prompt("Undefined Alarm Sevrty")
+    }
+    field(TIME, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsTimeStamp      time")
+        interest(2)
+        prompt("Time")
+    }
+    field(FLNK, DBF_FWDLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Forward Process Link")
+    }
+    field(LABL, DBF_STRING) {
+        promptgroup("80 - Display")
+        interest(1)
+        pp(TRUE)
+        size(20)
+        prompt("Button Label")
+    }
+    field(VAL, DBF_USHORT) {
+        promptgroup("40 - Input")
+        asl(ASL0)
+        pp(TRUE)
+        prompt("Status")
+    }
+    field(OVAL, DBF_USHORT) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Old Status")
+    }
+    field(WFLG, DBF_USHORT) {
+        pp(TRUE)
+        prompt("Wait Flag")
+    }
+    field(OFLG, DBF_USHORT) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Old Flag")
+    }
+}
+recordtype(bo) {
+    %#include "epicsTypes.h"
+    %#include "link.h"
+    %#include "epicsMutex.h"
+    %#include "ellLib.h"
+    %#include "epicsTime.h"
+    %#include "callback.h"
+    field(NAME, DBF_STRING) {
+        special(SPC_NOMOD)
+        size(61)
+        prompt("Record Name")
+    }
+    field(DESC, DBF_STRING) {
+        promptgroup("10 - Common")
+        size(41)
+        prompt("Descriptor")
+    }
+    field(ASG, DBF_STRING) {
+        promptgroup("10 - Common")
+        special(SPC_AS)
+        size(29)
+        prompt("Access Security Group")
+    }
+    field(SCAN, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuScan)
+        interest(1)
+        prompt("Scan Mechanism")
+    }
+    field(PINI, DBF_MENU) {
+        promptgroup("20 - Scan")
+        menu(menuPini)
+        interest(1)
+        prompt("Process at iocInit")
+    }
+    field(PHAS, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        prompt("Scan Phase")
+    }
+    field(EVNT, DBF_STRING) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        size(40)
+        prompt("Event Name")
+    }
+    field(TSE, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Event")
+    }
+    field(TSEL, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Link")
+    }
+    field(DTYP, DBF_DEVICE) {
+        promptgroup("10 - Common")
+        interest(1)
+        prompt("Device Type")
+    }
+    field(DISV, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        initial("1")
+        prompt("Disable Value")
+    }
+    field(DISA, DBF_SHORT) {
+        prompt("Disable")
+    }
+    field(SDIS, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Scanning Disable")
+    }
+    field(MLOK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsMutexId        mlok")
+        interest(4)
+        prompt("Monitor lock")
+    }
+    field(MLIS, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             mlis")
+        interest(4)
+        prompt("Monitor List")
+    }
+    field(BKLNK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             bklnk")
+        interest(4)
+        prompt("Backwards link tracking")
+    }
+    field(DISP, DBF_UCHAR) {
+        prompt("Disable putField")
+    }
+    field(PROC, DBF_UCHAR) {
+        interest(3)
+        pp(TRUE)
+        prompt("Force Processing")
+    }
+    field(STAT, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        initial("UDF")
+        prompt("Alarm Status")
+    }
+    field(SEVR, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        prompt("Alarm Severity")
+    }
+    field(NSTA, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        interest(2)
+        prompt("New Alarm Status")
+    }
+    field(NSEV, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("New Alarm Severity")
+    }
+    field(ACKS, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("Alarm Ack Severity")
+    }
+    field(ACKT, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        special(SPC_NOMOD)
+        menu(menuYesNo)
+        initial("YES")
+        interest(2)
+        prompt("Alarm Ack Transient")
+    }
+    field(DISS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        prompt("Disable Alarm Sevrty")
+    }
+    field(LCNT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(2)
+        prompt("Lock Count")
+    }
+    field(PACT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Record active")
+    }
+    field(PUTF, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("dbPutField process")
+    }
+    field(RPRO, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Reprocess ")
+    }
+    field(ASP, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct asgMember    *asp")
+        interest(4)
+        prompt("Access Security Pvt")
+    }
+    field(PPN, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotify *ppn")
+        interest(4)
+        prompt("pprocessNotify")
+    }
+    field(PPNR, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotifyRecord *ppnr")
+        interest(4)
+        prompt("pprocessNotifyRecord")
+    }
+    field(SPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct scan_element *spvt")
+        interest(4)
+        prompt("Scan Private")
+    }
+    field(RSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct typed_rset   *rset")
+        interest(4)
+        prompt("Address of RSET")
+    }
+    field(DSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dset         *dset")
+        interest(4)
+        prompt("DSET address")
+    }
+    field(DPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("void                *dpvt")
+        interest(4)
+        prompt("Device Private")
+    }
+    field(RDES, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dbRecordType *rdes")
+        interest(4)
+        prompt("Address of dbRecordType")
+    }
+    field(LSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct lockRecord   *lset")
+        interest(4)
+        prompt("Lock Set")
+    }
+    field(PRIO, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuPriority)
+        interest(1)
+        prompt("Scheduling Priority")
+    }
+    field(TPRO, DBF_UCHAR) {
+        prompt("Trace Processing")
+    }
+    field(BKPT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("char                bkpt")
+        interest(1)
+        prompt("Break Point")
+    }
+    field(UDF, DBF_UCHAR) {
+        promptgroup("10 - Common")
+        initial("1")
+        interest(1)
+        pp(TRUE)
+        prompt("Undefined")
+    }
+    field(UDFS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        initial("INVALID")
+        interest(1)
+        prompt("Undefined Alarm Sevrty")
+    }
+    field(TIME, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsTimeStamp      time")
+        interest(2)
+        prompt("Time")
+    }
+    field(FLNK, DBF_FWDLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Forward Process Link")
+    }
+    field(VAL, DBF_ENUM) {
+        promptgroup("50 - Output")
+        asl(ASL0)
+        pp(TRUE)
+        prompt("Current Value")
+    }
+    field(OMSL, DBF_MENU) {
+        promptgroup("50 - Output")
+        menu(menuOmsl)
+        interest(1)
+        prompt("Output Mode Select")
+    }
+    field(DOL, DBF_INLINK) {
+        promptgroup("40 - Input")
+        interest(1)
+        prompt("Desired Output Loc")
+    }
+    field(OUT, DBF_OUTLINK) {
+        promptgroup("50 - Output")
+        interest(1)
+        prompt("Output Specification")
+    }
+    field(HIGH, DBF_DOUBLE) {
+        promptgroup("30 - Action")
+        interest(1)
+        prompt("Seconds to Hold High")
+    }
+    field(ZNAM, DBF_STRING) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        pp(TRUE)
+        size(26)
+        prompt("Zero Name")
+    }
+    field(ONAM, DBF_STRING) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        pp(TRUE)
+        size(26)
+        prompt("One Name")
+    }
+    field(RVAL, DBF_ULONG) {
+        pp(TRUE)
+        prompt("Raw Value")
+    }
+    field(ORAW, DBF_ULONG) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("prev Raw Value")
+    }
+    field(MASK, DBF_ULONG) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Hardware Mask")
+    }
+    field(RPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("void *  rpvt")
+        interest(4)
+        prompt("Record Private")
+    }
+    field(WDPT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("void *	wdpt")
+        interest(4)
+        prompt("Watch Dog Timer ID")
+    }
+    field(ZSV, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("Zero Error Severity")
+    }
+    field(OSV, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("One Error Severity")
+    }
+    field(COSV, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("Change of State Sevr")
+    }
+    field(RBV, DBF_ULONG) {
+        special(SPC_NOMOD)
+        prompt("Readback Value")
+    }
+    field(ORBV, DBF_ULONG) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Prev Readback Value")
+    }
+    field(MLST, DBF_USHORT) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Last Value Monitored")
+    }
+    field(LALM, DBF_USHORT) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Last Value Alarmed")
+    }
+    field(SIOL, DBF_OUTLINK) {
+        promptgroup("90 - Simulate")
+        interest(1)
+        prompt("Simulation Output Link")
+    }
+    field(SIML, DBF_INLINK) {
+        promptgroup("90 - Simulate")
+        interest(1)
+        prompt("Simulation Mode Link")
+    }
+    field(SIMM, DBF_MENU) {
+        special(SPC_MOD)
+        menu(menuYesNo)
+        interest(1)
+        prompt("Simulation Mode")
+    }
+    field(SIMS, DBF_MENU) {
+        promptgroup("90 - Simulate")
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("Simulation Mode Severity")
+    }
+    field(OLDSIMM, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuSimm)
+        interest(4)
+        prompt("Prev. Simulation Mode")
+    }
+    field(SSCN, DBF_MENU) {
+        promptgroup("90 - Simulate")
+        menu(menuScan)
+        initial("65535")
+        interest(1)
+        prompt("Sim. Mode Scan")
+    }
+    field(SDLY, DBF_DOUBLE) {
+        promptgroup("90 - Simulate")
+        initial("-1.0")
+        interest(2)
+        prompt("Sim. Mode Async Delay")
+    }
+    field(SIMPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("CALLBACK            *simpvt")
+        interest(4)
+        prompt("Sim. Mode Private")
+    }
+    field(IVOA, DBF_MENU) {
+        promptgroup("50 - Output")
+        menu(menuIvoa)
+        interest(2)
+        prompt("INVALID outpt action")
+    }
+    field(IVOV, DBF_USHORT) {
+        promptgroup("50 - Output")
+        interest(2)
+        prompt("INVALID output value")
+    }
+}
+device(bo, CONSTANT, devBoSoft, "Soft Channel")
+device(bo, CONSTANT, devBoSoftRaw, "Raw Soft Channel")
+device(bo, CONSTANT, devBoSoftCallback, "Async Soft Channel")
+device(bo, INST_IO, devBoGeneralTime, "General Time")
+device(bo, INST_IO, devBoDbState, "Db State")
+device(bo, INST_IO, asynBoInt32, "asynInt32")
+device(bo, INST_IO, asynBoUInt32Digital, "asynUInt32Digital")
+recordtype(dfanout) {
+    %#include "epicsTypes.h"
+    %#include "link.h"
+    %#include "epicsMutex.h"
+    %#include "ellLib.h"
+    %#include "epicsTime.h"
+    field(NAME, DBF_STRING) {
+        special(SPC_NOMOD)
+        size(61)
+        prompt("Record Name")
+    }
+    field(DESC, DBF_STRING) {
+        promptgroup("10 - Common")
+        size(41)
+        prompt("Descriptor")
+    }
+    field(ASG, DBF_STRING) {
+        promptgroup("10 - Common")
+        special(SPC_AS)
+        size(29)
+        prompt("Access Security Group")
+    }
+    field(SCAN, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuScan)
+        interest(1)
+        prompt("Scan Mechanism")
+    }
+    field(PINI, DBF_MENU) {
+        promptgroup("20 - Scan")
+        menu(menuPini)
+        interest(1)
+        prompt("Process at iocInit")
+    }
+    field(PHAS, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        prompt("Scan Phase")
+    }
+    field(EVNT, DBF_STRING) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        size(40)
+        prompt("Event Name")
+    }
+    field(TSE, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Event")
+    }
+    field(TSEL, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Link")
+    }
+    field(DTYP, DBF_DEVICE) {
+        promptgroup("10 - Common")
+        interest(1)
+        prompt("Device Type")
+    }
+    field(DISV, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        initial("1")
+        prompt("Disable Value")
+    }
+    field(DISA, DBF_SHORT) {
+        prompt("Disable")
+    }
+    field(SDIS, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Scanning Disable")
+    }
+    field(MLOK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsMutexId        mlok")
+        interest(4)
+        prompt("Monitor lock")
+    }
+    field(MLIS, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             mlis")
+        interest(4)
+        prompt("Monitor List")
+    }
+    field(BKLNK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             bklnk")
+        interest(4)
+        prompt("Backwards link tracking")
+    }
+    field(DISP, DBF_UCHAR) {
+        prompt("Disable putField")
+    }
+    field(PROC, DBF_UCHAR) {
+        interest(3)
+        pp(TRUE)
+        prompt("Force Processing")
+    }
+    field(STAT, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        initial("UDF")
+        prompt("Alarm Status")
+    }
+    field(SEVR, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        prompt("Alarm Severity")
+    }
+    field(NSTA, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        interest(2)
+        prompt("New Alarm Status")
+    }
+    field(NSEV, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("New Alarm Severity")
+    }
+    field(ACKS, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("Alarm Ack Severity")
+    }
+    field(ACKT, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        special(SPC_NOMOD)
+        menu(menuYesNo)
+        initial("YES")
+        interest(2)
+        prompt("Alarm Ack Transient")
+    }
+    field(DISS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        prompt("Disable Alarm Sevrty")
+    }
+    field(LCNT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(2)
+        prompt("Lock Count")
+    }
+    field(PACT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Record active")
+    }
+    field(PUTF, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("dbPutField process")
+    }
+    field(RPRO, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Reprocess ")
+    }
+    field(ASP, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct asgMember    *asp")
+        interest(4)
+        prompt("Access Security Pvt")
+    }
+    field(PPN, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotify *ppn")
+        interest(4)
+        prompt("pprocessNotify")
+    }
+    field(PPNR, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotifyRecord *ppnr")
+        interest(4)
+        prompt("pprocessNotifyRecord")
+    }
+    field(SPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct scan_element *spvt")
+        interest(4)
+        prompt("Scan Private")
+    }
+    field(RSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct typed_rset   *rset")
+        interest(4)
+        prompt("Address of RSET")
+    }
+    field(DSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dset         *dset")
+        interest(4)
+        prompt("DSET address")
+    }
+    field(DPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("void                *dpvt")
+        interest(4)
+        prompt("Device Private")
+    }
+    field(RDES, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dbRecordType *rdes")
+        interest(4)
+        prompt("Address of dbRecordType")
+    }
+    field(LSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct lockRecord   *lset")
+        interest(4)
+        prompt("Lock Set")
+    }
+    field(PRIO, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuPriority)
+        interest(1)
+        prompt("Scheduling Priority")
+    }
+    field(TPRO, DBF_UCHAR) {
+        prompt("Trace Processing")
+    }
+    field(BKPT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("char                bkpt")
+        interest(1)
+        prompt("Break Point")
+    }
+    field(UDF, DBF_UCHAR) {
+        promptgroup("10 - Common")
+        initial("1")
+        interest(1)
+        pp(TRUE)
+        prompt("Undefined")
+    }
+    field(UDFS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        initial("INVALID")
+        interest(1)
+        prompt("Undefined Alarm Sevrty")
+    }
+    field(TIME, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsTimeStamp      time")
+        interest(2)
+        prompt("Time")
+    }
+    field(FLNK, DBF_FWDLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Forward Process Link")
+    }
+    field(VAL, DBF_DOUBLE) {
+        promptgroup("40 - Input")
+        asl(ASL0)
+        pp(TRUE)
+        prompt("Desired Output")
+    }
+    field(SELM, DBF_MENU) {
+        promptgroup("30 - Action")
+        menu(dfanoutSELM)
+        interest(1)
+        prompt("Select Mechanism")
+    }
+    field(SELN, DBF_USHORT) {
+        initial("1")
+        interest(1)
+        prompt("Link Selection")
+    }
+    field(SELL, DBF_INLINK) {
+        promptgroup("30 - Action")
+        interest(1)
+        prompt("Link Selection Loc")
+    }
+    field(OUTA, DBF_OUTLINK) {
+        promptgroup("50 - Output")
+        interest(1)
+        prompt("Output Spec A")
+    }
+    field(OUTB, DBF_OUTLINK) {
+        promptgroup("50 - Output")
+        interest(1)
+        prompt("Output Spec B")
+    }
+    field(OUTC, DBF_OUTLINK) {
+        promptgroup("50 - Output")
+        interest(1)
+        prompt("Output Spec C")
+    }
+    field(OUTD, DBF_OUTLINK) {
+        promptgroup("50 - Output")
+        interest(1)
+        prompt("Output Spec D")
+    }
+    field(OUTE, DBF_OUTLINK) {
+        promptgroup("50 - Output")
+        interest(1)
+        prompt("Output Spec E")
+    }
+    field(OUTF, DBF_OUTLINK) {
+        promptgroup("50 - Output")
+        interest(1)
+        prompt("Output Spec F")
+    }
+    field(OUTG, DBF_OUTLINK) {
+        promptgroup("50 - Output")
+        interest(1)
+        prompt("Output Spec G")
+    }
+    field(OUTH, DBF_OUTLINK) {
+        promptgroup("50 - Output")
+        interest(1)
+        prompt("Output Spec H")
+    }
+    field(DOL, DBF_INLINK) {
+        promptgroup("40 - Input")
+        interest(1)
+        prompt("Desired Output Loc")
+    }
+    field(OMSL, DBF_MENU) {
+        promptgroup("50 - Output")
+        menu(menuOmsl)
+        interest(1)
+        prompt("Output Mode Select")
+    }
+    field(EGU, DBF_STRING) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        size(16)
+        prompt("Engineering Units")
+    }
+    field(PREC, DBF_SHORT) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("Display Precision")
+    }
+    field(HOPR, DBF_DOUBLE) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("High Operating Range")
+    }
+    field(LOPR, DBF_DOUBLE) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("Low Operating Range")
+    }
+    field(HIHI, DBF_DOUBLE) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        interest(1)
+        pp(TRUE)
+        prompt("Hihi Alarm Limit")
+    }
+    field(LOLO, DBF_DOUBLE) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        interest(1)
+        pp(TRUE)
+        prompt("Lolo Alarm Limit")
+    }
+    field(HIGH, DBF_DOUBLE) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        interest(1)
+        pp(TRUE)
+        prompt("High Alarm Limit")
+    }
+    field(LOW, DBF_DOUBLE) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        interest(1)
+        pp(TRUE)
+        prompt("Low Alarm Limit")
+    }
+    field(HHSV, DBF_MENU) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("Hihi Severity")
+    }
+    field(LLSV, DBF_MENU) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("Lolo Severity")
+    }
+    field(HSV, DBF_MENU) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("High Severity")
+    }
+    field(LSV, DBF_MENU) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("Low Severity")
+    }
+    field(HYST, DBF_DOUBLE) {
+        promptgroup("70 - Alarm")
+        interest(1)
+        prompt("Alarm Deadband")
+    }
+    field(ADEL, DBF_DOUBLE) {
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("Archive Deadband")
+    }
+    field(MDEL, DBF_DOUBLE) {
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("Monitor Deadband")
+    }
+    field(LALM, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Last Value Alarmed")
+    }
+    field(ALST, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Last Value Archived")
+    }
+    field(MLST, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Last Val Monitored")
+    }
+}
+recordtype(mbbi) {
+    %#include "epicsTypes.h"
+    %#include "link.h"
+    %#include "epicsMutex.h"
+    %#include "ellLib.h"
+    %#include "epicsTime.h"
+    %#include "callback.h"
+    field(NAME, DBF_STRING) {
+        special(SPC_NOMOD)
+        size(61)
+        prompt("Record Name")
+    }
+    field(DESC, DBF_STRING) {
+        promptgroup("10 - Common")
+        size(41)
+        prompt("Descriptor")
+    }
+    field(ASG, DBF_STRING) {
+        promptgroup("10 - Common")
+        special(SPC_AS)
+        size(29)
+        prompt("Access Security Group")
+    }
+    field(SCAN, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuScan)
+        interest(1)
+        prompt("Scan Mechanism")
+    }
+    field(PINI, DBF_MENU) {
+        promptgroup("20 - Scan")
+        menu(menuPini)
+        interest(1)
+        prompt("Process at iocInit")
+    }
+    field(PHAS, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        prompt("Scan Phase")
+    }
+    field(EVNT, DBF_STRING) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        size(40)
+        prompt("Event Name")
+    }
+    field(TSE, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Event")
+    }
+    field(TSEL, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Link")
+    }
+    field(DTYP, DBF_DEVICE) {
+        promptgroup("10 - Common")
+        interest(1)
+        prompt("Device Type")
+    }
+    field(DISV, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        initial("1")
+        prompt("Disable Value")
+    }
+    field(DISA, DBF_SHORT) {
+        prompt("Disable")
+    }
+    field(SDIS, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Scanning Disable")
+    }
+    field(MLOK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsMutexId        mlok")
+        interest(4)
+        prompt("Monitor lock")
+    }
+    field(MLIS, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             mlis")
+        interest(4)
+        prompt("Monitor List")
+    }
+    field(BKLNK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             bklnk")
+        interest(4)
+        prompt("Backwards link tracking")
+    }
+    field(DISP, DBF_UCHAR) {
+        prompt("Disable putField")
+    }
+    field(PROC, DBF_UCHAR) {
+        interest(3)
+        pp(TRUE)
+        prompt("Force Processing")
+    }
+    field(STAT, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        initial("UDF")
+        prompt("Alarm Status")
+    }
+    field(SEVR, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        prompt("Alarm Severity")
+    }
+    field(NSTA, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        interest(2)
+        prompt("New Alarm Status")
+    }
+    field(NSEV, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("New Alarm Severity")
+    }
+    field(ACKS, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("Alarm Ack Severity")
+    }
+    field(ACKT, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        special(SPC_NOMOD)
+        menu(menuYesNo)
+        initial("YES")
+        interest(2)
+        prompt("Alarm Ack Transient")
+    }
+    field(DISS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        prompt("Disable Alarm Sevrty")
+    }
+    field(LCNT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(2)
+        prompt("Lock Count")
+    }
+    field(PACT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Record active")
+    }
+    field(PUTF, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("dbPutField process")
+    }
+    field(RPRO, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Reprocess ")
+    }
+    field(ASP, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct asgMember    *asp")
+        interest(4)
+        prompt("Access Security Pvt")
+    }
+    field(PPN, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotify *ppn")
+        interest(4)
+        prompt("pprocessNotify")
+    }
+    field(PPNR, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotifyRecord *ppnr")
+        interest(4)
+        prompt("pprocessNotifyRecord")
+    }
+    field(SPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct scan_element *spvt")
+        interest(4)
+        prompt("Scan Private")
+    }
+    field(RSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct typed_rset   *rset")
+        interest(4)
+        prompt("Address of RSET")
+    }
+    field(DSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dset         *dset")
+        interest(4)
+        prompt("DSET address")
+    }
+    field(DPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("void                *dpvt")
+        interest(4)
+        prompt("Device Private")
+    }
+    field(RDES, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dbRecordType *rdes")
+        interest(4)
+        prompt("Address of dbRecordType")
+    }
+    field(LSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct lockRecord   *lset")
+        interest(4)
+        prompt("Lock Set")
+    }
+    field(PRIO, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuPriority)
+        interest(1)
+        prompt("Scheduling Priority")
+    }
+    field(TPRO, DBF_UCHAR) {
+        prompt("Trace Processing")
+    }
+    field(BKPT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("char                bkpt")
+        interest(1)
+        prompt("Break Point")
+    }
+    field(UDF, DBF_UCHAR) {
+        promptgroup("10 - Common")
+        initial("1")
+        interest(1)
+        pp(TRUE)
+        prompt("Undefined")
+    }
+    field(UDFS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        initial("INVALID")
+        interest(1)
+        prompt("Undefined Alarm Sevrty")
+    }
+    field(TIME, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsTimeStamp      time")
+        interest(2)
+        prompt("Time")
+    }
+    field(FLNK, DBF_FWDLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Forward Process Link")
+    }
+    field(VAL, DBF_ENUM) {
+        promptgroup("40 - Input")
+        asl(ASL0)
+        pp(TRUE)
+        prompt("Current Value")
+    }
+    field(NOBT, DBF_USHORT) {
+        promptgroup("40 - Input")
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Number of Bits")
+    }
+    field(INP, DBF_INLINK) {
+        promptgroup("40 - Input")
+        interest(1)
+        prompt("Input Specification")
+    }
+    field(ZRVL, DBF_ULONG) {
+        base(HEX)
+        promptgroup("41 - Input 0-7")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Zero Value")
+    }
+    field(ONVL, DBF_ULONG) {
+        base(HEX)
+        promptgroup("41 - Input 0-7")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("One Value")
+    }
+    field(TWVL, DBF_ULONG) {
+        base(HEX)
+        promptgroup("41 - Input 0-7")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Two Value")
+    }
+    field(THVL, DBF_ULONG) {
+        base(HEX)
+        promptgroup("41 - Input 0-7")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Three Value")
+    }
+    field(FRVL, DBF_ULONG) {
+        base(HEX)
+        promptgroup("41 - Input 0-7")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Four Value")
+    }
+    field(FVVL, DBF_ULONG) {
+        base(HEX)
+        promptgroup("41 - Input 0-7")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Five Value")
+    }
+    field(SXVL, DBF_ULONG) {
+        base(HEX)
+        promptgroup("41 - Input 0-7")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Six Value")
+    }
+    field(SVVL, DBF_ULONG) {
+        base(HEX)
+        promptgroup("41 - Input 0-7")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Seven Value")
+    }
+    field(EIVL, DBF_ULONG) {
+        base(HEX)
+        promptgroup("42 - Input 8-15")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Eight Value")
+    }
+    field(NIVL, DBF_ULONG) {
+        base(HEX)
+        promptgroup("42 - Input 8-15")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Nine Value")
+    }
+    field(TEVL, DBF_ULONG) {
+        base(HEX)
+        promptgroup("42 - Input 8-15")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Ten Value")
+    }
+    field(ELVL, DBF_ULONG) {
+        base(HEX)
+        promptgroup("42 - Input 8-15")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Eleven Value")
+    }
+    field(TVVL, DBF_ULONG) {
+        base(HEX)
+        promptgroup("42 - Input 8-15")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Twelve Value")
+    }
+    field(TTVL, DBF_ULONG) {
+        base(HEX)
+        promptgroup("42 - Input 8-15")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Thirteen Value")
+    }
+    field(FTVL, DBF_ULONG) {
+        base(HEX)
+        promptgroup("42 - Input 8-15")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Fourteen Value")
+    }
+    field(FFVL, DBF_ULONG) {
+        base(HEX)
+        promptgroup("42 - Input 8-15")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Fifteen Value")
+    }
+    field(ZRST, DBF_STRING) {
+        promptgroup("81 - Display 0-7")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        size(26)
+        prompt("Zero String")
+    }
+    field(ONST, DBF_STRING) {
+        promptgroup("81 - Display 0-7")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        size(26)
+        prompt("One String")
+    }
+    field(TWST, DBF_STRING) {
+        promptgroup("81 - Display 0-7")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        size(26)
+        prompt("Two String")
+    }
+    field(THST, DBF_STRING) {
+        promptgroup("81 - Display 0-7")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        size(26)
+        prompt("Three String")
+    }
+    field(FRST, DBF_STRING) {
+        promptgroup("81 - Display 0-7")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        size(26)
+        prompt("Four String")
+    }
+    field(FVST, DBF_STRING) {
+        promptgroup("81 - Display 0-7")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        size(26)
+        prompt("Five String")
+    }
+    field(SXST, DBF_STRING) {
+        promptgroup("81 - Display 0-7")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        size(26)
+        prompt("Six String")
+    }
+    field(SVST, DBF_STRING) {
+        promptgroup("81 - Display 0-7")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        size(26)
+        prompt("Seven String")
+    }
+    field(EIST, DBF_STRING) {
+        promptgroup("82 - Display 8-15")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        size(26)
+        prompt("Eight String")
+    }
+    field(NIST, DBF_STRING) {
+        promptgroup("82 - Display 8-15")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        size(26)
+        prompt("Nine String")
+    }
+    field(TEST, DBF_STRING) {
+        promptgroup("82 - Display 8-15")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        size(26)
+        prompt("Ten String")
+    }
+    field(ELST, DBF_STRING) {
+        promptgroup("82 - Display 8-15")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        size(26)
+        prompt("Eleven String")
+    }
+    field(TVST, DBF_STRING) {
+        promptgroup("82 - Display 8-15")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        size(26)
+        prompt("Twelve String")
+    }
+    field(TTST, DBF_STRING) {
+        promptgroup("82 - Display 8-15")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        size(26)
+        prompt("Thirteen String")
+    }
+    field(FTST, DBF_STRING) {
+        promptgroup("82 - Display 8-15")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        size(26)
+        prompt("Fourteen String")
+    }
+    field(FFST, DBF_STRING) {
+        promptgroup("82 - Display 8-15")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        size(26)
+        prompt("Fifteen String")
+    }
+    field(ZRSV, DBF_MENU) {
+        promptgroup("71 - Alarm 0-7")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("State Zero Severity")
+    }
+    field(ONSV, DBF_MENU) {
+        promptgroup("71 - Alarm 0-7")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("State One Severity")
+    }
+    field(TWSV, DBF_MENU) {
+        promptgroup("71 - Alarm 0-7")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("State Two Severity")
+    }
+    field(THSV, DBF_MENU) {
+        promptgroup("71 - Alarm 0-7")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("State Three Severity")
+    }
+    field(FRSV, DBF_MENU) {
+        promptgroup("71 - Alarm 0-7")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("State Four Severity")
+    }
+    field(FVSV, DBF_MENU) {
+        promptgroup("71 - Alarm 0-7")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("State Five Severity")
+    }
+    field(SXSV, DBF_MENU) {
+        promptgroup("71 - Alarm 0-7")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("State Six Severity")
+    }
+    field(SVSV, DBF_MENU) {
+        promptgroup("71 - Alarm 0-7")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("State Seven Severity")
+    }
+    field(EISV, DBF_MENU) {
+        promptgroup("72 - Alarm 8-15")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("State Eight Severity")
+    }
+    field(NISV, DBF_MENU) {
+        promptgroup("72 - Alarm 8-15")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("State Nine Severity")
+    }
+    field(TESV, DBF_MENU) {
+        promptgroup("72 - Alarm 8-15")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("State Ten Severity")
+    }
+    field(ELSV, DBF_MENU) {
+        promptgroup("72 - Alarm 8-15")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("State Eleven Severity")
+    }
+    field(TVSV, DBF_MENU) {
+        promptgroup("72 - Alarm 8-15")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("State Twelve Severity")
+    }
+    field(TTSV, DBF_MENU) {
+        promptgroup("72 - Alarm 8-15")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("State Thirteen Sevr")
+    }
+    field(FTSV, DBF_MENU) {
+        promptgroup("72 - Alarm 8-15")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("State Fourteen Sevr")
+    }
+    field(FFSV, DBF_MENU) {
+        promptgroup("72 - Alarm 8-15")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("State Fifteen Severity")
+    }
+    field(AFTC, DBF_DOUBLE) {
+        promptgroup("70 - Alarm")
+        interest(1)
+        prompt("Alarm Filter Time Constant")
+    }
+    field(AFVL, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Alarm Filter Value")
+    }
+    field(UNSV, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("Unknown State Severity")
+    }
+    field(COSV, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("Change of State Svr")
+    }
+    field(RVAL, DBF_ULONG) {
+        pp(TRUE)
+        prompt("Raw Value")
+    }
+    field(ORAW, DBF_ULONG) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Prev Raw Value")
+    }
+    field(MASK, DBF_ULONG) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Hardware Mask")
+    }
+    field(MLST, DBF_USHORT) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Last Value Monitored")
+    }
+    field(LALM, DBF_USHORT) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Last Value Alarmed")
+    }
+    field(SDEF, DBF_SHORT) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("States Defined")
+    }
+    field(SHFT, DBF_USHORT) {
+        promptgroup("40 - Input")
+        interest(1)
+        prompt("Shift")
+    }
+    field(SIOL, DBF_INLINK) {
+        promptgroup("90 - Simulate")
+        interest(1)
+        prompt("Simulation Input Link")
+    }
+    field(SVAL, DBF_ULONG) {
+        prompt("Simulation Value")
+    }
+    field(SIML, DBF_INLINK) {
+        promptgroup("90 - Simulate")
+        interest(1)
+        prompt("Simulation Mode Link")
+    }
+    field(SIMM, DBF_MENU) {
+        special(SPC_MOD)
+        menu(menuSimm)
+        interest(1)
+        prompt("Simulation Mode")
+    }
+    field(SIMS, DBF_MENU) {
+        promptgroup("90 - Simulate")
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("Simulation Mode Severity")
+    }
+    field(OLDSIMM, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuSimm)
+        interest(4)
+        prompt("Prev. Simulation Mode")
+    }
+    field(SSCN, DBF_MENU) {
+        promptgroup("90 - Simulate")
+        menu(menuScan)
+        initial("65535")
+        interest(1)
+        prompt("Sim. Mode Scan")
+    }
+    field(SDLY, DBF_DOUBLE) {
+        promptgroup("90 - Simulate")
+        initial("-1.0")
+        interest(2)
+        prompt("Sim. Mode Async Delay")
+    }
+    field(SIMPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("CALLBACK            *simpvt")
+        interest(4)
+        prompt("Sim. Mode Private")
+    }
+}
+device(mbbi, CONSTANT, devMbbiSoft, "Soft Channel")
+device(mbbi, CONSTANT, devMbbiSoftRaw, "Raw Soft Channel")
+device(mbbi, CONSTANT, devMbbiSoftCallback, "Async Soft Channel")
+device(mbbi, INST_IO, asynMbbiInt32, "asynInt32")
+device(mbbi, INST_IO, asynMbbiUInt32Digital, "asynUInt32Digital")
+recordtype(event) {
+    %#include "epicsTypes.h"
+    %#include "link.h"
+    %#include "epicsMutex.h"
+    %#include "ellLib.h"
+    %#include "epicsTime.h"
+    %#include "dbScan.h"
+    %#include "callback.h"
+    field(NAME, DBF_STRING) {
+        special(SPC_NOMOD)
+        size(61)
+        prompt("Record Name")
+    }
+    field(DESC, DBF_STRING) {
+        promptgroup("10 - Common")
+        size(41)
+        prompt("Descriptor")
+    }
+    field(ASG, DBF_STRING) {
+        promptgroup("10 - Common")
+        special(SPC_AS)
+        size(29)
+        prompt("Access Security Group")
+    }
+    field(SCAN, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuScan)
+        interest(1)
+        prompt("Scan Mechanism")
+    }
+    field(PINI, DBF_MENU) {
+        promptgroup("20 - Scan")
+        menu(menuPini)
+        interest(1)
+        prompt("Process at iocInit")
+    }
+    field(PHAS, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        prompt("Scan Phase")
+    }
+    field(EVNT, DBF_STRING) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        size(40)
+        prompt("Event Name")
+    }
+    field(TSE, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Event")
+    }
+    field(TSEL, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Link")
+    }
+    field(DTYP, DBF_DEVICE) {
+        promptgroup("10 - Common")
+        interest(1)
+        prompt("Device Type")
+    }
+    field(DISV, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        initial("1")
+        prompt("Disable Value")
+    }
+    field(DISA, DBF_SHORT) {
+        prompt("Disable")
+    }
+    field(SDIS, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Scanning Disable")
+    }
+    field(MLOK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsMutexId        mlok")
+        interest(4)
+        prompt("Monitor lock")
+    }
+    field(MLIS, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             mlis")
+        interest(4)
+        prompt("Monitor List")
+    }
+    field(BKLNK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             bklnk")
+        interest(4)
+        prompt("Backwards link tracking")
+    }
+    field(DISP, DBF_UCHAR) {
+        prompt("Disable putField")
+    }
+    field(PROC, DBF_UCHAR) {
+        interest(3)
+        pp(TRUE)
+        prompt("Force Processing")
+    }
+    field(STAT, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        initial("UDF")
+        prompt("Alarm Status")
+    }
+    field(SEVR, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        prompt("Alarm Severity")
+    }
+    field(NSTA, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        interest(2)
+        prompt("New Alarm Status")
+    }
+    field(NSEV, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("New Alarm Severity")
+    }
+    field(ACKS, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("Alarm Ack Severity")
+    }
+    field(ACKT, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        special(SPC_NOMOD)
+        menu(menuYesNo)
+        initial("YES")
+        interest(2)
+        prompt("Alarm Ack Transient")
+    }
+    field(DISS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        prompt("Disable Alarm Sevrty")
+    }
+    field(LCNT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(2)
+        prompt("Lock Count")
+    }
+    field(PACT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Record active")
+    }
+    field(PUTF, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("dbPutField process")
+    }
+    field(RPRO, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Reprocess ")
+    }
+    field(ASP, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct asgMember    *asp")
+        interest(4)
+        prompt("Access Security Pvt")
+    }
+    field(PPN, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotify *ppn")
+        interest(4)
+        prompt("pprocessNotify")
+    }
+    field(PPNR, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotifyRecord *ppnr")
+        interest(4)
+        prompt("pprocessNotifyRecord")
+    }
+    field(SPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct scan_element *spvt")
+        interest(4)
+        prompt("Scan Private")
+    }
+    field(RSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct typed_rset   *rset")
+        interest(4)
+        prompt("Address of RSET")
+    }
+    field(DSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dset         *dset")
+        interest(4)
+        prompt("DSET address")
+    }
+    field(DPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("void                *dpvt")
+        interest(4)
+        prompt("Device Private")
+    }
+    field(RDES, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dbRecordType *rdes")
+        interest(4)
+        prompt("Address of dbRecordType")
+    }
+    field(LSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct lockRecord   *lset")
+        interest(4)
+        prompt("Lock Set")
+    }
+    field(PRIO, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuPriority)
+        interest(1)
+        prompt("Scheduling Priority")
+    }
+    field(TPRO, DBF_UCHAR) {
+        prompt("Trace Processing")
+    }
+    field(BKPT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("char                bkpt")
+        interest(1)
+        prompt("Break Point")
+    }
+    field(UDF, DBF_UCHAR) {
+        promptgroup("10 - Common")
+        initial("1")
+        interest(1)
+        pp(TRUE)
+        prompt("Undefined")
+    }
+    field(UDFS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        initial("INVALID")
+        interest(1)
+        prompt("Undefined Alarm Sevrty")
+    }
+    field(TIME, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsTimeStamp      time")
+        interest(2)
+        prompt("Time")
+    }
+    field(FLNK, DBF_FWDLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Forward Process Link")
+    }
+    field(VAL, DBF_STRING) {
+        promptgroup("40 - Input")
+        special(SPC_MOD)
+        asl(ASL0)
+        size(40)
+        prompt("Event Name To Post")
+    }
+    field(EPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("EVENTPVT epvt")
+        interest(4)
+        prompt("Event private")
+    }
+    field(INP, DBF_INLINK) {
+        promptgroup("40 - Input")
+        interest(1)
+        prompt("Input Specification")
+    }
+    field(SIOL, DBF_INLINK) {
+        promptgroup("90 - Simulate")
+        interest(1)
+        prompt("Simulation Input Link")
+    }
+    field(SVAL, DBF_STRING) {
+        size(40)
+        prompt("Simulation Value")
+    }
+    field(SIML, DBF_INLINK) {
+        promptgroup("90 - Simulate")
+        interest(1)
+        prompt("Simulation Mode Link")
+    }
+    field(SIMM, DBF_MENU) {
+        special(SPC_MOD)
+        menu(menuYesNo)
+        interest(1)
+        prompt("Simulation Mode")
+    }
+    field(SIMS, DBF_MENU) {
+        promptgroup("90 - Simulate")
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("Simulation Mode Severity")
+    }
+    field(OLDSIMM, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuSimm)
+        interest(4)
+        prompt("Prev. Simulation Mode")
+    }
+    field(SSCN, DBF_MENU) {
+        promptgroup("90 - Simulate")
+        menu(menuScan)
+        initial("65535")
+        interest(1)
+        prompt("Sim. Mode Scan")
+    }
+    field(SDLY, DBF_DOUBLE) {
+        promptgroup("90 - Simulate")
+        initial("-1.0")
+        interest(2)
+        prompt("Sim. Mode Async Delay")
+    }
+    field(SIMPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("CALLBACK            *simpvt")
+        interest(4)
+        prompt("Sim. Mode Private")
+    }
+}
+device(event, CONSTANT, devEventSoft, "Soft Channel")
+recordtype(compress) {
+    %#include "epicsTypes.h"
+    %#include "link.h"
+    %#include "epicsMutex.h"
+    %#include "ellLib.h"
+    %#include "epicsTime.h"
+    field(NAME, DBF_STRING) {
+        special(SPC_NOMOD)
+        size(61)
+        prompt("Record Name")
+    }
+    field(DESC, DBF_STRING) {
+        promptgroup("10 - Common")
+        size(41)
+        prompt("Descriptor")
+    }
+    field(ASG, DBF_STRING) {
+        promptgroup("10 - Common")
+        special(SPC_AS)
+        size(29)
+        prompt("Access Security Group")
+    }
+    field(SCAN, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuScan)
+        interest(1)
+        prompt("Scan Mechanism")
+    }
+    field(PINI, DBF_MENU) {
+        promptgroup("20 - Scan")
+        menu(menuPini)
+        interest(1)
+        prompt("Process at iocInit")
+    }
+    field(PHAS, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        prompt("Scan Phase")
+    }
+    field(EVNT, DBF_STRING) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        size(40)
+        prompt("Event Name")
+    }
+    field(TSE, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Event")
+    }
+    field(TSEL, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Link")
+    }
+    field(DTYP, DBF_DEVICE) {
+        promptgroup("10 - Common")
+        interest(1)
+        prompt("Device Type")
+    }
+    field(DISV, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        initial("1")
+        prompt("Disable Value")
+    }
+    field(DISA, DBF_SHORT) {
+        prompt("Disable")
+    }
+    field(SDIS, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Scanning Disable")
+    }
+    field(MLOK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsMutexId        mlok")
+        interest(4)
+        prompt("Monitor lock")
+    }
+    field(MLIS, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             mlis")
+        interest(4)
+        prompt("Monitor List")
+    }
+    field(BKLNK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             bklnk")
+        interest(4)
+        prompt("Backwards link tracking")
+    }
+    field(DISP, DBF_UCHAR) {
+        prompt("Disable putField")
+    }
+    field(PROC, DBF_UCHAR) {
+        interest(3)
+        pp(TRUE)
+        prompt("Force Processing")
+    }
+    field(STAT, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        initial("UDF")
+        prompt("Alarm Status")
+    }
+    field(SEVR, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        prompt("Alarm Severity")
+    }
+    field(NSTA, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        interest(2)
+        prompt("New Alarm Status")
+    }
+    field(NSEV, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("New Alarm Severity")
+    }
+    field(ACKS, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("Alarm Ack Severity")
+    }
+    field(ACKT, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        special(SPC_NOMOD)
+        menu(menuYesNo)
+        initial("YES")
+        interest(2)
+        prompt("Alarm Ack Transient")
+    }
+    field(DISS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        prompt("Disable Alarm Sevrty")
+    }
+    field(LCNT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(2)
+        prompt("Lock Count")
+    }
+    field(PACT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Record active")
+    }
+    field(PUTF, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("dbPutField process")
+    }
+    field(RPRO, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Reprocess ")
+    }
+    field(ASP, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct asgMember    *asp")
+        interest(4)
+        prompt("Access Security Pvt")
+    }
+    field(PPN, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotify *ppn")
+        interest(4)
+        prompt("pprocessNotify")
+    }
+    field(PPNR, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotifyRecord *ppnr")
+        interest(4)
+        prompt("pprocessNotifyRecord")
+    }
+    field(SPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct scan_element *spvt")
+        interest(4)
+        prompt("Scan Private")
+    }
+    field(RSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct typed_rset   *rset")
+        interest(4)
+        prompt("Address of RSET")
+    }
+    field(DSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dset         *dset")
+        interest(4)
+        prompt("DSET address")
+    }
+    field(DPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("void                *dpvt")
+        interest(4)
+        prompt("Device Private")
+    }
+    field(RDES, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dbRecordType *rdes")
+        interest(4)
+        prompt("Address of dbRecordType")
+    }
+    field(LSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct lockRecord   *lset")
+        interest(4)
+        prompt("Lock Set")
+    }
+    field(PRIO, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuPriority)
+        interest(1)
+        prompt("Scheduling Priority")
+    }
+    field(TPRO, DBF_UCHAR) {
+        prompt("Trace Processing")
+    }
+    field(BKPT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("char                bkpt")
+        interest(1)
+        prompt("Break Point")
+    }
+    field(UDF, DBF_UCHAR) {
+        promptgroup("10 - Common")
+        initial("1")
+        interest(1)
+        pp(TRUE)
+        prompt("Undefined")
+    }
+    field(UDFS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        initial("INVALID")
+        interest(1)
+        prompt("Undefined Alarm Sevrty")
+    }
+    field(TIME, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsTimeStamp      time")
+        interest(2)
+        prompt("Time")
+    }
+    field(FLNK, DBF_FWDLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Forward Process Link")
+    }
+    field(VAL, DBF_NOACCESS) {
+        special(SPC_DBADDR)
+        asl(ASL0)
+        extra("void *		val")
+        pp(TRUE)
+        prompt("Value")
+    }
+    field(INP, DBF_INLINK) {
+        promptgroup("40 - Input")
+        interest(1)
+        prompt("Input Specification")
+    }
+    field(RES, DBF_SHORT) {
+        special(SPC_RESET)
+        asl(ASL0)
+        interest(3)
+        prompt("Reset")
+    }
+    field(ALG, DBF_MENU) {
+        promptgroup("30 - Action")
+        special(SPC_RESET)
+        menu(compressALG)
+        interest(1)
+        prompt("Compression Algorithm")
+    }
+    field(BALG, DBF_MENU) {
+        promptgroup("30 - Action")
+        special(SPC_RESET)
+        menu(bufferingALG)
+        interest(1)
+        prompt("Buffering Algorithm")
+    }
+    field(NSAM, DBF_ULONG) {
+        promptgroup("30 - Action")
+        special(SPC_NOMOD)
+        initial("1")
+        interest(1)
+        prompt("Number of Values")
+    }
+    field(N, DBF_ULONG) {
+        promptgroup("30 - Action")
+        special(SPC_RESET)
+        initial("1")
+        interest(1)
+        prompt("N to 1 Compression")
+    }
+    field(IHIL, DBF_DOUBLE) {
+        promptgroup("30 - Action")
+        interest(1)
+        prompt("Init High Interest Lim")
+    }
+    field(ILIL, DBF_DOUBLE) {
+        promptgroup("30 - Action")
+        interest(1)
+        prompt("Init Low Interest Lim")
+    }
+    field(HOPR, DBF_DOUBLE) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("High Operating Range")
+    }
+    field(LOPR, DBF_DOUBLE) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("Low Operating Range")
+    }
+    field(PREC, DBF_SHORT) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("Display Precision")
+    }
+    field(EGU, DBF_STRING) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        size(16)
+        prompt("Engineering Units")
+    }
+    field(OFF, DBF_ULONG) {
+        special(SPC_NOMOD)
+        prompt("Offset")
+    }
+    field(NUSE, DBF_ULONG) {
+        special(SPC_NOMOD)
+        prompt("Number Used")
+    }
+    field(OUSE, DBF_ULONG) {
+        special(SPC_NOMOD)
+        prompt("Old Number Used")
+    }
+    field(BPTR, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("double		*bptr")
+        interest(4)
+        prompt("Buffer Pointer")
+    }
+    field(SPTR, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("double		*sptr")
+        interest(4)
+        prompt("Summing Buffer Ptr")
+    }
+    field(WPTR, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("double		*wptr")
+        interest(4)
+        prompt("Working Buffer Ptr")
+    }
+    field(INPN, DBF_LONG) {
+        special(SPC_NOMOD)
+        interest(4)
+        prompt("Number of elements in Working Buffer")
+    }
+    field(CVB, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Compress Value Buffer")
+    }
+    field(INX, DBF_ULONG) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Compressed Array Inx")
+    }
+}
+recordtype(mbbo) {
+    %#include "epicsTypes.h"
+    %#include "link.h"
+    %#include "epicsMutex.h"
+    %#include "ellLib.h"
+    %#include "epicsTime.h"
+    %#include "callback.h"
+    field(NAME, DBF_STRING) {
+        special(SPC_NOMOD)
+        size(61)
+        prompt("Record Name")
+    }
+    field(DESC, DBF_STRING) {
+        promptgroup("10 - Common")
+        size(41)
+        prompt("Descriptor")
+    }
+    field(ASG, DBF_STRING) {
+        promptgroup("10 - Common")
+        special(SPC_AS)
+        size(29)
+        prompt("Access Security Group")
+    }
+    field(SCAN, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuScan)
+        interest(1)
+        prompt("Scan Mechanism")
+    }
+    field(PINI, DBF_MENU) {
+        promptgroup("20 - Scan")
+        menu(menuPini)
+        interest(1)
+        prompt("Process at iocInit")
+    }
+    field(PHAS, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        prompt("Scan Phase")
+    }
+    field(EVNT, DBF_STRING) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        size(40)
+        prompt("Event Name")
+    }
+    field(TSE, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Event")
+    }
+    field(TSEL, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Link")
+    }
+    field(DTYP, DBF_DEVICE) {
+        promptgroup("10 - Common")
+        interest(1)
+        prompt("Device Type")
+    }
+    field(DISV, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        initial("1")
+        prompt("Disable Value")
+    }
+    field(DISA, DBF_SHORT) {
+        prompt("Disable")
+    }
+    field(SDIS, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Scanning Disable")
+    }
+    field(MLOK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsMutexId        mlok")
+        interest(4)
+        prompt("Monitor lock")
+    }
+    field(MLIS, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             mlis")
+        interest(4)
+        prompt("Monitor List")
+    }
+    field(BKLNK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             bklnk")
+        interest(4)
+        prompt("Backwards link tracking")
+    }
+    field(DISP, DBF_UCHAR) {
+        prompt("Disable putField")
+    }
+    field(PROC, DBF_UCHAR) {
+        interest(3)
+        pp(TRUE)
+        prompt("Force Processing")
+    }
+    field(STAT, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        initial("UDF")
+        prompt("Alarm Status")
+    }
+    field(SEVR, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        prompt("Alarm Severity")
+    }
+    field(NSTA, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        interest(2)
+        prompt("New Alarm Status")
+    }
+    field(NSEV, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("New Alarm Severity")
+    }
+    field(ACKS, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("Alarm Ack Severity")
+    }
+    field(ACKT, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        special(SPC_NOMOD)
+        menu(menuYesNo)
+        initial("YES")
+        interest(2)
+        prompt("Alarm Ack Transient")
+    }
+    field(DISS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        prompt("Disable Alarm Sevrty")
+    }
+    field(LCNT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(2)
+        prompt("Lock Count")
+    }
+    field(PACT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Record active")
+    }
+    field(PUTF, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("dbPutField process")
+    }
+    field(RPRO, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Reprocess ")
+    }
+    field(ASP, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct asgMember    *asp")
+        interest(4)
+        prompt("Access Security Pvt")
+    }
+    field(PPN, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotify *ppn")
+        interest(4)
+        prompt("pprocessNotify")
+    }
+    field(PPNR, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotifyRecord *ppnr")
+        interest(4)
+        prompt("pprocessNotifyRecord")
+    }
+    field(SPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct scan_element *spvt")
+        interest(4)
+        prompt("Scan Private")
+    }
+    field(RSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct typed_rset   *rset")
+        interest(4)
+        prompt("Address of RSET")
+    }
+    field(DSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dset         *dset")
+        interest(4)
+        prompt("DSET address")
+    }
+    field(DPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("void                *dpvt")
+        interest(4)
+        prompt("Device Private")
+    }
+    field(RDES, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dbRecordType *rdes")
+        interest(4)
+        prompt("Address of dbRecordType")
+    }
+    field(LSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct lockRecord   *lset")
+        interest(4)
+        prompt("Lock Set")
+    }
+    field(PRIO, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuPriority)
+        interest(1)
+        prompt("Scheduling Priority")
+    }
+    field(TPRO, DBF_UCHAR) {
+        prompt("Trace Processing")
+    }
+    field(BKPT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("char                bkpt")
+        interest(1)
+        prompt("Break Point")
+    }
+    field(UDF, DBF_UCHAR) {
+        promptgroup("10 - Common")
+        initial("1")
+        interest(1)
+        pp(TRUE)
+        prompt("Undefined")
+    }
+    field(UDFS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        initial("INVALID")
+        interest(1)
+        prompt("Undefined Alarm Sevrty")
+    }
+    field(TIME, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsTimeStamp      time")
+        interest(2)
+        prompt("Time")
+    }
+    field(FLNK, DBF_FWDLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Forward Process Link")
+    }
+    field(VAL, DBF_ENUM) {
+        promptgroup("50 - Output")
+        special(SPC_DBADDR)
+        asl(ASL0)
+        pp(TRUE)
+        prompt("Desired Value")
+    }
+    field(DOL, DBF_INLINK) {
+        promptgroup("40 - Input")
+        interest(1)
+        prompt("Desired Output Loc")
+    }
+    field(OMSL, DBF_MENU) {
+        promptgroup("50 - Output")
+        menu(menuOmsl)
+        interest(1)
+        prompt("Output Mode Select")
+    }
+    field(NOBT, DBF_USHORT) {
+        promptgroup("50 - Output")
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Number of Bits")
+    }
+    field(OUT, DBF_OUTLINK) {
+        promptgroup("50 - Output")
+        interest(1)
+        prompt("Output Specification")
+    }
+    field(ZRVL, DBF_ULONG) {
+        base(HEX)
+        promptgroup("51 - Output 0-7")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Zero Value")
+    }
+    field(ONVL, DBF_ULONG) {
+        base(HEX)
+        promptgroup("51 - Output 0-7")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("One Value")
+    }
+    field(TWVL, DBF_ULONG) {
+        base(HEX)
+        promptgroup("51 - Output 0-7")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Two Value")
+    }
+    field(THVL, DBF_ULONG) {
+        base(HEX)
+        promptgroup("51 - Output 0-7")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Three Value")
+    }
+    field(FRVL, DBF_ULONG) {
+        base(HEX)
+        promptgroup("51 - Output 0-7")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Four Value")
+    }
+    field(FVVL, DBF_ULONG) {
+        base(HEX)
+        promptgroup("51 - Output 0-7")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Five Value")
+    }
+    field(SXVL, DBF_ULONG) {
+        base(HEX)
+        promptgroup("51 - Output 0-7")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Six Value")
+    }
+    field(SVVL, DBF_ULONG) {
+        base(HEX)
+        promptgroup("51 - Output 0-7")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Seven Value")
+    }
+    field(EIVL, DBF_ULONG) {
+        base(HEX)
+        promptgroup("52 - Output 8-15")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Eight Value")
+    }
+    field(NIVL, DBF_ULONG) {
+        base(HEX)
+        promptgroup("52 - Output 8-15")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Nine Value")
+    }
+    field(TEVL, DBF_ULONG) {
+        base(HEX)
+        promptgroup("52 - Output 8-15")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Ten Value")
+    }
+    field(ELVL, DBF_ULONG) {
+        base(HEX)
+        promptgroup("52 - Output 8-15")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Eleven Value")
+    }
+    field(TVVL, DBF_ULONG) {
+        base(HEX)
+        promptgroup("52 - Output 8-15")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Twelve Value")
+    }
+    field(TTVL, DBF_ULONG) {
+        base(HEX)
+        promptgroup("52 - Output 8-15")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Thirteen Value")
+    }
+    field(FTVL, DBF_ULONG) {
+        base(HEX)
+        promptgroup("52 - Output 8-15")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Fourteen Value")
+    }
+    field(FFVL, DBF_ULONG) {
+        base(HEX)
+        promptgroup("52 - Output 8-15")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Fifteen Value")
+    }
+    field(ZRST, DBF_STRING) {
+        promptgroup("81 - Display 0-7")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        size(26)
+        prompt("Zero String")
+    }
+    field(ONST, DBF_STRING) {
+        promptgroup("81 - Display 0-7")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        size(26)
+        prompt("One String")
+    }
+    field(TWST, DBF_STRING) {
+        promptgroup("81 - Display 0-7")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        size(26)
+        prompt("Two String")
+    }
+    field(THST, DBF_STRING) {
+        promptgroup("81 - Display 0-7")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        size(26)
+        prompt("Three String")
+    }
+    field(FRST, DBF_STRING) {
+        promptgroup("81 - Display 0-7")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        size(26)
+        prompt("Four String")
+    }
+    field(FVST, DBF_STRING) {
+        promptgroup("81 - Display 0-7")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        size(26)
+        prompt("Five String")
+    }
+    field(SXST, DBF_STRING) {
+        promptgroup("81 - Display 0-7")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        size(26)
+        prompt("Six String")
+    }
+    field(SVST, DBF_STRING) {
+        promptgroup("81 - Display 0-7")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        size(26)
+        prompt("Seven String")
+    }
+    field(EIST, DBF_STRING) {
+        promptgroup("82 - Display 8-15")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        size(26)
+        prompt("Eight String")
+    }
+    field(NIST, DBF_STRING) {
+        promptgroup("82 - Display 8-15")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        size(26)
+        prompt("Nine String")
+    }
+    field(TEST, DBF_STRING) {
+        promptgroup("82 - Display 8-15")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        size(26)
+        prompt("Ten String")
+    }
+    field(ELST, DBF_STRING) {
+        promptgroup("82 - Display 8-15")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        size(26)
+        prompt("Eleven String")
+    }
+    field(TVST, DBF_STRING) {
+        promptgroup("82 - Display 8-15")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        size(26)
+        prompt("Twelve String")
+    }
+    field(TTST, DBF_STRING) {
+        promptgroup("82 - Display 8-15")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        size(26)
+        prompt("Thirteen String")
+    }
+    field(FTST, DBF_STRING) {
+        promptgroup("82 - Display 8-15")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        size(26)
+        prompt("Fourteen String")
+    }
+    field(FFST, DBF_STRING) {
+        promptgroup("82 - Display 8-15")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        size(26)
+        prompt("Fifteen String")
+    }
+    field(ZRSV, DBF_MENU) {
+        promptgroup("71 - Alarm 0-7")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("State Zero Severity")
+    }
+    field(ONSV, DBF_MENU) {
+        promptgroup("71 - Alarm 0-7")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("State One Severity")
+    }
+    field(TWSV, DBF_MENU) {
+        promptgroup("71 - Alarm 0-7")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("State Two Severity")
+    }
+    field(THSV, DBF_MENU) {
+        promptgroup("71 - Alarm 0-7")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("State Three Severity")
+    }
+    field(FRSV, DBF_MENU) {
+        promptgroup("71 - Alarm 0-7")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("State Four Severity")
+    }
+    field(FVSV, DBF_MENU) {
+        promptgroup("71 - Alarm 0-7")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("State Five Severity")
+    }
+    field(SXSV, DBF_MENU) {
+        promptgroup("71 - Alarm 0-7")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("State Six Severity")
+    }
+    field(SVSV, DBF_MENU) {
+        promptgroup("71 - Alarm 0-7")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("State Seven Severity")
+    }
+    field(EISV, DBF_MENU) {
+        promptgroup("72 - Alarm 8-15")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("State Eight Severity")
+    }
+    field(NISV, DBF_MENU) {
+        promptgroup("72 - Alarm 8-15")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("State Nine Severity")
+    }
+    field(TESV, DBF_MENU) {
+        promptgroup("72 - Alarm 8-15")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("State Ten Severity")
+    }
+    field(ELSV, DBF_MENU) {
+        promptgroup("72 - Alarm 8-15")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("State Eleven Severity")
+    }
+    field(TVSV, DBF_MENU) {
+        promptgroup("72 - Alarm 8-15")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("State Twelve Severity")
+    }
+    field(TTSV, DBF_MENU) {
+        promptgroup("72 - Alarm 8-15")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("State Thirteen Sevr")
+    }
+    field(FTSV, DBF_MENU) {
+        promptgroup("72 - Alarm 8-15")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("State Fourteen Sevr")
+    }
+    field(FFSV, DBF_MENU) {
+        promptgroup("72 - Alarm 8-15")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("State Fifteen Sevr")
+    }
+    field(UNSV, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("Unknown State Sevr")
+    }
+    field(COSV, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("Change of State Sevr")
+    }
+    field(RVAL, DBF_ULONG) {
+        pp(TRUE)
+        prompt("Raw Value")
+    }
+    field(ORAW, DBF_ULONG) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Prev Raw Value")
+    }
+    field(RBV, DBF_ULONG) {
+        special(SPC_NOMOD)
+        prompt("Readback Value")
+    }
+    field(ORBV, DBF_ULONG) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Prev Readback Value")
+    }
+    field(MASK, DBF_ULONG) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Hardware Mask")
+    }
+    field(MLST, DBF_USHORT) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Last Value Monitored")
+    }
+    field(LALM, DBF_USHORT) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Last Value Alarmed")
+    }
+    field(SDEF, DBF_SHORT) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("States Defined")
+    }
+    field(SHFT, DBF_USHORT) {
+        promptgroup("50 - Output")
+        interest(1)
+        prompt("Shift")
+    }
+    field(SIOL, DBF_OUTLINK) {
+        promptgroup("90 - Simulate")
+        interest(1)
+        prompt("Simulation Output Link")
+    }
+    field(SIML, DBF_INLINK) {
+        promptgroup("90 - Simulate")
+        interest(1)
+        prompt("Simulation Mode Link")
+    }
+    field(SIMM, DBF_MENU) {
+        special(SPC_MOD)
+        menu(menuYesNo)
+        interest(1)
+        prompt("Simulation Mode")
+    }
+    field(SIMS, DBF_MENU) {
+        promptgroup("90 - Simulate")
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("Simulation Mode Severity")
+    }
+    field(OLDSIMM, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuSimm)
+        interest(4)
+        prompt("Prev. Simulation Mode")
+    }
+    field(SSCN, DBF_MENU) {
+        promptgroup("90 - Simulate")
+        menu(menuScan)
+        initial("65535")
+        interest(1)
+        prompt("Sim. Mode Scan")
+    }
+    field(SDLY, DBF_DOUBLE) {
+        promptgroup("90 - Simulate")
+        initial("-1.0")
+        interest(2)
+        prompt("Sim. Mode Async Delay")
+    }
+    field(SIMPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("CALLBACK            *simpvt")
+        interest(4)
+        prompt("Sim. Mode Private")
+    }
+    field(IVOA, DBF_MENU) {
+        promptgroup("50 - Output")
+        menu(menuIvoa)
+        interest(2)
+        prompt("INVALID outpt action")
+    }
+    field(IVOV, DBF_USHORT) {
+        promptgroup("50 - Output")
+        interest(2)
+        prompt("INVALID output value")
+    }
+}
+device(mbbo, CONSTANT, devMbboSoft, "Soft Channel")
+device(mbbo, CONSTANT, devMbboSoftRaw, "Raw Soft Channel")
+device(mbbo, CONSTANT, devMbboSoftCallback, "Async Soft Channel")
+device(mbbo, INST_IO, asynMbboInt32, "asynInt32")
+device(mbbo, INST_IO, asynMbboUInt32Digital, "asynUInt32Digital")
+recordtype(ao) {
+    %#include "epicsTypes.h"
+    %#include "link.h"
+    %#include "epicsMutex.h"
+    %#include "ellLib.h"
+    %#include "epicsTime.h"
+    %#include "callback.h"
+    field(NAME, DBF_STRING) {
+        special(SPC_NOMOD)
+        size(61)
+        prompt("Record Name")
+    }
+    field(DESC, DBF_STRING) {
+        promptgroup("10 - Common")
+        size(41)
+        prompt("Descriptor")
+    }
+    field(ASG, DBF_STRING) {
+        promptgroup("10 - Common")
+        special(SPC_AS)
+        size(29)
+        prompt("Access Security Group")
+    }
+    field(SCAN, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuScan)
+        interest(1)
+        prompt("Scan Mechanism")
+    }
+    field(PINI, DBF_MENU) {
+        promptgroup("20 - Scan")
+        menu(menuPini)
+        interest(1)
+        prompt("Process at iocInit")
+    }
+    field(PHAS, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        prompt("Scan Phase")
+    }
+    field(EVNT, DBF_STRING) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        size(40)
+        prompt("Event Name")
+    }
+    field(TSE, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Event")
+    }
+    field(TSEL, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Link")
+    }
+    field(DTYP, DBF_DEVICE) {
+        promptgroup("10 - Common")
+        interest(1)
+        prompt("Device Type")
+    }
+    field(DISV, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        initial("1")
+        prompt("Disable Value")
+    }
+    field(DISA, DBF_SHORT) {
+        prompt("Disable")
+    }
+    field(SDIS, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Scanning Disable")
+    }
+    field(MLOK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsMutexId        mlok")
+        interest(4)
+        prompt("Monitor lock")
+    }
+    field(MLIS, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             mlis")
+        interest(4)
+        prompt("Monitor List")
+    }
+    field(BKLNK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             bklnk")
+        interest(4)
+        prompt("Backwards link tracking")
+    }
+    field(DISP, DBF_UCHAR) {
+        prompt("Disable putField")
+    }
+    field(PROC, DBF_UCHAR) {
+        interest(3)
+        pp(TRUE)
+        prompt("Force Processing")
+    }
+    field(STAT, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        initial("UDF")
+        prompt("Alarm Status")
+    }
+    field(SEVR, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        prompt("Alarm Severity")
+    }
+    field(NSTA, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        interest(2)
+        prompt("New Alarm Status")
+    }
+    field(NSEV, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("New Alarm Severity")
+    }
+    field(ACKS, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("Alarm Ack Severity")
+    }
+    field(ACKT, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        special(SPC_NOMOD)
+        menu(menuYesNo)
+        initial("YES")
+        interest(2)
+        prompt("Alarm Ack Transient")
+    }
+    field(DISS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        prompt("Disable Alarm Sevrty")
+    }
+    field(LCNT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(2)
+        prompt("Lock Count")
+    }
+    field(PACT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Record active")
+    }
+    field(PUTF, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("dbPutField process")
+    }
+    field(RPRO, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Reprocess ")
+    }
+    field(ASP, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct asgMember    *asp")
+        interest(4)
+        prompt("Access Security Pvt")
+    }
+    field(PPN, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotify *ppn")
+        interest(4)
+        prompt("pprocessNotify")
+    }
+    field(PPNR, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotifyRecord *ppnr")
+        interest(4)
+        prompt("pprocessNotifyRecord")
+    }
+    field(SPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct scan_element *spvt")
+        interest(4)
+        prompt("Scan Private")
+    }
+    field(RSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct typed_rset   *rset")
+        interest(4)
+        prompt("Address of RSET")
+    }
+    field(DSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dset         *dset")
+        interest(4)
+        prompt("DSET address")
+    }
+    field(DPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("void                *dpvt")
+        interest(4)
+        prompt("Device Private")
+    }
+    field(RDES, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dbRecordType *rdes")
+        interest(4)
+        prompt("Address of dbRecordType")
+    }
+    field(LSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct lockRecord   *lset")
+        interest(4)
+        prompt("Lock Set")
+    }
+    field(PRIO, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuPriority)
+        interest(1)
+        prompt("Scheduling Priority")
+    }
+    field(TPRO, DBF_UCHAR) {
+        prompt("Trace Processing")
+    }
+    field(BKPT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("char                bkpt")
+        interest(1)
+        prompt("Break Point")
+    }
+    field(UDF, DBF_UCHAR) {
+        promptgroup("10 - Common")
+        initial("1")
+        interest(1)
+        pp(TRUE)
+        prompt("Undefined")
+    }
+    field(UDFS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        initial("INVALID")
+        interest(1)
+        prompt("Undefined Alarm Sevrty")
+    }
+    field(TIME, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsTimeStamp      time")
+        interest(2)
+        prompt("Time")
+    }
+    field(FLNK, DBF_FWDLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Forward Process Link")
+    }
+    field(VAL, DBF_DOUBLE) {
+        promptgroup("50 - Output")
+        asl(ASL0)
+        pp(TRUE)
+        prompt("Desired Output")
+    }
+    field(OVAL, DBF_DOUBLE) {
+        prompt("Output Value")
+    }
+    field(OUT, DBF_OUTLINK) {
+        promptgroup("50 - Output")
+        interest(1)
+        prompt("Output Specification")
+    }
+    field(OROC, DBF_DOUBLE) {
+        promptgroup("50 - Output")
+        interest(1)
+        prompt("Output Rate of Change")
+    }
+    field(DOL, DBF_INLINK) {
+        promptgroup("40 - Input")
+        interest(1)
+        prompt("Desired Output Loc")
+    }
+    field(OMSL, DBF_MENU) {
+        promptgroup("50 - Output")
+        menu(menuOmsl)
+        interest(1)
+        prompt("Output Mode Select")
+    }
+    field(OIF, DBF_MENU) {
+        promptgroup("50 - Output")
+        menu(aoOIF)
+        interest(1)
+        prompt("Out Full/Incremental")
+    }
+    field(PREC, DBF_SHORT) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("Display Precision")
+    }
+    field(LINR, DBF_MENU) {
+        promptgroup("60 - Convert")
+        special(SPC_LINCONV)
+        menu(menuConvert)
+        interest(1)
+        pp(TRUE)
+        prompt("Linearization")
+    }
+    field(EGUF, DBF_DOUBLE) {
+        promptgroup("60 - Convert")
+        special(SPC_LINCONV)
+        interest(1)
+        pp(TRUE)
+        prompt("Eng Units Full")
+    }
+    field(EGUL, DBF_DOUBLE) {
+        promptgroup("60 - Convert")
+        special(SPC_LINCONV)
+        interest(1)
+        pp(TRUE)
+        prompt("Eng Units Low")
+    }
+    field(EGU, DBF_STRING) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        size(16)
+        prompt("Engineering Units")
+    }
+    field(ROFF, DBF_ULONG) {
+        interest(2)
+        pp(TRUE)
+        prompt("Raw Offset")
+    }
+    field(EOFF, DBF_DOUBLE) {
+        promptgroup("60 - Convert")
+        interest(2)
+        pp(TRUE)
+        prompt("EGU to Raw Offset")
+    }
+    field(ESLO, DBF_DOUBLE) {
+        promptgroup("60 - Convert")
+        initial("1")
+        interest(2)
+        pp(TRUE)
+        prompt("EGU to Raw Slope")
+    }
+    field(DRVH, DBF_DOUBLE) {
+        prop(YES)
+        promptgroup("30 - Action")
+        interest(1)
+        pp(TRUE)
+        prompt("Drive High Limit")
+    }
+    field(DRVL, DBF_DOUBLE) {
+        prop(YES)
+        promptgroup("30 - Action")
+        interest(1)
+        pp(TRUE)
+        prompt("Drive Low Limit")
+    }
+    field(HOPR, DBF_DOUBLE) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("High Operating Range")
+    }
+    field(LOPR, DBF_DOUBLE) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("Low Operating Range")
+    }
+    field(AOFF, DBF_DOUBLE) {
+        promptgroup("60 - Convert")
+        interest(1)
+        pp(TRUE)
+        prompt("Adjustment Offset")
+    }
+    field(ASLO, DBF_DOUBLE) {
+        promptgroup("60 - Convert")
+        interest(1)
+        pp(TRUE)
+        prompt("Adjustment Slope")
+    }
+    field(HIHI, DBF_DOUBLE) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        interest(1)
+        pp(TRUE)
+        prompt("Hihi Alarm Limit")
+    }
+    field(LOLO, DBF_DOUBLE) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        interest(1)
+        pp(TRUE)
+        prompt("Lolo Alarm Limit")
+    }
+    field(HIGH, DBF_DOUBLE) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        interest(1)
+        pp(TRUE)
+        prompt("High Alarm Limit")
+    }
+    field(LOW, DBF_DOUBLE) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        interest(1)
+        pp(TRUE)
+        prompt("Low Alarm Limit")
+    }
+    field(HHSV, DBF_MENU) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("Hihi Severity")
+    }
+    field(LLSV, DBF_MENU) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("Lolo Severity")
+    }
+    field(HSV, DBF_MENU) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("High Severity")
+    }
+    field(LSV, DBF_MENU) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("Low Severity")
+    }
+    field(HYST, DBF_DOUBLE) {
+        promptgroup("70 - Alarm")
+        interest(1)
+        prompt("Alarm Deadband")
+    }
+    field(ADEL, DBF_DOUBLE) {
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("Archive Deadband")
+    }
+    field(MDEL, DBF_DOUBLE) {
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("Monitor Deadband")
+    }
+    field(RVAL, DBF_LONG) {
+        pp(TRUE)
+        prompt("Current Raw Value")
+    }
+    field(ORAW, DBF_LONG) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Previous Raw Value")
+    }
+    field(RBV, DBF_LONG) {
+        special(SPC_NOMOD)
+        prompt("Readback Value")
+    }
+    field(ORBV, DBF_LONG) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Prev Readback Value")
+    }
+    field(PVAL, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Previous value")
+    }
+    field(LALM, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Last Value Alarmed")
+    }
+    field(ALST, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Last Value Archived")
+    }
+    field(MLST, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Last Val Monitored")
+    }
+    field(PBRK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("void *   pbrk")
+        interest(4)
+        prompt("Ptrto brkTable")
+    }
+    field(INIT, DBF_SHORT) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Initialized?")
+    }
+    field(LBRK, DBF_SHORT) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("LastBreak Point")
+    }
+    field(SIOL, DBF_OUTLINK) {
+        promptgroup("90 - Simulate")
+        interest(1)
+        prompt("Simulation Output Link")
+    }
+    field(SIML, DBF_INLINK) {
+        promptgroup("90 - Simulate")
+        interest(1)
+        prompt("Simulation Mode Link")
+    }
+    field(SIMM, DBF_MENU) {
+        special(SPC_MOD)
+        menu(menuYesNo)
+        interest(1)
+        prompt("Simulation Mode")
+    }
+    field(SIMS, DBF_MENU) {
+        promptgroup("90 - Simulate")
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("Simulation Mode Severity")
+    }
+    field(OLDSIMM, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuSimm)
+        interest(4)
+        prompt("Prev. Simulation Mode")
+    }
+    field(SSCN, DBF_MENU) {
+        promptgroup("90 - Simulate")
+        menu(menuScan)
+        initial("65535")
+        interest(1)
+        prompt("Sim. Mode Scan")
+    }
+    field(SDLY, DBF_DOUBLE) {
+        promptgroup("90 - Simulate")
+        initial("-1.0")
+        interest(2)
+        prompt("Sim. Mode Async Delay")
+    }
+    field(SIMPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("CALLBACK            *simpvt")
+        interest(4)
+        prompt("Sim. Mode Private")
+    }
+    field(IVOA, DBF_MENU) {
+        promptgroup("50 - Output")
+        menu(menuIvoa)
+        interest(2)
+        prompt("INVALID output action")
+    }
+    field(IVOV, DBF_DOUBLE) {
+        promptgroup("50 - Output")
+        interest(2)
+        prompt("INVALID output value")
+    }
+    field(OMOD, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        prompt("Was OVAL modified?")
+    }
+}
+device(ao, CONSTANT, devAoSoft, "Soft Channel")
+device(ao, CONSTANT, devAoSoftRaw, "Raw Soft Channel")
+device(ao, CONSTANT, devAoSoftCallback, "Async Soft Channel")
+device(ao, INST_IO, devAoStats, "IOC stats")
+device(ao, INST_IO, asynAoInt32, "asynInt32")
+device(ao, INST_IO, asynAoFloat64, "asynFloat64")
+recordtype(aao) {
+    %#include "epicsTypes.h"
+    %#include "link.h"
+    %#include "epicsMutex.h"
+    %#include "ellLib.h"
+    %#include "epicsTime.h"
+    %#include "callback.h"
+    field(NAME, DBF_STRING) {
+        special(SPC_NOMOD)
+        size(61)
+        prompt("Record Name")
+    }
+    field(DESC, DBF_STRING) {
+        promptgroup("10 - Common")
+        size(41)
+        prompt("Descriptor")
+    }
+    field(ASG, DBF_STRING) {
+        promptgroup("10 - Common")
+        special(SPC_AS)
+        size(29)
+        prompt("Access Security Group")
+    }
+    field(SCAN, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuScan)
+        interest(1)
+        prompt("Scan Mechanism")
+    }
+    field(PINI, DBF_MENU) {
+        promptgroup("20 - Scan")
+        menu(menuPini)
+        interest(1)
+        prompt("Process at iocInit")
+    }
+    field(PHAS, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        prompt("Scan Phase")
+    }
+    field(EVNT, DBF_STRING) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        size(40)
+        prompt("Event Name")
+    }
+    field(TSE, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Event")
+    }
+    field(TSEL, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Link")
+    }
+    field(DTYP, DBF_DEVICE) {
+        promptgroup("10 - Common")
+        interest(1)
+        prompt("Device Type")
+    }
+    field(DISV, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        initial("1")
+        prompt("Disable Value")
+    }
+    field(DISA, DBF_SHORT) {
+        prompt("Disable")
+    }
+    field(SDIS, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Scanning Disable")
+    }
+    field(MLOK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsMutexId        mlok")
+        interest(4)
+        prompt("Monitor lock")
+    }
+    field(MLIS, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             mlis")
+        interest(4)
+        prompt("Monitor List")
+    }
+    field(BKLNK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             bklnk")
+        interest(4)
+        prompt("Backwards link tracking")
+    }
+    field(DISP, DBF_UCHAR) {
+        prompt("Disable putField")
+    }
+    field(PROC, DBF_UCHAR) {
+        interest(3)
+        pp(TRUE)
+        prompt("Force Processing")
+    }
+    field(STAT, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        initial("UDF")
+        prompt("Alarm Status")
+    }
+    field(SEVR, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        prompt("Alarm Severity")
+    }
+    field(NSTA, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        interest(2)
+        prompt("New Alarm Status")
+    }
+    field(NSEV, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("New Alarm Severity")
+    }
+    field(ACKS, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("Alarm Ack Severity")
+    }
+    field(ACKT, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        special(SPC_NOMOD)
+        menu(menuYesNo)
+        initial("YES")
+        interest(2)
+        prompt("Alarm Ack Transient")
+    }
+    field(DISS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        prompt("Disable Alarm Sevrty")
+    }
+    field(LCNT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(2)
+        prompt("Lock Count")
+    }
+    field(PACT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Record active")
+    }
+    field(PUTF, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("dbPutField process")
+    }
+    field(RPRO, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Reprocess ")
+    }
+    field(ASP, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct asgMember    *asp")
+        interest(4)
+        prompt("Access Security Pvt")
+    }
+    field(PPN, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotify *ppn")
+        interest(4)
+        prompt("pprocessNotify")
+    }
+    field(PPNR, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotifyRecord *ppnr")
+        interest(4)
+        prompt("pprocessNotifyRecord")
+    }
+    field(SPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct scan_element *spvt")
+        interest(4)
+        prompt("Scan Private")
+    }
+    field(RSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct typed_rset   *rset")
+        interest(4)
+        prompt("Address of RSET")
+    }
+    field(DSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dset         *dset")
+        interest(4)
+        prompt("DSET address")
+    }
+    field(DPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("void                *dpvt")
+        interest(4)
+        prompt("Device Private")
+    }
+    field(RDES, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dbRecordType *rdes")
+        interest(4)
+        prompt("Address of dbRecordType")
+    }
+    field(LSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct lockRecord   *lset")
+        interest(4)
+        prompt("Lock Set")
+    }
+    field(PRIO, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuPriority)
+        interest(1)
+        prompt("Scheduling Priority")
+    }
+    field(TPRO, DBF_UCHAR) {
+        prompt("Trace Processing")
+    }
+    field(BKPT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("char                bkpt")
+        interest(1)
+        prompt("Break Point")
+    }
+    field(UDF, DBF_UCHAR) {
+        promptgroup("10 - Common")
+        initial("1")
+        interest(1)
+        pp(TRUE)
+        prompt("Undefined")
+    }
+    field(UDFS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        initial("INVALID")
+        interest(1)
+        prompt("Undefined Alarm Sevrty")
+    }
+    field(TIME, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsTimeStamp      time")
+        interest(2)
+        prompt("Time")
+    }
+    field(FLNK, DBF_FWDLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Forward Process Link")
+    }
+    field(VAL, DBF_NOACCESS) {
+        special(SPC_DBADDR)
+        asl(ASL0)
+        extra("void *		val")
+        pp(TRUE)
+        prompt("Value")
+    }
+    field(PREC, DBF_SHORT) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("Display Precision")
+    }
+    field(OUT, DBF_OUTLINK) {
+        promptgroup("50 - Output")
+        interest(1)
+        prompt("Output Specification")
+    }
+    field(EGU, DBF_STRING) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        size(16)
+        prompt("Engineering Units")
+    }
+    field(HOPR, DBF_DOUBLE) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("High Operating Range")
+    }
+    field(LOPR, DBF_DOUBLE) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("Low Operating Range")
+    }
+    field(NELM, DBF_ULONG) {
+        promptgroup("30 - Action")
+        special(SPC_NOMOD)
+        initial("1")
+        interest(1)
+        prompt("Number of Elements")
+    }
+    field(FTVL, DBF_MENU) {
+        promptgroup("30 - Action")
+        special(SPC_NOMOD)
+        menu(menuFtype)
+        interest(1)
+        prompt("Field Type of Value")
+    }
+    field(NORD, DBF_ULONG) {
+        special(SPC_NOMOD)
+        prompt("Number elements read")
+    }
+    field(BPTR, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("void *		bptr")
+        interest(4)
+        prompt("Buffer Pointer")
+    }
+    field(SIML, DBF_INLINK) {
+        promptgroup("90 - Simulate")
+        interest(1)
+        prompt("Simulation Mode Link")
+    }
+    field(SIMM, DBF_MENU) {
+        special(SPC_MOD)
+        menu(menuYesNo)
+        interest(1)
+        prompt("Simulation Mode")
+    }
+    field(SIMS, DBF_MENU) {
+        promptgroup("90 - Simulate")
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("Simulation Mode Severity")
+    }
+    field(SIOL, DBF_OUTLINK) {
+        promptgroup("90 - Simulate")
+        interest(1)
+        prompt("Simulation Output Link")
+    }
+    field(OLDSIMM, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuSimm)
+        interest(4)
+        prompt("Prev. Simulation Mode")
+    }
+    field(SSCN, DBF_MENU) {
+        promptgroup("90 - Simulate")
+        menu(menuScan)
+        initial("65535")
+        interest(1)
+        prompt("Sim. Mode Scan")
+    }
+    field(SDLY, DBF_DOUBLE) {
+        promptgroup("90 - Simulate")
+        initial("-1.0")
+        interest(2)
+        prompt("Sim. Mode Async Delay")
+    }
+    field(SIMPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("CALLBACK            *simpvt")
+        interest(4)
+        prompt("Sim. Mode Private")
+    }
+    field(MPST, DBF_MENU) {
+        promptgroup("80 - Display")
+        menu(aaoPOST)
+        interest(1)
+        prompt("Post Value Monitors")
+    }
+    field(APST, DBF_MENU) {
+        promptgroup("80 - Display")
+        menu(aaoPOST)
+        interest(1)
+        prompt("Post Archive Monitors")
+    }
+    field(HASH, DBF_ULONG) {
+        interest(3)
+        prompt("Hash of OnChange data.")
+    }
+}
+device(aao, CONSTANT, devAaoSoft, "Soft Channel")
+recordtype(mbbiDirect) {
+    %#include "epicsTypes.h"
+    %#include "link.h"
+    %#include "epicsMutex.h"
+    %#include "ellLib.h"
+    %#include "epicsTime.h"
+    %#include "callback.h"
+    field(NAME, DBF_STRING) {
+        special(SPC_NOMOD)
+        size(61)
+        prompt("Record Name")
+    }
+    field(DESC, DBF_STRING) {
+        promptgroup("10 - Common")
+        size(41)
+        prompt("Descriptor")
+    }
+    field(ASG, DBF_STRING) {
+        promptgroup("10 - Common")
+        special(SPC_AS)
+        size(29)
+        prompt("Access Security Group")
+    }
+    field(SCAN, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuScan)
+        interest(1)
+        prompt("Scan Mechanism")
+    }
+    field(PINI, DBF_MENU) {
+        promptgroup("20 - Scan")
+        menu(menuPini)
+        interest(1)
+        prompt("Process at iocInit")
+    }
+    field(PHAS, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        prompt("Scan Phase")
+    }
+    field(EVNT, DBF_STRING) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        size(40)
+        prompt("Event Name")
+    }
+    field(TSE, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Event")
+    }
+    field(TSEL, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Link")
+    }
+    field(DTYP, DBF_DEVICE) {
+        promptgroup("10 - Common")
+        interest(1)
+        prompt("Device Type")
+    }
+    field(DISV, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        initial("1")
+        prompt("Disable Value")
+    }
+    field(DISA, DBF_SHORT) {
+        prompt("Disable")
+    }
+    field(SDIS, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Scanning Disable")
+    }
+    field(MLOK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsMutexId        mlok")
+        interest(4)
+        prompt("Monitor lock")
+    }
+    field(MLIS, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             mlis")
+        interest(4)
+        prompt("Monitor List")
+    }
+    field(BKLNK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             bklnk")
+        interest(4)
+        prompt("Backwards link tracking")
+    }
+    field(DISP, DBF_UCHAR) {
+        prompt("Disable putField")
+    }
+    field(PROC, DBF_UCHAR) {
+        interest(3)
+        pp(TRUE)
+        prompt("Force Processing")
+    }
+    field(STAT, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        initial("UDF")
+        prompt("Alarm Status")
+    }
+    field(SEVR, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        prompt("Alarm Severity")
+    }
+    field(NSTA, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        interest(2)
+        prompt("New Alarm Status")
+    }
+    field(NSEV, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("New Alarm Severity")
+    }
+    field(ACKS, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("Alarm Ack Severity")
+    }
+    field(ACKT, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        special(SPC_NOMOD)
+        menu(menuYesNo)
+        initial("YES")
+        interest(2)
+        prompt("Alarm Ack Transient")
+    }
+    field(DISS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        prompt("Disable Alarm Sevrty")
+    }
+    field(LCNT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(2)
+        prompt("Lock Count")
+    }
+    field(PACT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Record active")
+    }
+    field(PUTF, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("dbPutField process")
+    }
+    field(RPRO, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Reprocess ")
+    }
+    field(ASP, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct asgMember    *asp")
+        interest(4)
+        prompt("Access Security Pvt")
+    }
+    field(PPN, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotify *ppn")
+        interest(4)
+        prompt("pprocessNotify")
+    }
+    field(PPNR, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotifyRecord *ppnr")
+        interest(4)
+        prompt("pprocessNotifyRecord")
+    }
+    field(SPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct scan_element *spvt")
+        interest(4)
+        prompt("Scan Private")
+    }
+    field(RSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct typed_rset   *rset")
+        interest(4)
+        prompt("Address of RSET")
+    }
+    field(DSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dset         *dset")
+        interest(4)
+        prompt("DSET address")
+    }
+    field(DPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("void                *dpvt")
+        interest(4)
+        prompt("Device Private")
+    }
+    field(RDES, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dbRecordType *rdes")
+        interest(4)
+        prompt("Address of dbRecordType")
+    }
+    field(LSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct lockRecord   *lset")
+        interest(4)
+        prompt("Lock Set")
+    }
+    field(PRIO, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuPriority)
+        interest(1)
+        prompt("Scheduling Priority")
+    }
+    field(TPRO, DBF_UCHAR) {
+        prompt("Trace Processing")
+    }
+    field(BKPT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("char                bkpt")
+        interest(1)
+        prompt("Break Point")
+    }
+    field(UDF, DBF_UCHAR) {
+        promptgroup("10 - Common")
+        initial("1")
+        interest(1)
+        pp(TRUE)
+        prompt("Undefined")
+    }
+    field(UDFS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        initial("INVALID")
+        interest(1)
+        prompt("Undefined Alarm Sevrty")
+    }
+    field(TIME, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsTimeStamp      time")
+        interest(2)
+        prompt("Time")
+    }
+    field(FLNK, DBF_FWDLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Forward Process Link")
+    }
+    field(VAL, DBF_LONG) {
+        promptgroup("40 - Input")
+        asl(ASL0)
+        pp(TRUE)
+        prompt("Current Value")
+    }
+    field(NOBT, DBF_SHORT) {
+        promptgroup("40 - Input")
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Number of Bits")
+    }
+    field(INP, DBF_INLINK) {
+        promptgroup("40 - Input")
+        interest(1)
+        prompt("Input Specification")
+    }
+    field(RVAL, DBF_ULONG) {
+        pp(TRUE)
+        prompt("Raw Value")
+    }
+    field(ORAW, DBF_ULONG) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Prev Raw Value")
+    }
+    field(MASK, DBF_ULONG) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Hardware Mask")
+    }
+    field(MLST, DBF_LONG) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Last Value Monitored")
+    }
+    field(SHFT, DBF_USHORT) {
+        promptgroup("40 - Input")
+        interest(1)
+        prompt("Shift")
+    }
+    field(SIOL, DBF_INLINK) {
+        promptgroup("90 - Simulate")
+        interest(1)
+        prompt("Simulation Input Link")
+    }
+    field(SVAL, DBF_LONG) {
+        prompt("Simulation Value")
+    }
+    field(SIML, DBF_INLINK) {
+        promptgroup("90 - Simulate")
+        interest(1)
+        prompt("Simulation Mode Link")
+    }
+    field(SIMM, DBF_MENU) {
+        special(SPC_MOD)
+        menu(menuSimm)
+        interest(1)
+        prompt("Simulation Mode")
+    }
+    field(SIMS, DBF_MENU) {
+        promptgroup("90 - Simulate")
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("Simulation Mode Severity")
+    }
+    field(OLDSIMM, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuSimm)
+        interest(4)
+        prompt("Prev. Simulation Mode")
+    }
+    field(SSCN, DBF_MENU) {
+        promptgroup("90 - Simulate")
+        menu(menuScan)
+        initial("65535")
+        interest(1)
+        prompt("Sim. Mode Scan")
+    }
+    field(SDLY, DBF_DOUBLE) {
+        promptgroup("90 - Simulate")
+        initial("-1.0")
+        interest(2)
+        prompt("Sim. Mode Async Delay")
+    }
+    field(SIMPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("CALLBACK            *simpvt")
+        interest(4)
+        prompt("Sim. Mode Private")
+    }
+    field(B0, DBF_UCHAR) {
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 0")
+    }
+    field(B1, DBF_UCHAR) {
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 1")
+    }
+    field(B2, DBF_UCHAR) {
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 2")
+    }
+    field(B3, DBF_UCHAR) {
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 3")
+    }
+    field(B4, DBF_UCHAR) {
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 4")
+    }
+    field(B5, DBF_UCHAR) {
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 5")
+    }
+    field(B6, DBF_UCHAR) {
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 6")
+    }
+    field(B7, DBF_UCHAR) {
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 7")
+    }
+    field(B8, DBF_UCHAR) {
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 8")
+    }
+    field(B9, DBF_UCHAR) {
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 9")
+    }
+    field(BA, DBF_UCHAR) {
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 10")
+    }
+    field(BB, DBF_UCHAR) {
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 11")
+    }
+    field(BC, DBF_UCHAR) {
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 12")
+    }
+    field(BD, DBF_UCHAR) {
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 13")
+    }
+    field(BE, DBF_UCHAR) {
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 14")
+    }
+    field(BF, DBF_UCHAR) {
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 15")
+    }
+    field(B10, DBF_UCHAR) {
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 16")
+    }
+    field(B11, DBF_UCHAR) {
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 17")
+    }
+    field(B12, DBF_UCHAR) {
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 18")
+    }
+    field(B13, DBF_UCHAR) {
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 19")
+    }
+    field(B14, DBF_UCHAR) {
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 20")
+    }
+    field(B15, DBF_UCHAR) {
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 21")
+    }
+    field(B16, DBF_UCHAR) {
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 22")
+    }
+    field(B17, DBF_UCHAR) {
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 23")
+    }
+    field(B18, DBF_UCHAR) {
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 24")
+    }
+    field(B19, DBF_UCHAR) {
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 25")
+    }
+    field(B1A, DBF_UCHAR) {
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 26")
+    }
+    field(B1B, DBF_UCHAR) {
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 27")
+    }
+    field(B1C, DBF_UCHAR) {
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 28")
+    }
+    field(B1D, DBF_UCHAR) {
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 29")
+    }
+    field(B1E, DBF_UCHAR) {
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 30")
+    }
+    field(B1F, DBF_UCHAR) {
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 31")
+    }
+}
+device(mbbiDirect, CONSTANT, devMbbiDirectSoft, "Soft Channel")
+device(mbbiDirect, CONSTANT, devMbbiDirectSoftRaw, "Raw Soft Channel")
+device(mbbiDirect, CONSTANT, devMbbiDirectSoftCallback, "Async Soft Channel")
+device(mbbiDirect, INST_IO, asynMbbiDirectUInt32Digital, "asynUInt32Digital")
+recordtype(asyn) {
+    %#include "epicsTypes.h"
+    %#include "link.h"
+    %#include "epicsMutex.h"
+    %#include "ellLib.h"
+    %#include "epicsTime.h"
+    field(NAME, DBF_STRING) {
+        special(SPC_NOMOD)
+        size(61)
+        prompt("Record Name")
+    }
+    field(DESC, DBF_STRING) {
+        promptgroup("10 - Common")
+        size(41)
+        prompt("Descriptor")
+    }
+    field(ASG, DBF_STRING) {
+        promptgroup("10 - Common")
+        special(SPC_AS)
+        size(29)
+        prompt("Access Security Group")
+    }
+    field(SCAN, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuScan)
+        interest(1)
+        prompt("Scan Mechanism")
+    }
+    field(PINI, DBF_MENU) {
+        promptgroup("20 - Scan")
+        menu(menuPini)
+        interest(1)
+        prompt("Process at iocInit")
+    }
+    field(PHAS, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        prompt("Scan Phase")
+    }
+    field(EVNT, DBF_STRING) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        size(40)
+        prompt("Event Name")
+    }
+    field(TSE, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Event")
+    }
+    field(TSEL, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Link")
+    }
+    field(DTYP, DBF_DEVICE) {
+        promptgroup("10 - Common")
+        interest(1)
+        prompt("Device Type")
+    }
+    field(DISV, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        initial("1")
+        prompt("Disable Value")
+    }
+    field(DISA, DBF_SHORT) {
+        prompt("Disable")
+    }
+    field(SDIS, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Scanning Disable")
+    }
+    field(MLOK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsMutexId        mlok")
+        interest(4)
+        prompt("Monitor lock")
+    }
+    field(MLIS, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             mlis")
+        interest(4)
+        prompt("Monitor List")
+    }
+    field(BKLNK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             bklnk")
+        interest(4)
+        prompt("Backwards link tracking")
+    }
+    field(DISP, DBF_UCHAR) {
+        prompt("Disable putField")
+    }
+    field(PROC, DBF_UCHAR) {
+        interest(3)
+        pp(TRUE)
+        prompt("Force Processing")
+    }
+    field(STAT, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        initial("UDF")
+        prompt("Alarm Status")
+    }
+    field(SEVR, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        prompt("Alarm Severity")
+    }
+    field(NSTA, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        interest(2)
+        prompt("New Alarm Status")
+    }
+    field(NSEV, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("New Alarm Severity")
+    }
+    field(ACKS, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("Alarm Ack Severity")
+    }
+    field(ACKT, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        special(SPC_NOMOD)
+        menu(menuYesNo)
+        initial("YES")
+        interest(2)
+        prompt("Alarm Ack Transient")
+    }
+    field(DISS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        prompt("Disable Alarm Sevrty")
+    }
+    field(LCNT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(2)
+        prompt("Lock Count")
+    }
+    field(PACT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Record active")
+    }
+    field(PUTF, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("dbPutField process")
+    }
+    field(RPRO, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Reprocess ")
+    }
+    field(ASP, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct asgMember    *asp")
+        interest(4)
+        prompt("Access Security Pvt")
+    }
+    field(PPN, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotify *ppn")
+        interest(4)
+        prompt("pprocessNotify")
+    }
+    field(PPNR, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotifyRecord *ppnr")
+        interest(4)
+        prompt("pprocessNotifyRecord")
+    }
+    field(SPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct scan_element *spvt")
+        interest(4)
+        prompt("Scan Private")
+    }
+    field(RSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct typed_rset   *rset")
+        interest(4)
+        prompt("Address of RSET")
+    }
+    field(DSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dset         *dset")
+        interest(4)
+        prompt("DSET address")
+    }
+    field(DPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("void                *dpvt")
+        interest(4)
+        prompt("Device Private")
+    }
+    field(RDES, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dbRecordType *rdes")
+        interest(4)
+        prompt("Address of dbRecordType")
+    }
+    field(LSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct lockRecord   *lset")
+        interest(4)
+        prompt("Lock Set")
+    }
+    field(PRIO, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuPriority)
+        interest(1)
+        prompt("Scheduling Priority")
+    }
+    field(TPRO, DBF_UCHAR) {
+        prompt("Trace Processing")
+    }
+    field(BKPT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("char                bkpt")
+        interest(1)
+        prompt("Break Point")
+    }
+    field(UDF, DBF_UCHAR) {
+        promptgroup("10 - Common")
+        initial("1")
+        interest(1)
+        pp(TRUE)
+        prompt("Undefined")
+    }
+    field(UDFS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        initial("INVALID")
+        interest(1)
+        prompt("Undefined Alarm Sevrty")
+    }
+    field(TIME, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsTimeStamp      time")
+        interest(2)
+        prompt("Time")
+    }
+    field(FLNK, DBF_FWDLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Forward Process Link")
+    }
+    field(VAL, DBF_LONG) {
+        asl(ASL0)
+        interest(4)
+        prompt("Value field (unused)")
+    }
+    field(PORT, DBF_STRING) {
+        promptgroup("40 - Input")
+        special(SPC_MOD)
+        initial("")
+        interest(1)
+        size(40)
+        prompt("asyn port")
+    }
+    field(ADDR, DBF_LONG) {
+        promptgroup("40 - Input")
+        special(SPC_MOD)
+        initial("0")
+        interest(1)
+        prompt("asyn address")
+    }
+    field(PCNCT, DBF_MENU) {
+        special(SPC_MOD)
+        menu(asynCONNECT)
+        interest(2)
+        prompt("Port Connect/Disconnect")
+    }
+    field(DRVINFO, DBF_STRING) {
+        promptgroup("40 - Input")
+        special(SPC_MOD)
+        initial("")
+        interest(2)
+        size(40)
+        prompt("Driver info string")
+    }
+    field(REASON, DBF_LONG) {
+        special(SPC_MOD)
+        interest(2)
+        prompt("asynUser->reason")
+    }
+    field(TMOD, DBF_MENU) {
+        promptgroup("40 - Input")
+        menu(asynTMOD)
+        interest(1)
+        prompt("Transaction mode")
+    }
+    field(TMOT, DBF_DOUBLE) {
+        promptgroup("40 - Input")
+        initial("1.0")
+        interest(1)
+        prompt("Timeout (sec)")
+    }
+    field(IFACE, DBF_MENU) {
+        promptgroup("40 - Input")
+        special(SPC_MOD)
+        menu(asynINTERFACE)
+        interest(2)
+        prompt("Interface")
+    }
+    field(OCTETIV, DBF_LONG) {
+        interest(2)
+        prompt("asynOctet is valid")
+    }
+    field(OPTIONIV, DBF_LONG) {
+        interest(2)
+        prompt("asynOption is valid")
+    }
+    field(GPIBIV, DBF_LONG) {
+        interest(2)
+        prompt("asynGPIB is valid")
+    }
+    field(I32IV, DBF_LONG) {
+        interest(2)
+        prompt("asynInt32 is valid")
+    }
+    field(UI32IV, DBF_LONG) {
+        interest(2)
+        prompt("asynUInt32Digital is valid")
+    }
+    field(F64IV, DBF_LONG) {
+        interest(2)
+        prompt("asynFloat64 is valid")
+    }
+    field(AOUT, DBF_STRING) {
+        promptgroup("50 - Output")
+        interest(1)
+        pp(TRUE)
+        size(40)
+        prompt("Output (command) string")
+    }
+    field(OEOS, DBF_STRING) {
+        promptgroup("50 - Output")
+        special(SPC_MOD)
+        interest(1)
+        size(40)
+        prompt("Output delimiter")
+    }
+    field(BOUT, DBF_CHAR) {
+        special(SPC_DBADDR)
+        interest(1)
+        pp(TRUE)
+        prompt("Output binary data")
+    }
+    field(OPTR, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("void *optr")
+        interest(4)
+        prompt("Output buffer pointer")
+    }
+    field(OMAX, DBF_LONG) {
+        promptgroup("50 - Output")
+        special(SPC_NOMOD)
+        initial("80")
+        interest(1)
+        prompt("Max. size of output array")
+    }
+    field(NOWT, DBF_LONG) {
+        promptgroup("50 - Output")
+        initial("80")
+        interest(1)
+        prompt("Number of bytes to write")
+    }
+    field(NAWT, DBF_LONG) {
+        interest(1)
+        prompt("Number of bytes actually written")
+    }
+    field(OFMT, DBF_MENU) {
+        promptgroup("50 - Output")
+        menu(asynFMT)
+        interest(1)
+        prompt("Output format")
+    }
+    field(AINP, DBF_STRING) {
+        special(SPC_NOMOD)
+        interest(1)
+        size(40)
+        prompt("Input (response) string")
+    }
+    field(TINP, DBF_STRING) {
+        special(SPC_NOMOD)
+        asl(ASL0)
+        interest(1)
+        size(40)
+        prompt("Translated input string")
+    }
+    field(IEOS, DBF_STRING) {
+        promptgroup("40 - Input")
+        special(SPC_MOD)
+        interest(1)
+        size(40)
+        prompt("Input Delimiter")
+    }
+    field(BINP, DBF_CHAR) {
+        special(SPC_DBADDR)
+        asl(ASL0)
+        prompt("Input binary data")
+    }
+    field(IPTR, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("void *iptr")
+        interest(4)
+        size(4)
+        prompt("Input buffer pointer")
+    }
+    field(IMAX, DBF_LONG) {
+        promptgroup("40 - Input")
+        special(SPC_NOMOD)
+        initial("80")
+        interest(1)
+        prompt("Max. size of input array")
+    }
+    field(NRRD, DBF_LONG) {
+        promptgroup("40 - Input")
+        interest(1)
+        prompt("Number of bytes to read")
+    }
+    field(NORD, DBF_LONG) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Number of bytes read")
+    }
+    field(IFMT, DBF_MENU) {
+        promptgroup("40 - Input")
+        menu(asynFMT)
+        interest(1)
+        prompt("Input format")
+    }
+    field(EOMR, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(asynEOMREASON)
+        interest(1)
+        prompt("EOM reason")
+    }
+    field(I32INP, DBF_LONG) {
+        special(SPC_NOMOD)
+        interest(2)
+        prompt("asynInt32 input")
+    }
+    field(I32OUT, DBF_LONG) {
+        promptgroup("50 - Output")
+        interest(2)
+        pp(TRUE)
+        prompt("asynInt32 output")
+    }
+    field(UI32INP, DBF_ULONG) {
+        special(SPC_NOMOD)
+        interest(2)
+        prompt("asynUInt32Digital input")
+    }
+    field(UI32OUT, DBF_ULONG) {
+        promptgroup("50 - Output")
+        interest(2)
+        pp(TRUE)
+        prompt("asynUInt32Digital output")
+    }
+    field(UI32MASK, DBF_ULONG) {
+        promptgroup("50 - Output")
+        special(SPC_MOD)
+        interest(2)
+        initial("0xffffffff")
+        prompt("asynUInt32Digital mask")
+    }
+    field(F64INP, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(2)
+        prompt("asynFloat64 input")
+    }
+    field(F64OUT, DBF_DOUBLE) {
+        promptgroup("50 - Output")
+        interest(2)
+        pp(TRUE)
+        prompt("asynFloat64 output")
+    }
+    field(BAUD, DBF_MENU) {
+        promptgroup("40 - Input")
+        special(SPC_MOD)
+        menu(serialBAUD)
+        interest(2)
+        prompt("Baud rate")
+    }
+    field(LBAUD, DBF_LONG) {
+        promptgroup("40 - Input")
+        special(SPC_MOD)
+        interest(2)
+        prompt("Baud rate")
+    }
+    field(PRTY, DBF_MENU) {
+        promptgroup("40 - Input")
+        special(SPC_MOD)
+        menu(serialPRTY)
+        interest(2)
+        prompt("Parity")
+    }
+    field(DBIT, DBF_MENU) {
+        promptgroup("40 - Input")
+        special(SPC_MOD)
+        menu(serialDBIT)
+        interest(2)
+        prompt("Data bits")
+    }
+    field(SBIT, DBF_MENU) {
+        promptgroup("40 - Input")
+        special(SPC_MOD)
+        menu(serialSBIT)
+        interest(2)
+        prompt("Stop bits")
+    }
+    field(MCTL, DBF_MENU) {
+        promptgroup("40 - Input")
+        special(SPC_MOD)
+        menu(serialMCTL)
+        interest(2)
+        prompt("Modem control")
+    }
+    field(FCTL, DBF_MENU) {
+        promptgroup("40 - Input")
+        special(SPC_MOD)
+        menu(serialFCTL)
+        interest(2)
+        prompt("Flow control")
+    }
+    field(IXON, DBF_MENU) {
+        promptgroup("40 - Input")
+        special(SPC_MOD)
+        menu(serialIX)
+        interest(2)
+        prompt("Output XON/XOFF")
+    }
+    field(IXOFF, DBF_MENU) {
+        promptgroup("40 - Input")
+        special(SPC_MOD)
+        menu(serialIX)
+        interest(2)
+        prompt("Input XON/XOFF")
+    }
+    field(IXANY, DBF_MENU) {
+        promptgroup("40 - Input")
+        special(SPC_MOD)
+        menu(serialIX)
+        interest(2)
+        prompt("XON=any character")
+    }
+    field(HOSTINFO, DBF_STRING) {
+        promptgroup("40 - Input")
+        special(SPC_MOD)
+        initial("")
+        interest(1)
+        size(40)
+        prompt("host info")
+    }
+    field(DRTO, DBF_MENU) {
+        promptgroup("40 - Input")
+        special(SPC_MOD)
+        menu(ipDRTO)
+        interest(2)
+        prompt("Disconnect on timeout")
+    }
+    field(UCMD, DBF_MENU) {
+        promptgroup("50 - Output")
+        menu(gpibUCMD)
+        interest(2)
+        pp(TRUE)
+        prompt("Universal command")
+    }
+    field(ACMD, DBF_MENU) {
+        promptgroup("50 - Output")
+        menu(gpibACMD)
+        interest(2)
+        pp(TRUE)
+        prompt("Addressed command")
+    }
+    field(SPR, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(2)
+        prompt("Serial poll response")
+    }
+    field(TMSK, DBF_LONG) {
+        promptgroup("80 - Display")
+        special(SPC_MOD)
+        interest(1)
+        prompt("Trace mask")
+    }
+    field(TB0, DBF_MENU) {
+        promptgroup("80 - Display")
+        special(SPC_MOD)
+        menu(asynTRACE)
+        interest(1)
+        prompt("Trace error")
+    }
+    field(TB1, DBF_MENU) {
+        promptgroup("80 - Display")
+        special(SPC_MOD)
+        menu(asynTRACE)
+        interest(1)
+        prompt("Trace IO device")
+    }
+    field(TB2, DBF_MENU) {
+        promptgroup("80 - Display")
+        special(SPC_MOD)
+        menu(asynTRACE)
+        interest(1)
+        prompt("Trace IO filter")
+    }
+    field(TB3, DBF_MENU) {
+        promptgroup("80 - Display")
+        special(SPC_MOD)
+        menu(asynTRACE)
+        interest(1)
+        prompt("Trace IO driver")
+    }
+    field(TB4, DBF_MENU) {
+        promptgroup("80 - Display")
+        special(SPC_MOD)
+        menu(asynTRACE)
+        interest(1)
+        prompt("Trace flow")
+    }
+    field(TB5, DBF_MENU) {
+        promptgroup("80 - Display")
+        special(SPC_MOD)
+        menu(asynTRACE)
+        interest(1)
+        prompt("Trace warning")
+    }
+    field(TIOM, DBF_LONG) {
+        promptgroup("80 - Display")
+        special(SPC_MOD)
+        interest(1)
+        prompt("Trace I/O mask")
+    }
+    field(TIB0, DBF_MENU) {
+        promptgroup("80 - Display")
+        special(SPC_MOD)
+        menu(asynTRACE)
+        interest(1)
+        prompt("Trace IO ASCII")
+    }
+    field(TIB1, DBF_MENU) {
+        promptgroup("80 - Display")
+        special(SPC_MOD)
+        menu(asynTRACE)
+        interest(1)
+        prompt("Trace IO escape")
+    }
+    field(TIB2, DBF_MENU) {
+        promptgroup("80 - Display")
+        special(SPC_MOD)
+        menu(asynTRACE)
+        interest(1)
+        prompt("Trace IO hex")
+    }
+    field(TINM, DBF_LONG) {
+        promptgroup("80 - Display")
+        special(SPC_MOD)
+        interest(1)
+        prompt("Trace Info mask")
+    }
+    field(TINB0, DBF_MENU) {
+        promptgroup("80 - Display")
+        special(SPC_MOD)
+        menu(asynTRACE)
+        interest(1)
+        prompt("Trace Info Time")
+    }
+    field(TINB1, DBF_MENU) {
+        promptgroup("80 - Display")
+        special(SPC_MOD)
+        menu(asynTRACE)
+        interest(1)
+        prompt("Trace Info Port")
+    }
+    field(TINB2, DBF_MENU) {
+        promptgroup("80 - Display")
+        special(SPC_MOD)
+        menu(asynTRACE)
+        interest(1)
+        prompt("Trace Info Source")
+    }
+    field(TINB3, DBF_MENU) {
+        promptgroup("80 - Display")
+        special(SPC_MOD)
+        menu(asynTRACE)
+        interest(1)
+        prompt("Trace Info Thread")
+    }
+    field(TSIZ, DBF_LONG) {
+        promptgroup("80 - Display")
+        special(SPC_MOD)
+        interest(1)
+        prompt("Trace IO truncate size")
+    }
+    field(TFIL, DBF_STRING) {
+        promptgroup("80 - Display")
+        special(SPC_MOD)
+        interest(1)
+        size(40)
+        prompt("Trace IO file")
+    }
+    field(AUCT, DBF_MENU) {
+        promptgroup("40 - Input")
+        special(SPC_MOD)
+        menu(asynAUTOCONNECT)
+        interest(1)
+        prompt("Autoconnect")
+    }
+    field(CNCT, DBF_MENU) {
+        promptgroup("40 - Input")
+        special(SPC_MOD)
+        menu(asynCONNECT)
+        interest(1)
+        prompt("Connect/Disconnect")
+    }
+    field(ENBL, DBF_MENU) {
+        promptgroup("40 - Input")
+        special(SPC_MOD)
+        menu(asynENABLE)
+        interest(1)
+        prompt("Enable/Disable")
+    }
+    field(ERRS, DBF_NOACCESS) {
+        special(SPC_DBADDR)
+        extra("char *errs")
+        interest(4)
+        prompt("Error string")
+    }
+    field(AQR, DBF_UCHAR) {
+        special(SPC_MOD)
+        interest(4)
+        prompt("Abort queueRequest")
+    }
+}
+device(asyn, INST_IO, asynRecordDevice, "asynRecordDevice")
+recordtype(motor) {
+    %#include "epicsTypes.h"
+    %#include "link.h"
+    %#include "epicsMutex.h"
+    %#include "ellLib.h"
+    %#include "epicsTime.h"
+    field(NAME, DBF_STRING) {
+        special(SPC_NOMOD)
+        size(61)
+        prompt("Record Name")
+    }
+    field(DESC, DBF_STRING) {
+        promptgroup("10 - Common")
+        size(41)
+        prompt("Descriptor")
+    }
+    field(ASG, DBF_STRING) {
+        promptgroup("10 - Common")
+        special(SPC_AS)
+        size(29)
+        prompt("Access Security Group")
+    }
+    field(SCAN, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuScan)
+        interest(1)
+        prompt("Scan Mechanism")
+    }
+    field(PINI, DBF_MENU) {
+        promptgroup("20 - Scan")
+        menu(menuPini)
+        interest(1)
+        prompt("Process at iocInit")
+    }
+    field(PHAS, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        prompt("Scan Phase")
+    }
+    field(EVNT, DBF_STRING) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        size(40)
+        prompt("Event Name")
+    }
+    field(TSE, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Event")
+    }
+    field(TSEL, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Link")
+    }
+    field(DTYP, DBF_DEVICE) {
+        promptgroup("10 - Common")
+        interest(1)
+        prompt("Device Type")
+    }
+    field(DISV, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        initial("1")
+        prompt("Disable Value")
+    }
+    field(DISA, DBF_SHORT) {
+        prompt("Disable")
+    }
+    field(SDIS, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Scanning Disable")
+    }
+    field(MLOK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsMutexId        mlok")
+        interest(4)
+        prompt("Monitor lock")
+    }
+    field(MLIS, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             mlis")
+        interest(4)
+        prompt("Monitor List")
+    }
+    field(BKLNK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             bklnk")
+        interest(4)
+        prompt("Backwards link tracking")
+    }
+    field(DISP, DBF_UCHAR) {
+        prompt("Disable putField")
+    }
+    field(PROC, DBF_UCHAR) {
+        interest(3)
+        pp(TRUE)
+        prompt("Force Processing")
+    }
+    field(STAT, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        initial("UDF")
+        prompt("Alarm Status")
+    }
+    field(SEVR, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        prompt("Alarm Severity")
+    }
+    field(NSTA, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        interest(2)
+        prompt("New Alarm Status")
+    }
+    field(NSEV, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("New Alarm Severity")
+    }
+    field(ACKS, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("Alarm Ack Severity")
+    }
+    field(ACKT, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        special(SPC_NOMOD)
+        menu(menuYesNo)
+        initial("YES")
+        interest(2)
+        prompt("Alarm Ack Transient")
+    }
+    field(DISS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        prompt("Disable Alarm Sevrty")
+    }
+    field(LCNT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(2)
+        prompt("Lock Count")
+    }
+    field(PACT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Record active")
+    }
+    field(PUTF, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("dbPutField process")
+    }
+    field(RPRO, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Reprocess ")
+    }
+    field(ASP, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct asgMember    *asp")
+        interest(4)
+        prompt("Access Security Pvt")
+    }
+    field(PPN, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotify *ppn")
+        interest(4)
+        prompt("pprocessNotify")
+    }
+    field(PPNR, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotifyRecord *ppnr")
+        interest(4)
+        prompt("pprocessNotifyRecord")
+    }
+    field(SPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct scan_element *spvt")
+        interest(4)
+        prompt("Scan Private")
+    }
+    field(RSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct typed_rset   *rset")
+        interest(4)
+        prompt("Address of RSET")
+    }
+    field(DSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dset         *dset")
+        interest(4)
+        prompt("DSET address")
+    }
+    field(DPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("void                *dpvt")
+        interest(4)
+        prompt("Device Private")
+    }
+    field(RDES, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dbRecordType *rdes")
+        interest(4)
+        prompt("Address of dbRecordType")
+    }
+    field(LSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct lockRecord   *lset")
+        interest(4)
+        prompt("Lock Set")
+    }
+    field(PRIO, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuPriority)
+        interest(1)
+        prompt("Scheduling Priority")
+    }
+    field(TPRO, DBF_UCHAR) {
+        prompt("Trace Processing")
+    }
+    field(BKPT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("char                bkpt")
+        interest(1)
+        prompt("Break Point")
+    }
+    field(UDF, DBF_UCHAR) {
+        promptgroup("10 - Common")
+        initial("1")
+        interest(1)
+        pp(TRUE)
+        prompt("Undefined")
+    }
+    field(UDFS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        initial("INVALID")
+        interest(1)
+        prompt("Undefined Alarm Sevrty")
+    }
+    field(TIME, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsTimeStamp      time")
+        interest(2)
+        prompt("Time")
+    }
+    field(FLNK, DBF_FWDLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Forward Process Link")
+    }
+    field(VERS, DBF_FLOAT) {
+        special(SPC_NOMOD)
+        initial("1")
+        prompt("Code Version")
+    }
+    field(OFF, DBF_DOUBLE) {
+        special(SPC_MOD)
+        asl(ASL0)
+        pp(TRUE)
+        prompt("User Offset (EGU)")
+    }
+    field(FOFF, DBF_MENU) {
+        promptgroup("10 - Common")
+        special(SPC_MOD)
+        asl(ASL0)
+        menu(motorFOFF)
+        interest(1)
+        prompt("Offset-Freeze Switch")
+    }
+    field(FOF, DBF_SHORT) {
+        special(SPC_MOD)
+        asl(ASL0)
+        interest(1)
+        prompt("Freeze Offset")
+    }
+    field(VOF, DBF_SHORT) {
+        special(SPC_MOD)
+        asl(ASL0)
+        interest(1)
+        prompt("Variable Offset")
+    }
+    field(DIR, DBF_MENU) {
+        promptgroup("10 - Common")
+        special(SPC_MOD)
+        menu(motorDIR)
+        interest(1)
+        pp(TRUE)
+        prompt("User Direction")
+    }
+    field(SET, DBF_MENU) {
+        asl(ASL0)
+        menu(motorSET)
+        interest(1)
+        prompt("Set/Use Switch")
+    }
+    field(SSET, DBF_SHORT) {
+        special(SPC_MOD)
+        asl(ASL0)
+        interest(1)
+        prompt("Set SET Mode")
+    }
+    field(SUSE, DBF_SHORT) {
+        special(SPC_MOD)
+        asl(ASL0)
+        interest(1)
+        prompt("Set USE Mode")
+    }
+    field(VELO, DBF_DOUBLE) {
+        promptgroup("10 - Common")
+        special(SPC_MOD)
+        interest(1)
+        prompt("Velocity (EGU/s)")
+    }
+    field(VBAS, DBF_DOUBLE) {
+        promptgroup("10 - Common")
+        special(SPC_MOD)
+        interest(1)
+        prompt("Base Velocity (EGU/s)")
+    }
+    field(VMAX, DBF_DOUBLE) {
+        promptgroup("10 - Common")
+        special(SPC_MOD)
+        interest(1)
+        prompt("Max. Velocity (EGU/s)")
+    }
+    field(S, DBF_DOUBLE) {
+        promptgroup("10 - Common")
+        special(SPC_MOD)
+        interest(1)
+        prompt("Speed (revolutions/sec)")
+    }
+    field(SBAS, DBF_DOUBLE) {
+        promptgroup("10 - Common")
+        special(SPC_MOD)
+        interest(1)
+        prompt("Base Speed (RPS)")
+    }
+    field(SMAX, DBF_DOUBLE) {
+        promptgroup("10 - Common")
+        special(SPC_MOD)
+        interest(1)
+        prompt("Max. Speed (RPS)")
+    }
+    field(ACCL, DBF_DOUBLE) {
+        promptgroup("10 - Common")
+        special(SPC_MOD)
+        initial("0.2")
+        interest(1)
+        prompt("Seconds to Velocity")
+    }
+    field(ACCS, DBF_DOUBLE) {
+        promptgroup("10 - Common")
+        special(SPC_MOD)
+        interest(1)
+        prompt("Move Accel. (EGU/s^2)")
+    }
+    field(ACCU, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(motorACCSused)
+        prompt("ACCS used")
+    }
+    field(BDST, DBF_DOUBLE) {
+        promptgroup("10 - Common")
+        special(SPC_MOD)
+        asl(ASL0)
+        interest(1)
+        prompt("BL Distance (EGU)")
+    }
+    field(BVEL, DBF_DOUBLE) {
+        promptgroup("10 - Common")
+        special(SPC_MOD)
+        interest(1)
+        prompt("BL Velocity (EGU/s)")
+    }
+    field(SBAK, DBF_DOUBLE) {
+        promptgroup("10 - Common")
+        special(SPC_MOD)
+        interest(1)
+        prompt("BL Speed (RPS)")
+    }
+    field(BACC, DBF_DOUBLE) {
+        promptgroup("10 - Common")
+        special(SPC_MOD)
+        initial("0.5")
+        interest(1)
+        prompt("BL Seconds to Velocity")
+    }
+    field(FRAC, DBF_FLOAT) {
+        promptgroup("10 - Common")
+        special(SPC_MOD)
+        initial("1")
+        interest(1)
+        prompt("Move Fraction")
+    }
+    field(OUT, DBF_OUTLINK) {
+        promptgroup("10 - Common")
+        special(SPC_MOD)
+        interest(1)
+        prompt("Output Specification")
+    }
+    field(CARD, DBF_SHORT) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Card Number")
+    }
+    field(RDBL, DBF_INLINK) {
+        promptgroup("10 - Common")
+        special(SPC_MOD)
+        interest(1)
+        prompt("Readback Location")
+    }
+    field(DOL, DBF_INLINK) {
+        promptgroup("10 - Common")
+        special(SPC_MOD)
+        interest(1)
+        prompt("Desired Output Loc")
+    }
+    field(OMSL, DBF_MENU) {
+        promptgroup("10 - Common")
+        menu(menuOmsl)
+        interest(1)
+        prompt("Output Mode Select")
+    }
+    field(RLNK, DBF_OUTLINK) {
+        promptgroup("10 - Common")
+        special(SPC_MOD)
+        interest(1)
+        prompt("Readback OutLink")
+    }
+    field(SREV, DBF_LONG) {
+        promptgroup("10 - Common")
+        special(SPC_MOD)
+        initial("200")
+        interest(1)
+        pp(TRUE)
+        prompt("Steps per Revolution")
+    }
+    field(UREV, DBF_DOUBLE) {
+        promptgroup("10 - Common")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("EGU's per Revolution")
+    }
+    field(MRES, DBF_DOUBLE) {
+        promptgroup("10 - Common")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Motor Step Size (EGU)")
+    }
+    field(ERES, DBF_DOUBLE) {
+        promptgroup("10 - Common")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Encoder Step Size (EGU)")
+    }
+    field(RRES, DBF_DOUBLE) {
+        promptgroup("10 - Common")
+        interest(1)
+        prompt("Readback Step Size (EGU")
+    }
+    field(UEIP, DBF_MENU) {
+        promptgroup("10 - Common")
+        special(SPC_MOD)
+        menu(motorUEIP)
+        interest(1)
+        pp(TRUE)
+        prompt("Use Encoder If Present")
+    }
+    field(URIP, DBF_MENU) {
+        promptgroup("10 - Common")
+        special(SPC_MOD)
+        menu(motorUEIP)
+        interest(1)
+        pp(TRUE)
+        prompt("Use RDBL Link If Presen")
+    }
+    field(PREC, DBF_SHORT) {
+        promptgroup("10 - Common")
+        interest(1)
+        prompt("Display Precision")
+    }
+    field(EGU, DBF_STRING) {
+        promptgroup("10 - Common")
+        interest(1)
+        size(16)
+        prompt("Engineering Units")
+    }
+    field(HLM, DBF_DOUBLE) {
+        special(SPC_MOD)
+        pp(TRUE)
+        prompt("User High Limit")
+    }
+    field(LLM, DBF_DOUBLE) {
+        special(SPC_MOD)
+        pp(TRUE)
+        prompt("User Low Limit")
+    }
+    field(DHLM, DBF_DOUBLE) {
+        promptgroup("10 - Common")
+        special(SPC_MOD)
+        pp(TRUE)
+        prompt("Dial High Limit")
+    }
+    field(DLLM, DBF_DOUBLE) {
+        promptgroup("10 - Common")
+        special(SPC_MOD)
+        pp(TRUE)
+        prompt("Dial Low Limit")
+    }
+    field(HOPR, DBF_DOUBLE) {
+        promptgroup("10 - Common")
+        interest(1)
+        prompt("High Operating Range")
+    }
+    field(LOPR, DBF_DOUBLE) {
+        promptgroup("10 - Common")
+        interest(1)
+        prompt("Low Operating Range")
+    }
+    field(HLS, DBF_SHORT) {
+        special(SPC_NOMOD)
+        prompt("User High Limit Switch")
+    }
+    field(LLS, DBF_SHORT) {
+        special(SPC_NOMOD)
+        prompt("User Low Limit Switch")
+    }
+    field(RHLS, DBF_SHORT) {
+        special(SPC_NOMOD)
+        prompt("Raw High Limit Switch")
+    }
+    field(RLLS, DBF_SHORT) {
+        special(SPC_NOMOD)
+        prompt("Raw Low Limit Switch")
+    }
+    field(HIHI, DBF_DOUBLE) {
+        promptgroup("10 - Common")
+        interest(2)
+        pp(TRUE)
+        prompt("Hihi Alarm Limit (EGU)")
+    }
+    field(LOLO, DBF_DOUBLE) {
+        promptgroup("10 - Common")
+        interest(2)
+        pp(TRUE)
+        prompt("Lolo Alarm Limit (EGU)")
+    }
+    field(HIGH, DBF_DOUBLE) {
+        promptgroup("10 - Common")
+        interest(2)
+        pp(TRUE)
+        prompt("High Alarm Limit (EGU)")
+    }
+    field(LOW, DBF_DOUBLE) {
+        promptgroup("10 - Common")
+        interest(2)
+        pp(TRUE)
+        prompt("Low Alarm Limit (EGU)")
+    }
+    field(HHSV, DBF_MENU) {
+        promptgroup("10 - Common")
+        menu(menuAlarmSevr)
+        interest(2)
+        pp(TRUE)
+        prompt("Hihi Severity")
+    }
+    field(LLSV, DBF_MENU) {
+        promptgroup("10 - Common")
+        menu(menuAlarmSevr)
+        interest(2)
+        pp(TRUE)
+        prompt("Lolo Severity")
+    }
+    field(HSV, DBF_MENU) {
+        promptgroup("10 - Common")
+        menu(menuAlarmSevr)
+        interest(2)
+        pp(TRUE)
+        prompt("High Severity")
+    }
+    field(LSV, DBF_MENU) {
+        promptgroup("10 - Common")
+        menu(menuAlarmSevr)
+        interest(2)
+        pp(TRUE)
+        prompt("Low Severity")
+    }
+    field(HLSV, DBF_MENU) {
+        promptgroup("10 - Common")
+        menu(menuAlarmSevr)
+        interest(2)
+        pp(TRUE)
+        prompt("HW Limit Violation Svr")
+    }
+    field(MISV, DBF_MENU) {
+        promptgroup("10 - Common")
+        menu(menuAlarmSevr)
+        interest(2)
+        pp(TRUE)
+        prompt("MISS Severity")
+    }
+    field(RDBD, DBF_DOUBLE) {
+        promptgroup("10 - Common")
+        special(SPC_MOD)
+        interest(1)
+        prompt("Retry Deadband (EGU)")
+    }
+    field(SPDB, DBF_DOUBLE) {
+        promptgroup("10 - Common")
+        special(SPC_MOD)
+        interest(1)
+        prompt("Setpoint Deadband (EGU)")
+    }
+    field(RCNT, DBF_SHORT) {
+        special(SPC_NOMOD)
+        interest(2)
+        prompt("Retry count")
+    }
+    field(RTRY, DBF_SHORT) {
+        promptgroup("10 - Common")
+        initial("10")
+        interest(1)
+        prompt("Max retry count")
+    }
+    field(MISS, DBF_SHORT) {
+        special(SPC_NOMOD)
+        interest(2)
+        prompt("Ran out of retries")
+    }
+    field(SPMG, DBF_MENU) {
+        asl(ASL0)
+        menu(motorSPMG)
+        initial("3")
+        interest(1)
+        pp(TRUE)
+        prompt("Stop/Pause/Move/Go")
+    }
+    field(LSPG, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(motorSPMG)
+        initial("3")
+        interest(1)
+        prompt("Last SPMG")
+    }
+    field(STOP, DBF_SHORT) {
+        asl(ASL0)
+        interest(1)
+        pp(TRUE)
+        prompt("Stop")
+    }
+    field(HOMF, DBF_SHORT) {
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Home Forward")
+    }
+    field(HOMR, DBF_SHORT) {
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Home Reverse")
+    }
+    field(JOGF, DBF_SHORT) {
+        special(SPC_MOD)
+        asl(ASL0)
+        interest(1)
+        pp(TRUE)
+        prompt("Jog motor Forward")
+    }
+    field(JOGR, DBF_SHORT) {
+        special(SPC_MOD)
+        asl(ASL0)
+        interest(1)
+        pp(TRUE)
+        prompt("Jog motor Reverse")
+    }
+    field(TWF, DBF_SHORT) {
+        special(SPC_MOD)
+        asl(ASL0)
+        interest(1)
+        pp(TRUE)
+        prompt("Tweak motor Forward")
+    }
+    field(TWR, DBF_SHORT) {
+        special(SPC_MOD)
+        asl(ASL0)
+        interest(1)
+        pp(TRUE)
+        prompt("Tweak motor Reverse")
+    }
+    field(TWV, DBF_DOUBLE) {
+        promptgroup("10 - Common")
+        asl(ASL0)
+        interest(1)
+        prompt("Tweak Step Size (EGU)")
+    }
+    field(VAL, DBF_DOUBLE) {
+        special(SPC_MOD)
+        asl(ASL0)
+        pp(TRUE)
+        prompt("User Desired Value (EGU")
+    }
+    field(DVAL, DBF_DOUBLE) {
+        special(SPC_MOD)
+        asl(ASL0)
+        pp(TRUE)
+        prompt("Dial Desired Value (EGU")
+    }
+    field(RVAL, DBF_LONG) {
+        special(SPC_MOD)
+        asl(ASL0)
+        pp(TRUE)
+        prompt("Raw Desired Value (step")
+    }
+    field(RLV, DBF_DOUBLE) {
+        special(SPC_MOD)
+        asl(ASL0)
+        pp(TRUE)
+        prompt("Relative Value (EGU)")
+    }
+    field(RBV, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        prompt("User Readback Value")
+    }
+    field(DRBV, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        prompt("Dial Readback Value")
+    }
+    field(DIFF, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        prompt("Difference dval-drbv")
+    }
+    field(RDIF, DBF_LONG) {
+        special(SPC_NOMOD)
+        prompt("Difference rval-rrbv")
+    }
+    field(CDIR, DBF_SHORT) {
+        special(SPC_NOMOD)
+        prompt("Raw cmnd direction")
+    }
+    field(RRBV, DBF_LONG) {
+        special(SPC_NOMOD)
+        prompt("Raw Readback Value")
+    }
+    field(RMP, DBF_LONG) {
+        special(SPC_NOMOD)
+        prompt("Raw Motor Position")
+    }
+    field(REP, DBF_LONG) {
+        special(SPC_NOMOD)
+        prompt("Raw Encoder Position")
+    }
+    field(RVEL, DBF_LONG) {
+        promptgroup("10 - Common")
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Raw Velocity")
+    }
+    field(DMOV, DBF_SHORT) {
+        promptgroup("10 - Common")
+        special(SPC_NOMOD)
+        initial("1")
+        prompt("Done moving to value")
+    }
+    field(MOVN, DBF_SHORT) {
+        special(SPC_NOMOD)
+        prompt("Motor is moving")
+    }
+    field(MSTA, DBF_ULONG) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Motor Status")
+    }
+    field(MFLG, DBF_ULONG) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Motor Flags")
+    }
+    field(LVIO, DBF_SHORT) {
+        special(SPC_NOMOD)
+        initial("1")
+        prompt("Limit violation")
+    }
+    field(TDIR, DBF_SHORT) {
+        special(SPC_NOMOD)
+        prompt("Direction of Travel")
+    }
+    field(ATHM, DBF_SHORT) {
+        special(SPC_NOMOD)
+        prompt("At HOME")
+    }
+    field(PP, DBF_SHORT) {
+        special(SPC_NOMOD)
+        initial("0")
+        interest(2)
+        prompt("Post process command")
+    }
+    field(MIP, DBF_USHORT) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Motion In Progress")
+    }
+    field(MMAP, DBF_ULONG) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Monitor Mask")
+    }
+    field(NMAP, DBF_ULONG) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Monitor Mask (more)")
+    }
+    field(DLY, DBF_DOUBLE) {
+        promptgroup("10 - Common")
+        special(SPC_MOD)
+        interest(1)
+        prompt("Readback settle time (s)")
+    }
+    field(CBAK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("void             *cbak")
+        interest(4)
+        size(4)
+        prompt("Callback structure")
+    }
+    field(priv, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct motor_priv *priv")
+        interest(4)
+        size(4)
+        prompt("Private data")
+    }
+    field(PCOF, DBF_DOUBLE) {
+        promptgroup("10 - Common")
+        special(SPC_MOD)
+        initial("0")
+        interest(1)
+        prompt("Proportional Gain")
+    }
+    field(ICOF, DBF_DOUBLE) {
+        promptgroup("10 - Common")
+        special(SPC_MOD)
+        initial("0")
+        interest(1)
+        prompt("Integral Gain")
+    }
+    field(DCOF, DBF_DOUBLE) {
+        promptgroup("10 - Common")
+        special(SPC_MOD)
+        initial("0")
+        interest(1)
+        prompt("Derivative Gain")
+    }
+    field(CNEN, DBF_MENU) {
+        promptgroup("10 - Common")
+        special(SPC_MOD)
+        asl(ASL0)
+        menu(motorTORQ)
+        pp(TRUE)
+        prompt("Enable control")
+    }
+    field(INIT, DBF_STRING) {
+        promptgroup("10 - Common")
+        interest(1)
+        size(40)
+        prompt("Startup commands")
+    }
+    field(PREM, DBF_STRING) {
+        promptgroup("10 - Common")
+        interest(1)
+        size(40)
+        prompt("Pre-move commands")
+    }
+    field(POST, DBF_STRING) {
+        promptgroup("10 - Common")
+        interest(1)
+        size(40)
+        prompt("Post-move commands")
+    }
+    field(STOO, DBF_OUTLINK) {
+        promptgroup("10 - Common")
+        special(SPC_MOD)
+        interest(1)
+        prompt("STOP OutLink")
+    }
+    field(DINP, DBF_INLINK) {
+        promptgroup("10 - Common")
+        special(SPC_MOD)
+        interest(1)
+        prompt("DMOV Input Link")
+    }
+    field(RINP, DBF_INLINK) {
+        promptgroup("10 - Common")
+        special(SPC_MOD)
+        interest(1)
+        prompt("RMP Input Link")
+    }
+    field(JVEL, DBF_DOUBLE) {
+        promptgroup("10 - Common")
+        special(SPC_MOD)
+        interest(1)
+        prompt("Jog Velocity (EGU/s)")
+    }
+    field(JAR, DBF_DOUBLE) {
+        promptgroup("10 - Common")
+        special(SPC_MOD)
+        interest(1)
+        prompt("Jog Accel. (EGU/s^2)")
+    }
+    field(LOCK, DBF_MENU) {
+        promptgroup("10 - Common")
+        menu(menuYesNo)
+        initial("NO")
+        interest(1)
+        prompt("Soft Channel Position Lock")
+    }
+    field(NTM, DBF_MENU) {
+        promptgroup("10 - Common")
+        menu(menuYesNo)
+        initial("YES")
+        interest(1)
+        prompt("New Target Monitor")
+    }
+    field(NTMF, DBF_USHORT) {
+        promptgroup("10 - Common")
+        special(SPC_MOD)
+        interest(1)
+        initial("2")
+        prompt("NTM Deadband Factor")
+    }
+    field(HVEL, DBF_DOUBLE) {
+        promptgroup("10 - Common")
+        special(SPC_MOD)
+        interest(1)
+        prompt("Home Velocity (EGU/s)")
+    }
+    field(STUP, DBF_MENU) {
+        menu(motorSTUP)
+        interest(3)
+        pp(TRUE)
+        prompt("Status Update")
+        promptgroup("10 - Common")
+        special(SPC_MOD)
+        asl(ASL0)
+        initial("OFF")
+    }
+    field(RMOD, DBF_MENU) {
+        promptgroup("10 - Common")
+        menu(motorRMOD)
+        interest(1)
+        initial("Default")
+        prompt("Retry Mode")
+    }
+    field(ADEL, DBF_DOUBLE) {
+        promptgroup("10 - Common")
+        interest(1)
+        prompt("Archive Deadband")
+    }
+    field(MDEL, DBF_DOUBLE) {
+        promptgroup("10 - Common")
+        interest(1)
+        prompt("Monitor Deadband")
+    }
+    field(SYNC, DBF_SHORT) {
+        interest(1)
+        pp(TRUE)
+        prompt("Sync position")
+    }
+    field(IGSET, DBF_SHORT) {
+        interest(2)
+        prompt("Ignore SET field")
+    }
+    field(SPAM, DBF_SHORT) {
+        interest(2)
+        prompt("Debug print bit mask")
+    }
+}
+device(motor, INST_IO, devMotorAsyn, "asynMotor")
+device(motor, CONSTANT, devMotorSoft, "Soft Channel")
+recordtype(waveform) {
+    %#include "epicsTypes.h"
+    %#include "link.h"
+    %#include "epicsMutex.h"
+    %#include "ellLib.h"
+    %#include "epicsTime.h"
+    %#include "callback.h"
+    field(NAME, DBF_STRING) {
+        special(SPC_NOMOD)
+        size(61)
+        prompt("Record Name")
+    }
+    field(DESC, DBF_STRING) {
+        promptgroup("10 - Common")
+        size(41)
+        prompt("Descriptor")
+    }
+    field(ASG, DBF_STRING) {
+        promptgroup("10 - Common")
+        special(SPC_AS)
+        size(29)
+        prompt("Access Security Group")
+    }
+    field(SCAN, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuScan)
+        interest(1)
+        prompt("Scan Mechanism")
+    }
+    field(PINI, DBF_MENU) {
+        promptgroup("20 - Scan")
+        menu(menuPini)
+        interest(1)
+        prompt("Process at iocInit")
+    }
+    field(PHAS, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        prompt("Scan Phase")
+    }
+    field(EVNT, DBF_STRING) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        size(40)
+        prompt("Event Name")
+    }
+    field(TSE, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Event")
+    }
+    field(TSEL, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Link")
+    }
+    field(DTYP, DBF_DEVICE) {
+        promptgroup("10 - Common")
+        interest(1)
+        prompt("Device Type")
+    }
+    field(DISV, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        initial("1")
+        prompt("Disable Value")
+    }
+    field(DISA, DBF_SHORT) {
+        prompt("Disable")
+    }
+    field(SDIS, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Scanning Disable")
+    }
+    field(MLOK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsMutexId        mlok")
+        interest(4)
+        prompt("Monitor lock")
+    }
+    field(MLIS, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             mlis")
+        interest(4)
+        prompt("Monitor List")
+    }
+    field(BKLNK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             bklnk")
+        interest(4)
+        prompt("Backwards link tracking")
+    }
+    field(DISP, DBF_UCHAR) {
+        prompt("Disable putField")
+    }
+    field(PROC, DBF_UCHAR) {
+        interest(3)
+        pp(TRUE)
+        prompt("Force Processing")
+    }
+    field(STAT, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        initial("UDF")
+        prompt("Alarm Status")
+    }
+    field(SEVR, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        prompt("Alarm Severity")
+    }
+    field(NSTA, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        interest(2)
+        prompt("New Alarm Status")
+    }
+    field(NSEV, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("New Alarm Severity")
+    }
+    field(ACKS, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("Alarm Ack Severity")
+    }
+    field(ACKT, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        special(SPC_NOMOD)
+        menu(menuYesNo)
+        initial("YES")
+        interest(2)
+        prompt("Alarm Ack Transient")
+    }
+    field(DISS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        prompt("Disable Alarm Sevrty")
+    }
+    field(LCNT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(2)
+        prompt("Lock Count")
+    }
+    field(PACT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Record active")
+    }
+    field(PUTF, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("dbPutField process")
+    }
+    field(RPRO, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Reprocess ")
+    }
+    field(ASP, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct asgMember    *asp")
+        interest(4)
+        prompt("Access Security Pvt")
+    }
+    field(PPN, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotify *ppn")
+        interest(4)
+        prompt("pprocessNotify")
+    }
+    field(PPNR, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotifyRecord *ppnr")
+        interest(4)
+        prompt("pprocessNotifyRecord")
+    }
+    field(SPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct scan_element *spvt")
+        interest(4)
+        prompt("Scan Private")
+    }
+    field(RSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct typed_rset   *rset")
+        interest(4)
+        prompt("Address of RSET")
+    }
+    field(DSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dset         *dset")
+        interest(4)
+        prompt("DSET address")
+    }
+    field(DPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("void                *dpvt")
+        interest(4)
+        prompt("Device Private")
+    }
+    field(RDES, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dbRecordType *rdes")
+        interest(4)
+        prompt("Address of dbRecordType")
+    }
+    field(LSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct lockRecord   *lset")
+        interest(4)
+        prompt("Lock Set")
+    }
+    field(PRIO, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuPriority)
+        interest(1)
+        prompt("Scheduling Priority")
+    }
+    field(TPRO, DBF_UCHAR) {
+        prompt("Trace Processing")
+    }
+    field(BKPT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("char                bkpt")
+        interest(1)
+        prompt("Break Point")
+    }
+    field(UDF, DBF_UCHAR) {
+        promptgroup("10 - Common")
+        initial("1")
+        interest(1)
+        pp(TRUE)
+        prompt("Undefined")
+    }
+    field(UDFS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        initial("INVALID")
+        interest(1)
+        prompt("Undefined Alarm Sevrty")
+    }
+    field(TIME, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsTimeStamp      time")
+        interest(2)
+        prompt("Time")
+    }
+    field(FLNK, DBF_FWDLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Forward Process Link")
+    }
+    field(VAL, DBF_NOACCESS) {
+        special(SPC_DBADDR)
+        asl(ASL0)
+        extra("void *		val")
+        pp(TRUE)
+        prompt("Value")
+    }
+    field(RARM, DBF_SHORT) {
+        promptgroup("30 - Action")
+        interest(1)
+        pp(TRUE)
+        prompt("Rearm the waveform")
+    }
+    field(PREC, DBF_SHORT) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("Display Precision")
+    }
+    field(INP, DBF_INLINK) {
+        promptgroup("40 - Input")
+        interest(1)
+        prompt("Input Specification")
+    }
+    field(EGU, DBF_STRING) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        size(16)
+        prompt("Engineering Units")
+    }
+    field(HOPR, DBF_DOUBLE) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("High Operating Range")
+    }
+    field(LOPR, DBF_DOUBLE) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("Low Operating Range")
+    }
+    field(NELM, DBF_ULONG) {
+        promptgroup("30 - Action")
+        special(SPC_NOMOD)
+        initial("1")
+        interest(1)
+        prompt("Number of Elements")
+    }
+    field(FTVL, DBF_MENU) {
+        promptgroup("30 - Action")
+        special(SPC_NOMOD)
+        menu(menuFtype)
+        interest(1)
+        prompt("Field Type of Value")
+    }
+    field(BUSY, DBF_SHORT) {
+        special(SPC_NOMOD)
+        prompt("Busy Indicator")
+    }
+    field(NORD, DBF_ULONG) {
+        special(SPC_NOMOD)
+        prompt("Number elements read")
+    }
+    field(BPTR, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("void *		bptr")
+        interest(4)
+        prompt("Buffer Pointer")
+    }
+    field(SIOL, DBF_INLINK) {
+        promptgroup("90 - Simulate")
+        interest(1)
+        prompt("Simulation Input Link")
+    }
+    field(SIML, DBF_INLINK) {
+        promptgroup("90 - Simulate")
+        interest(1)
+        prompt("Simulation Mode Link")
+    }
+    field(SIMM, DBF_MENU) {
+        special(SPC_MOD)
+        menu(menuYesNo)
+        interest(1)
+        prompt("Simulation Mode")
+    }
+    field(SIMS, DBF_MENU) {
+        promptgroup("90 - Simulate")
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("Simulation Mode Severity")
+    }
+    field(OLDSIMM, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuSimm)
+        interest(4)
+        prompt("Prev. Simulation Mode")
+    }
+    field(SSCN, DBF_MENU) {
+        promptgroup("90 - Simulate")
+        menu(menuScan)
+        initial("65535")
+        interest(1)
+        prompt("Sim. Mode Scan")
+    }
+    field(SDLY, DBF_DOUBLE) {
+        promptgroup("90 - Simulate")
+        initial("-1.0")
+        interest(2)
+        prompt("Sim. Mode Async Delay")
+    }
+    field(SIMPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("CALLBACK            *simpvt")
+        interest(4)
+        prompt("Sim. Mode Private")
+    }
+    field(MPST, DBF_MENU) {
+        promptgroup("80 - Display")
+        menu(waveformPOST)
+        interest(1)
+        prompt("Post Value Monitors")
+    }
+    field(APST, DBF_MENU) {
+        promptgroup("80 - Display")
+        menu(waveformPOST)
+        interest(1)
+        prompt("Post Archive Monitors")
+    }
+    field(HASH, DBF_ULONG) {
+        interest(3)
+        prompt("Hash of OnChange data.")
+    }
+}
+device(waveform, CONSTANT, devWfSoft, "Soft Channel")
+device(waveform, INST_IO, devWaveformStats, "IOC stats")
+device(waveform, INST_IO, asynWfOctetCmdResponse, "asynOctetCmdResponse")
+device(waveform, INST_IO, asynWfOctetWriteRead, "asynOctetWriteRead")
+device(waveform, INST_IO, asynWfOctetRead, "asynOctetRead")
+device(waveform, INST_IO, asynWfOctetWrite, "asynOctetWrite")
+device(waveform, INST_IO, asynWfOctetWriteBinary, "asynOctetWriteBinary")
+device(waveform, INST_IO, asynInt8ArrayWfIn, "asynInt8ArrayIn")
+device(waveform, INST_IO, asynInt8ArrayWfOut, "asynInt8ArrayOut")
+device(waveform, INST_IO, asynInt16ArrayWfIn, "asynInt16ArrayIn")
+device(waveform, INST_IO, asynInt16ArrayWfOut, "asynInt16ArrayOut")
+device(waveform, INST_IO, asynInt32ArrayWfIn, "asynInt32ArrayIn")
+device(waveform, INST_IO, asynInt32ArrayWfOut, "asynInt32ArrayOut")
+device(waveform, INST_IO, asynInt32TimeSeries, "asynInt32TimeSeries")
+device(waveform, INST_IO, asynFloat32ArrayWfIn, "asynFloat32ArrayIn")
+device(waveform, INST_IO, asynFloat32ArrayWfOut, "asynFloat32ArrayOut")
+device(waveform, INST_IO, asynFloat64ArrayWfIn, "asynFloat64ArrayIn")
+device(waveform, INST_IO, asynFloat64ArrayWfOut, "asynFloat64ArrayOut")
+device(waveform, INST_IO, asynFloat64TimeSeries, "asynFloat64TimeSeries")
+recordtype(fanout) {
+    %#include "epicsTypes.h"
+    %#include "link.h"
+    %#include "epicsMutex.h"
+    %#include "ellLib.h"
+    %#include "epicsTime.h"
+    field(NAME, DBF_STRING) {
+        special(SPC_NOMOD)
+        size(61)
+        prompt("Record Name")
+    }
+    field(DESC, DBF_STRING) {
+        promptgroup("10 - Common")
+        size(41)
+        prompt("Descriptor")
+    }
+    field(ASG, DBF_STRING) {
+        promptgroup("10 - Common")
+        special(SPC_AS)
+        size(29)
+        prompt("Access Security Group")
+    }
+    field(SCAN, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuScan)
+        interest(1)
+        prompt("Scan Mechanism")
+    }
+    field(PINI, DBF_MENU) {
+        promptgroup("20 - Scan")
+        menu(menuPini)
+        interest(1)
+        prompt("Process at iocInit")
+    }
+    field(PHAS, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        prompt("Scan Phase")
+    }
+    field(EVNT, DBF_STRING) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        size(40)
+        prompt("Event Name")
+    }
+    field(TSE, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Event")
+    }
+    field(TSEL, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Link")
+    }
+    field(DTYP, DBF_DEVICE) {
+        promptgroup("10 - Common")
+        interest(1)
+        prompt("Device Type")
+    }
+    field(DISV, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        initial("1")
+        prompt("Disable Value")
+    }
+    field(DISA, DBF_SHORT) {
+        prompt("Disable")
+    }
+    field(SDIS, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Scanning Disable")
+    }
+    field(MLOK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsMutexId        mlok")
+        interest(4)
+        prompt("Monitor lock")
+    }
+    field(MLIS, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             mlis")
+        interest(4)
+        prompt("Monitor List")
+    }
+    field(BKLNK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             bklnk")
+        interest(4)
+        prompt("Backwards link tracking")
+    }
+    field(DISP, DBF_UCHAR) {
+        prompt("Disable putField")
+    }
+    field(PROC, DBF_UCHAR) {
+        interest(3)
+        pp(TRUE)
+        prompt("Force Processing")
+    }
+    field(STAT, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        initial("UDF")
+        prompt("Alarm Status")
+    }
+    field(SEVR, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        prompt("Alarm Severity")
+    }
+    field(NSTA, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        interest(2)
+        prompt("New Alarm Status")
+    }
+    field(NSEV, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("New Alarm Severity")
+    }
+    field(ACKS, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("Alarm Ack Severity")
+    }
+    field(ACKT, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        special(SPC_NOMOD)
+        menu(menuYesNo)
+        initial("YES")
+        interest(2)
+        prompt("Alarm Ack Transient")
+    }
+    field(DISS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        prompt("Disable Alarm Sevrty")
+    }
+    field(LCNT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(2)
+        prompt("Lock Count")
+    }
+    field(PACT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Record active")
+    }
+    field(PUTF, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("dbPutField process")
+    }
+    field(RPRO, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Reprocess ")
+    }
+    field(ASP, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct asgMember    *asp")
+        interest(4)
+        prompt("Access Security Pvt")
+    }
+    field(PPN, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotify *ppn")
+        interest(4)
+        prompt("pprocessNotify")
+    }
+    field(PPNR, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotifyRecord *ppnr")
+        interest(4)
+        prompt("pprocessNotifyRecord")
+    }
+    field(SPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct scan_element *spvt")
+        interest(4)
+        prompt("Scan Private")
+    }
+    field(RSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct typed_rset   *rset")
+        interest(4)
+        prompt("Address of RSET")
+    }
+    field(DSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dset         *dset")
+        interest(4)
+        prompt("DSET address")
+    }
+    field(DPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("void                *dpvt")
+        interest(4)
+        prompt("Device Private")
+    }
+    field(RDES, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dbRecordType *rdes")
+        interest(4)
+        prompt("Address of dbRecordType")
+    }
+    field(LSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct lockRecord   *lset")
+        interest(4)
+        prompt("Lock Set")
+    }
+    field(PRIO, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuPriority)
+        interest(1)
+        prompt("Scheduling Priority")
+    }
+    field(TPRO, DBF_UCHAR) {
+        prompt("Trace Processing")
+    }
+    field(BKPT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("char                bkpt")
+        interest(1)
+        prompt("Break Point")
+    }
+    field(UDF, DBF_UCHAR) {
+        promptgroup("10 - Common")
+        initial("1")
+        interest(1)
+        pp(TRUE)
+        prompt("Undefined")
+    }
+    field(UDFS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        initial("INVALID")
+        interest(1)
+        prompt("Undefined Alarm Sevrty")
+    }
+    field(TIME, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsTimeStamp      time")
+        interest(2)
+        prompt("Time")
+    }
+    field(FLNK, DBF_FWDLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Forward Process Link")
+    }
+    field(VAL, DBF_LONG) {
+        asl(ASL0)
+        pp(TRUE)
+        prompt("Used to trigger")
+    }
+    field(SELM, DBF_MENU) {
+        promptgroup("30 - Action")
+        menu(fanoutSELM)
+        interest(1)
+        prompt("Select Mechanism")
+    }
+    field(SELN, DBF_USHORT) {
+        initial("1")
+        interest(1)
+        prompt("Link Selection")
+    }
+    field(SELL, DBF_INLINK) {
+        promptgroup("30 - Action")
+        interest(1)
+        prompt("Link Selection Loc")
+    }
+    field(OFFS, DBF_SHORT) {
+        promptgroup("30 - Action")
+        initial("0")
+        interest(1)
+        prompt("Offset for Specified")
+    }
+    field(SHFT, DBF_SHORT) {
+        promptgroup("30 - Action")
+        initial("-1")
+        interest(1)
+        prompt("Shift for Mask mode")
+    }
+    field(LNK0, DBF_FWDLINK) {
+        promptgroup("51 - Output 0-7")
+        interest(1)
+        prompt("Forward Link 0")
+    }
+    field(LNK1, DBF_FWDLINK) {
+        promptgroup("51 - Output 0-7")
+        interest(1)
+        prompt("Forward Link 1")
+    }
+    field(LNK2, DBF_FWDLINK) {
+        promptgroup("51 - Output 0-7")
+        interest(1)
+        prompt("Forward Link 2")
+    }
+    field(LNK3, DBF_FWDLINK) {
+        promptgroup("51 - Output 0-7")
+        interest(1)
+        prompt("Forward Link 3")
+    }
+    field(LNK4, DBF_FWDLINK) {
+        promptgroup("51 - Output 0-7")
+        interest(1)
+        prompt("Forward Link 4")
+    }
+    field(LNK5, DBF_FWDLINK) {
+        promptgroup("51 - Output 0-7")
+        interest(1)
+        prompt("Forward Link 5")
+    }
+    field(LNK6, DBF_FWDLINK) {
+        promptgroup("51 - Output 0-7")
+        interest(1)
+        prompt("Forward Link 6")
+    }
+    field(LNK7, DBF_FWDLINK) {
+        promptgroup("51 - Output 0-7")
+        interest(1)
+        prompt("Forward Link 7")
+    }
+    field(LNK8, DBF_FWDLINK) {
+        promptgroup("52 - Output 8-F")
+        interest(1)
+        prompt("Forward Link 8")
+    }
+    field(LNK9, DBF_FWDLINK) {
+        promptgroup("52 - Output 8-F")
+        interest(1)
+        prompt("Forward Link 9")
+    }
+    field(LNKA, DBF_FWDLINK) {
+        promptgroup("52 - Output 8-F")
+        interest(1)
+        prompt("Forward Link 10")
+    }
+    field(LNKB, DBF_FWDLINK) {
+        promptgroup("52 - Output 8-F")
+        interest(1)
+        prompt("Forward Link 11")
+    }
+    field(LNKC, DBF_FWDLINK) {
+        promptgroup("52 - Output 8-F")
+        interest(1)
+        prompt("Forward Link 12")
+    }
+    field(LNKD, DBF_FWDLINK) {
+        promptgroup("52 - Output 8-F")
+        interest(1)
+        prompt("Forward Link 13")
+    }
+    field(LNKE, DBF_FWDLINK) {
+        promptgroup("52 - Output 8-F")
+        interest(1)
+        prompt("Forward Link 14")
+    }
+    field(LNKF, DBF_FWDLINK) {
+        promptgroup("52 - Output 8-F")
+        interest(1)
+        prompt("Forward Link 15")
+    }
+}
+recordtype(longin) {
+    %#include "epicsTypes.h"
+    %#include "link.h"
+    %#include "epicsMutex.h"
+    %#include "ellLib.h"
+    %#include "epicsTime.h"
+    %#include "callback.h"
+    field(NAME, DBF_STRING) {
+        special(SPC_NOMOD)
+        size(61)
+        prompt("Record Name")
+    }
+    field(DESC, DBF_STRING) {
+        promptgroup("10 - Common")
+        size(41)
+        prompt("Descriptor")
+    }
+    field(ASG, DBF_STRING) {
+        promptgroup("10 - Common")
+        special(SPC_AS)
+        size(29)
+        prompt("Access Security Group")
+    }
+    field(SCAN, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuScan)
+        interest(1)
+        prompt("Scan Mechanism")
+    }
+    field(PINI, DBF_MENU) {
+        promptgroup("20 - Scan")
+        menu(menuPini)
+        interest(1)
+        prompt("Process at iocInit")
+    }
+    field(PHAS, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        prompt("Scan Phase")
+    }
+    field(EVNT, DBF_STRING) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        size(40)
+        prompt("Event Name")
+    }
+    field(TSE, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Event")
+    }
+    field(TSEL, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Link")
+    }
+    field(DTYP, DBF_DEVICE) {
+        promptgroup("10 - Common")
+        interest(1)
+        prompt("Device Type")
+    }
+    field(DISV, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        initial("1")
+        prompt("Disable Value")
+    }
+    field(DISA, DBF_SHORT) {
+        prompt("Disable")
+    }
+    field(SDIS, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Scanning Disable")
+    }
+    field(MLOK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsMutexId        mlok")
+        interest(4)
+        prompt("Monitor lock")
+    }
+    field(MLIS, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             mlis")
+        interest(4)
+        prompt("Monitor List")
+    }
+    field(BKLNK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             bklnk")
+        interest(4)
+        prompt("Backwards link tracking")
+    }
+    field(DISP, DBF_UCHAR) {
+        prompt("Disable putField")
+    }
+    field(PROC, DBF_UCHAR) {
+        interest(3)
+        pp(TRUE)
+        prompt("Force Processing")
+    }
+    field(STAT, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        initial("UDF")
+        prompt("Alarm Status")
+    }
+    field(SEVR, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        prompt("Alarm Severity")
+    }
+    field(NSTA, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        interest(2)
+        prompt("New Alarm Status")
+    }
+    field(NSEV, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("New Alarm Severity")
+    }
+    field(ACKS, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("Alarm Ack Severity")
+    }
+    field(ACKT, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        special(SPC_NOMOD)
+        menu(menuYesNo)
+        initial("YES")
+        interest(2)
+        prompt("Alarm Ack Transient")
+    }
+    field(DISS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        prompt("Disable Alarm Sevrty")
+    }
+    field(LCNT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(2)
+        prompt("Lock Count")
+    }
+    field(PACT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Record active")
+    }
+    field(PUTF, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("dbPutField process")
+    }
+    field(RPRO, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Reprocess ")
+    }
+    field(ASP, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct asgMember    *asp")
+        interest(4)
+        prompt("Access Security Pvt")
+    }
+    field(PPN, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotify *ppn")
+        interest(4)
+        prompt("pprocessNotify")
+    }
+    field(PPNR, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotifyRecord *ppnr")
+        interest(4)
+        prompt("pprocessNotifyRecord")
+    }
+    field(SPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct scan_element *spvt")
+        interest(4)
+        prompt("Scan Private")
+    }
+    field(RSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct typed_rset   *rset")
+        interest(4)
+        prompt("Address of RSET")
+    }
+    field(DSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dset         *dset")
+        interest(4)
+        prompt("DSET address")
+    }
+    field(DPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("void                *dpvt")
+        interest(4)
+        prompt("Device Private")
+    }
+    field(RDES, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dbRecordType *rdes")
+        interest(4)
+        prompt("Address of dbRecordType")
+    }
+    field(LSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct lockRecord   *lset")
+        interest(4)
+        prompt("Lock Set")
+    }
+    field(PRIO, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuPriority)
+        interest(1)
+        prompt("Scheduling Priority")
+    }
+    field(TPRO, DBF_UCHAR) {
+        prompt("Trace Processing")
+    }
+    field(BKPT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("char                bkpt")
+        interest(1)
+        prompt("Break Point")
+    }
+    field(UDF, DBF_UCHAR) {
+        promptgroup("10 - Common")
+        initial("1")
+        interest(1)
+        pp(TRUE)
+        prompt("Undefined")
+    }
+    field(UDFS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        initial("INVALID")
+        interest(1)
+        prompt("Undefined Alarm Sevrty")
+    }
+    field(TIME, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsTimeStamp      time")
+        interest(2)
+        prompt("Time")
+    }
+    field(FLNK, DBF_FWDLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Forward Process Link")
+    }
+    field(VAL, DBF_LONG) {
+        promptgroup("40 - Input")
+        asl(ASL0)
+        pp(TRUE)
+        prompt("Current value")
+    }
+    field(INP, DBF_INLINK) {
+        promptgroup("40 - Input")
+        interest(1)
+        prompt("Input Specification")
+    }
+    field(EGU, DBF_STRING) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        size(16)
+        prompt("Engineering Units")
+    }
+    field(HOPR, DBF_LONG) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("High Operating Range")
+    }
+    field(LOPR, DBF_LONG) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("Low Operating Range")
+    }
+    field(HIHI, DBF_LONG) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        interest(1)
+        pp(TRUE)
+        prompt("Hihi Alarm Limit")
+    }
+    field(LOLO, DBF_LONG) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        interest(1)
+        pp(TRUE)
+        prompt("Lolo Alarm Limit")
+    }
+    field(HIGH, DBF_LONG) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        interest(1)
+        pp(TRUE)
+        prompt("High Alarm Limit")
+    }
+    field(LOW, DBF_LONG) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        interest(1)
+        pp(TRUE)
+        prompt("Low Alarm Limit")
+    }
+    field(HHSV, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("Hihi Severity")
+    }
+    field(LLSV, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("Lolo Severity")
+    }
+    field(HSV, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("High Severity")
+    }
+    field(LSV, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("Low Severity")
+    }
+    field(HYST, DBF_LONG) {
+        promptgroup("70 - Alarm")
+        interest(1)
+        prompt("Alarm Deadband")
+    }
+    field(AFTC, DBF_DOUBLE) {
+        promptgroup("70 - Alarm")
+        interest(1)
+        prompt("Alarm Filter Time Constant")
+    }
+    field(AFVL, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Alarm Filter Value")
+    }
+    field(ADEL, DBF_LONG) {
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("Archive Deadband")
+    }
+    field(MDEL, DBF_LONG) {
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("Monitor Deadband")
+    }
+    field(LALM, DBF_LONG) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Last Value Alarmed")
+    }
+    field(ALST, DBF_LONG) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Last Value Archived")
+    }
+    field(MLST, DBF_LONG) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Last Val Monitored")
+    }
+    field(SIOL, DBF_INLINK) {
+        promptgroup("90 - Simulate")
+        interest(1)
+        prompt("Simulation Input Link")
+    }
+    field(SVAL, DBF_LONG) {
+        prompt("Simulation Value")
+    }
+    field(SIML, DBF_INLINK) {
+        promptgroup("90 - Simulate")
+        interest(1)
+        prompt("Simulation Mode Link")
+    }
+    field(SIMM, DBF_MENU) {
+        special(SPC_MOD)
+        menu(menuYesNo)
+        interest(1)
+        prompt("Simulation Mode")
+    }
+    field(SIMS, DBF_MENU) {
+        promptgroup("90 - Simulate")
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("Simulation Mode Severity")
+    }
+    field(OLDSIMM, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuSimm)
+        interest(4)
+        prompt("Prev. Simulation Mode")
+    }
+    field(SSCN, DBF_MENU) {
+        promptgroup("90 - Simulate")
+        menu(menuScan)
+        initial("65535")
+        interest(1)
+        prompt("Sim. Mode Scan")
+    }
+    field(SDLY, DBF_DOUBLE) {
+        promptgroup("90 - Simulate")
+        initial("-1.0")
+        interest(2)
+        prompt("Sim. Mode Async Delay")
+    }
+    field(SIMPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("CALLBACK            *simpvt")
+        interest(4)
+        prompt("Sim. Mode Private")
+    }
+}
+device(longin, CONSTANT, devLiSoft, "Soft Channel")
+device(longin, CONSTANT, devLiSoftCallback, "Async Soft Channel")
+device(longin, INST_IO, devLiGeneralTime, "General Time")
+device(longin, INST_IO, asynLiInt32, "asynInt32")
+device(longin, INST_IO, asynLiUInt32Digital, "asynUInt32Digital")
+recordtype(printf) {
+    %#include "epicsTypes.h"
+    %#include "link.h"
+    %#include "epicsMutex.h"
+    %#include "ellLib.h"
+    %#include "epicsTime.h"
+    %#include "devSup.h"
+    %
+    %/* Declare Device Support Entry Table */
+    %typedef struct printfdset {
+    %    long number;
+    %    DEVSUPFUN report;
+    %    DEVSUPFUN init;
+    %    DEVSUPFUN init_record;
+    %    DEVSUPFUN get_ioint_info;
+    %    DEVSUPFUN write_string;
+    %} printfdset;
+    %
+    %/* Number of INPx fields defined */
+    %#define PRINTF_NLINKS 10
+    field(NAME, DBF_STRING) {
+        special(SPC_NOMOD)
+        size(61)
+        prompt("Record Name")
+    }
+    field(DESC, DBF_STRING) {
+        promptgroup("10 - Common")
+        size(41)
+        prompt("Descriptor")
+    }
+    field(ASG, DBF_STRING) {
+        promptgroup("10 - Common")
+        special(SPC_AS)
+        size(29)
+        prompt("Access Security Group")
+    }
+    field(SCAN, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuScan)
+        interest(1)
+        prompt("Scan Mechanism")
+    }
+    field(PINI, DBF_MENU) {
+        promptgroup("20 - Scan")
+        menu(menuPini)
+        interest(1)
+        prompt("Process at iocInit")
+    }
+    field(PHAS, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        prompt("Scan Phase")
+    }
+    field(EVNT, DBF_STRING) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        size(40)
+        prompt("Event Name")
+    }
+    field(TSE, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Event")
+    }
+    field(TSEL, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Link")
+    }
+    field(DTYP, DBF_DEVICE) {
+        promptgroup("10 - Common")
+        interest(1)
+        prompt("Device Type")
+    }
+    field(DISV, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        initial("1")
+        prompt("Disable Value")
+    }
+    field(DISA, DBF_SHORT) {
+        prompt("Disable")
+    }
+    field(SDIS, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Scanning Disable")
+    }
+    field(MLOK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsMutexId        mlok")
+        interest(4)
+        prompt("Monitor lock")
+    }
+    field(MLIS, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             mlis")
+        interest(4)
+        prompt("Monitor List")
+    }
+    field(BKLNK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             bklnk")
+        interest(4)
+        prompt("Backwards link tracking")
+    }
+    field(DISP, DBF_UCHAR) {
+        prompt("Disable putField")
+    }
+    field(PROC, DBF_UCHAR) {
+        interest(3)
+        pp(TRUE)
+        prompt("Force Processing")
+    }
+    field(STAT, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        initial("UDF")
+        prompt("Alarm Status")
+    }
+    field(SEVR, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        prompt("Alarm Severity")
+    }
+    field(NSTA, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        interest(2)
+        prompt("New Alarm Status")
+    }
+    field(NSEV, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("New Alarm Severity")
+    }
+    field(ACKS, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("Alarm Ack Severity")
+    }
+    field(ACKT, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        special(SPC_NOMOD)
+        menu(menuYesNo)
+        initial("YES")
+        interest(2)
+        prompt("Alarm Ack Transient")
+    }
+    field(DISS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        prompt("Disable Alarm Sevrty")
+    }
+    field(LCNT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(2)
+        prompt("Lock Count")
+    }
+    field(PACT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Record active")
+    }
+    field(PUTF, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("dbPutField process")
+    }
+    field(RPRO, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Reprocess ")
+    }
+    field(ASP, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct asgMember    *asp")
+        interest(4)
+        prompt("Access Security Pvt")
+    }
+    field(PPN, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotify *ppn")
+        interest(4)
+        prompt("pprocessNotify")
+    }
+    field(PPNR, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotifyRecord *ppnr")
+        interest(4)
+        prompt("pprocessNotifyRecord")
+    }
+    field(SPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct scan_element *spvt")
+        interest(4)
+        prompt("Scan Private")
+    }
+    field(RSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct typed_rset   *rset")
+        interest(4)
+        prompt("Address of RSET")
+    }
+    field(DSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dset         *dset")
+        interest(4)
+        prompt("DSET address")
+    }
+    field(DPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("void                *dpvt")
+        interest(4)
+        prompt("Device Private")
+    }
+    field(RDES, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dbRecordType *rdes")
+        interest(4)
+        prompt("Address of dbRecordType")
+    }
+    field(LSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct lockRecord   *lset")
+        interest(4)
+        prompt("Lock Set")
+    }
+    field(PRIO, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuPriority)
+        interest(1)
+        prompt("Scheduling Priority")
+    }
+    field(TPRO, DBF_UCHAR) {
+        prompt("Trace Processing")
+    }
+    field(BKPT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("char                bkpt")
+        interest(1)
+        prompt("Break Point")
+    }
+    field(UDF, DBF_UCHAR) {
+        promptgroup("10 - Common")
+        initial("1")
+        interest(1)
+        pp(TRUE)
+        prompt("Undefined")
+    }
+    field(UDFS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        initial("INVALID")
+        interest(1)
+        prompt("Undefined Alarm Sevrty")
+    }
+    field(TIME, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsTimeStamp      time")
+        interest(2)
+        prompt("Time")
+    }
+    field(FLNK, DBF_FWDLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Forward Process Link")
+    }
+    field(VAL, DBF_NOACCESS) {
+        special(SPC_DBADDR)
+        asl(ASL0)
+        extra("char *val")
+        pp(TRUE)
+        prompt("Result")
+    }
+    field(SIZV, DBF_USHORT) {
+        promptgroup("30 - Action")
+        special(SPC_NOMOD)
+        initial("41")
+        interest(1)
+        prompt("Size of VAL buffer")
+    }
+    field(LEN, DBF_ULONG) {
+        special(SPC_NOMOD)
+        prompt("Length of VAL")
+    }
+    field(OUT, DBF_OUTLINK) {
+        promptgroup("50 - Output")
+        interest(1)
+        prompt("Output Specification")
+    }
+    field(FMT, DBF_STRING) {
+        promptgroup("30 - Action")
+        pp(TRUE)
+        size(81)
+        prompt("Format String")
+    }
+    field(IVLS, DBF_STRING) {
+        promptgroup("30 - Action")
+        initial("LNK")
+        size(16)
+        prompt("Invalid Link String")
+    }
+    field(INP0, DBF_INLINK) {
+        promptgroup("40 - Input")
+        interest(1)
+        prompt("Input 0")
+    }
+    field(INP1, DBF_INLINK) {
+        promptgroup("40 - Input")
+        interest(1)
+        prompt("Input 1")
+    }
+    field(INP2, DBF_INLINK) {
+        promptgroup("40 - Input")
+        interest(1)
+        prompt("Input 2")
+    }
+    field(INP3, DBF_INLINK) {
+        promptgroup("40 - Input")
+        interest(1)
+        prompt("Input 3")
+    }
+    field(INP4, DBF_INLINK) {
+        promptgroup("40 - Input")
+        interest(1)
+        prompt("Input 4")
+    }
+    field(INP5, DBF_INLINK) {
+        promptgroup("40 - Input")
+        interest(1)
+        prompt("Input 5")
+    }
+    field(INP6, DBF_INLINK) {
+        promptgroup("40 - Input")
+        interest(1)
+        prompt("Input 6")
+    }
+    field(INP7, DBF_INLINK) {
+        promptgroup("40 - Input")
+        interest(1)
+        prompt("Input 7")
+    }
+    field(INP8, DBF_INLINK) {
+        promptgroup("40 - Input")
+        interest(1)
+        prompt("Input 8")
+    }
+    field(INP9, DBF_INLINK) {
+        promptgroup("40 - Input")
+        interest(1)
+        prompt("Input 9")
+    }
+}
+device(printf, CONSTANT, devPrintfSoft, "Soft Channel")
+device(printf, CONSTANT, devPrintfSoftCallback, "Async Soft Channel")
+device(printf, INST_IO, devPrintfStdio, "stdio")
+recordtype(sel) {
+    %#include "epicsTypes.h"
+    %#include "link.h"
+    %#include "epicsMutex.h"
+    %#include "ellLib.h"
+    %#include "epicsTime.h"
+    field(NAME, DBF_STRING) {
+        special(SPC_NOMOD)
+        size(61)
+        prompt("Record Name")
+    }
+    field(DESC, DBF_STRING) {
+        promptgroup("10 - Common")
+        size(41)
+        prompt("Descriptor")
+    }
+    field(ASG, DBF_STRING) {
+        promptgroup("10 - Common")
+        special(SPC_AS)
+        size(29)
+        prompt("Access Security Group")
+    }
+    field(SCAN, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuScan)
+        interest(1)
+        prompt("Scan Mechanism")
+    }
+    field(PINI, DBF_MENU) {
+        promptgroup("20 - Scan")
+        menu(menuPini)
+        interest(1)
+        prompt("Process at iocInit")
+    }
+    field(PHAS, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        prompt("Scan Phase")
+    }
+    field(EVNT, DBF_STRING) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        size(40)
+        prompt("Event Name")
+    }
+    field(TSE, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Event")
+    }
+    field(TSEL, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Link")
+    }
+    field(DTYP, DBF_DEVICE) {
+        promptgroup("10 - Common")
+        interest(1)
+        prompt("Device Type")
+    }
+    field(DISV, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        initial("1")
+        prompt("Disable Value")
+    }
+    field(DISA, DBF_SHORT) {
+        prompt("Disable")
+    }
+    field(SDIS, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Scanning Disable")
+    }
+    field(MLOK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsMutexId        mlok")
+        interest(4)
+        prompt("Monitor lock")
+    }
+    field(MLIS, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             mlis")
+        interest(4)
+        prompt("Monitor List")
+    }
+    field(BKLNK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             bklnk")
+        interest(4)
+        prompt("Backwards link tracking")
+    }
+    field(DISP, DBF_UCHAR) {
+        prompt("Disable putField")
+    }
+    field(PROC, DBF_UCHAR) {
+        interest(3)
+        pp(TRUE)
+        prompt("Force Processing")
+    }
+    field(STAT, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        initial("UDF")
+        prompt("Alarm Status")
+    }
+    field(SEVR, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        prompt("Alarm Severity")
+    }
+    field(NSTA, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        interest(2)
+        prompt("New Alarm Status")
+    }
+    field(NSEV, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("New Alarm Severity")
+    }
+    field(ACKS, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("Alarm Ack Severity")
+    }
+    field(ACKT, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        special(SPC_NOMOD)
+        menu(menuYesNo)
+        initial("YES")
+        interest(2)
+        prompt("Alarm Ack Transient")
+    }
+    field(DISS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        prompt("Disable Alarm Sevrty")
+    }
+    field(LCNT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(2)
+        prompt("Lock Count")
+    }
+    field(PACT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Record active")
+    }
+    field(PUTF, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("dbPutField process")
+    }
+    field(RPRO, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Reprocess ")
+    }
+    field(ASP, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct asgMember    *asp")
+        interest(4)
+        prompt("Access Security Pvt")
+    }
+    field(PPN, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotify *ppn")
+        interest(4)
+        prompt("pprocessNotify")
+    }
+    field(PPNR, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotifyRecord *ppnr")
+        interest(4)
+        prompt("pprocessNotifyRecord")
+    }
+    field(SPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct scan_element *spvt")
+        interest(4)
+        prompt("Scan Private")
+    }
+    field(RSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct typed_rset   *rset")
+        interest(4)
+        prompt("Address of RSET")
+    }
+    field(DSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dset         *dset")
+        interest(4)
+        prompt("DSET address")
+    }
+    field(DPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("void                *dpvt")
+        interest(4)
+        prompt("Device Private")
+    }
+    field(RDES, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dbRecordType *rdes")
+        interest(4)
+        prompt("Address of dbRecordType")
+    }
+    field(LSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct lockRecord   *lset")
+        interest(4)
+        prompt("Lock Set")
+    }
+    field(PRIO, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuPriority)
+        interest(1)
+        prompt("Scheduling Priority")
+    }
+    field(TPRO, DBF_UCHAR) {
+        prompt("Trace Processing")
+    }
+    field(BKPT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("char                bkpt")
+        interest(1)
+        prompt("Break Point")
+    }
+    field(UDF, DBF_UCHAR) {
+        promptgroup("10 - Common")
+        initial("1")
+        interest(1)
+        pp(TRUE)
+        prompt("Undefined")
+    }
+    field(UDFS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        initial("INVALID")
+        interest(1)
+        prompt("Undefined Alarm Sevrty")
+    }
+    field(TIME, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsTimeStamp      time")
+        interest(2)
+        prompt("Time")
+    }
+    field(FLNK, DBF_FWDLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Forward Process Link")
+    }
+    field(VAL, DBF_DOUBLE) {
+        promptgroup("40 - Input")
+        special(SPC_NOMOD)
+        asl(ASL0)
+        prompt("Result")
+    }
+    field(SELM, DBF_MENU) {
+        promptgroup("30 - Action")
+        menu(selSELM)
+        prompt("Select Mechanism")
+    }
+    field(SELN, DBF_USHORT) {
+        prompt("Index value")
+    }
+    field(PREC, DBF_SHORT) {
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("Display Precision")
+    }
+    field(NVL, DBF_INLINK) {
+        promptgroup("30 - Action")
+        interest(1)
+        prompt("Index Value Location")
+    }
+    field(INPA, DBF_INLINK) {
+        promptgroup("41 - Input A-F")
+        interest(1)
+        prompt("Input A")
+    }
+    field(INPB, DBF_INLINK) {
+        promptgroup("41 - Input A-F")
+        interest(1)
+        prompt("Input B")
+    }
+    field(INPC, DBF_INLINK) {
+        promptgroup("41 - Input A-F")
+        interest(1)
+        prompt("Input C")
+    }
+    field(INPD, DBF_INLINK) {
+        promptgroup("41 - Input A-F")
+        interest(1)
+        prompt("Input D")
+    }
+    field(INPE, DBF_INLINK) {
+        promptgroup("41 - Input A-F")
+        interest(1)
+        prompt("Input E")
+    }
+    field(INPF, DBF_INLINK) {
+        promptgroup("41 - Input A-F")
+        interest(1)
+        prompt("Input F")
+    }
+    field(INPG, DBF_INLINK) {
+        promptgroup("42 - Input G-L")
+        interest(1)
+        prompt("Input G")
+    }
+    field(INPH, DBF_INLINK) {
+        promptgroup("42 - Input G-L")
+        interest(1)
+        prompt("Input H")
+    }
+    field(INPI, DBF_INLINK) {
+        promptgroup("42 - Input G-L")
+        interest(1)
+        prompt("Input I")
+    }
+    field(INPJ, DBF_INLINK) {
+        promptgroup("42 - Input G-L")
+        interest(1)
+        prompt("Input J")
+    }
+    field(INPK, DBF_INLINK) {
+        promptgroup("42 - Input G-L")
+        interest(1)
+        prompt("Input K")
+    }
+    field(INPL, DBF_INLINK) {
+        promptgroup("42 - Input G-L")
+        interest(1)
+        prompt("Input L")
+    }
+    field(EGU, DBF_STRING) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        size(16)
+        prompt("Engineering Units")
+    }
+    field(HOPR, DBF_DOUBLE) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("High Operating Rng")
+    }
+    field(LOPR, DBF_DOUBLE) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("Low Operating Range")
+    }
+    field(HIHI, DBF_DOUBLE) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        interest(1)
+        pp(TRUE)
+        prompt("Hihi Alarm Limit")
+    }
+    field(LOLO, DBF_DOUBLE) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        interest(1)
+        pp(TRUE)
+        prompt("Lolo Alarm Limit")
+    }
+    field(HIGH, DBF_DOUBLE) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        interest(1)
+        pp(TRUE)
+        prompt("High Alarm Limit")
+    }
+    field(LOW, DBF_DOUBLE) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        interest(1)
+        pp(TRUE)
+        prompt("Low Alarm Limit")
+    }
+    field(HHSV, DBF_MENU) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("Hihi Severity")
+    }
+    field(LLSV, DBF_MENU) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("Lolo Severity")
+    }
+    field(HSV, DBF_MENU) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("High Severity")
+    }
+    field(LSV, DBF_MENU) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("Low Severity")
+    }
+    field(HYST, DBF_DOUBLE) {
+        promptgroup("70 - Alarm")
+        interest(1)
+        prompt("Alarm Deadband")
+    }
+    field(ADEL, DBF_DOUBLE) {
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("Archive Deadband")
+    }
+    field(MDEL, DBF_DOUBLE) {
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("Monitor Deadband")
+    }
+    field(A, DBF_DOUBLE) {
+        pp(TRUE)
+        prompt("Value of Input A")
+    }
+    field(B, DBF_DOUBLE) {
+        pp(TRUE)
+        prompt("Value of Input B")
+    }
+    field(C, DBF_DOUBLE) {
+        pp(TRUE)
+        prompt("Value of Input C")
+    }
+    field(D, DBF_DOUBLE) {
+        pp(TRUE)
+        prompt("Value of Input D")
+    }
+    field(E, DBF_DOUBLE) {
+        pp(TRUE)
+        prompt("Value of Input E")
+    }
+    field(F, DBF_DOUBLE) {
+        pp(TRUE)
+        prompt("Value of Input F")
+    }
+    field(G, DBF_DOUBLE) {
+        pp(TRUE)
+        prompt("Value of Input G")
+    }
+    field(H, DBF_DOUBLE) {
+        pp(TRUE)
+        prompt("Value of Input H")
+    }
+    field(I, DBF_DOUBLE) {
+        pp(TRUE)
+        prompt("Value of Input I")
+    }
+    field(J, DBF_DOUBLE) {
+        pp(TRUE)
+        prompt("Value of Input J")
+    }
+    field(K, DBF_DOUBLE) {
+        pp(TRUE)
+        prompt("Value of Input K")
+    }
+    field(L, DBF_DOUBLE) {
+        pp(TRUE)
+        prompt("Value of Input L")
+    }
+    field(LA, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Prev Value of A")
+    }
+    field(LB, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Prev Value of B")
+    }
+    field(LC, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Prev Value of C")
+    }
+    field(LD, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Prev Value of D")
+    }
+    field(LE, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Prev Value of E")
+    }
+    field(LF, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Prev Value of F")
+    }
+    field(LG, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Prev Value of G")
+    }
+    field(LH, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Prev Value of H")
+    }
+    field(LI, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Prev Value of I")
+    }
+    field(LJ, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Prev Value of J")
+    }
+    field(LK, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Prev Value of K")
+    }
+    field(LL, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Prev Value of L")
+    }
+    field(LALM, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Last Value Alarmed")
+    }
+    field(ALST, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Last Value Archived")
+    }
+    field(MLST, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Last Val Monitored")
+    }
+    field(NLST, DBF_USHORT) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Last Index Monitored")
+    }
+}
+recordtype(bi) {
+    %#include "epicsTypes.h"
+    %#include "link.h"
+    %#include "epicsMutex.h"
+    %#include "ellLib.h"
+    %#include "epicsTime.h"
+    %#include "callback.h"
+    field(NAME, DBF_STRING) {
+        special(SPC_NOMOD)
+        size(61)
+        prompt("Record Name")
+    }
+    field(DESC, DBF_STRING) {
+        promptgroup("10 - Common")
+        size(41)
+        prompt("Descriptor")
+    }
+    field(ASG, DBF_STRING) {
+        promptgroup("10 - Common")
+        special(SPC_AS)
+        size(29)
+        prompt("Access Security Group")
+    }
+    field(SCAN, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuScan)
+        interest(1)
+        prompt("Scan Mechanism")
+    }
+    field(PINI, DBF_MENU) {
+        promptgroup("20 - Scan")
+        menu(menuPini)
+        interest(1)
+        prompt("Process at iocInit")
+    }
+    field(PHAS, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        prompt("Scan Phase")
+    }
+    field(EVNT, DBF_STRING) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        size(40)
+        prompt("Event Name")
+    }
+    field(TSE, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Event")
+    }
+    field(TSEL, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Link")
+    }
+    field(DTYP, DBF_DEVICE) {
+        promptgroup("10 - Common")
+        interest(1)
+        prompt("Device Type")
+    }
+    field(DISV, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        initial("1")
+        prompt("Disable Value")
+    }
+    field(DISA, DBF_SHORT) {
+        prompt("Disable")
+    }
+    field(SDIS, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Scanning Disable")
+    }
+    field(MLOK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsMutexId        mlok")
+        interest(4)
+        prompt("Monitor lock")
+    }
+    field(MLIS, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             mlis")
+        interest(4)
+        prompt("Monitor List")
+    }
+    field(BKLNK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             bklnk")
+        interest(4)
+        prompt("Backwards link tracking")
+    }
+    field(DISP, DBF_UCHAR) {
+        prompt("Disable putField")
+    }
+    field(PROC, DBF_UCHAR) {
+        interest(3)
+        pp(TRUE)
+        prompt("Force Processing")
+    }
+    field(STAT, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        initial("UDF")
+        prompt("Alarm Status")
+    }
+    field(SEVR, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        prompt("Alarm Severity")
+    }
+    field(NSTA, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        interest(2)
+        prompt("New Alarm Status")
+    }
+    field(NSEV, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("New Alarm Severity")
+    }
+    field(ACKS, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("Alarm Ack Severity")
+    }
+    field(ACKT, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        special(SPC_NOMOD)
+        menu(menuYesNo)
+        initial("YES")
+        interest(2)
+        prompt("Alarm Ack Transient")
+    }
+    field(DISS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        prompt("Disable Alarm Sevrty")
+    }
+    field(LCNT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(2)
+        prompt("Lock Count")
+    }
+    field(PACT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Record active")
+    }
+    field(PUTF, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("dbPutField process")
+    }
+    field(RPRO, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Reprocess ")
+    }
+    field(ASP, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct asgMember    *asp")
+        interest(4)
+        prompt("Access Security Pvt")
+    }
+    field(PPN, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotify *ppn")
+        interest(4)
+        prompt("pprocessNotify")
+    }
+    field(PPNR, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotifyRecord *ppnr")
+        interest(4)
+        prompt("pprocessNotifyRecord")
+    }
+    field(SPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct scan_element *spvt")
+        interest(4)
+        prompt("Scan Private")
+    }
+    field(RSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct typed_rset   *rset")
+        interest(4)
+        prompt("Address of RSET")
+    }
+    field(DSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dset         *dset")
+        interest(4)
+        prompt("DSET address")
+    }
+    field(DPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("void                *dpvt")
+        interest(4)
+        prompt("Device Private")
+    }
+    field(RDES, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dbRecordType *rdes")
+        interest(4)
+        prompt("Address of dbRecordType")
+    }
+    field(LSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct lockRecord   *lset")
+        interest(4)
+        prompt("Lock Set")
+    }
+    field(PRIO, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuPriority)
+        interest(1)
+        prompt("Scheduling Priority")
+    }
+    field(TPRO, DBF_UCHAR) {
+        prompt("Trace Processing")
+    }
+    field(BKPT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("char                bkpt")
+        interest(1)
+        prompt("Break Point")
+    }
+    field(UDF, DBF_UCHAR) {
+        promptgroup("10 - Common")
+        initial("1")
+        interest(1)
+        pp(TRUE)
+        prompt("Undefined")
+    }
+    field(UDFS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        initial("INVALID")
+        interest(1)
+        prompt("Undefined Alarm Sevrty")
+    }
+    field(TIME, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsTimeStamp      time")
+        interest(2)
+        prompt("Time")
+    }
+    field(FLNK, DBF_FWDLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Forward Process Link")
+    }
+    field(INP, DBF_INLINK) {
+        promptgroup("40 - Input")
+        interest(1)
+        prompt("Input Specification")
+    }
+    field(VAL, DBF_ENUM) {
+        promptgroup("40 - Input")
+        asl(ASL0)
+        pp(TRUE)
+        prompt("Current Value")
+    }
+    field(ZSV, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("Zero Error Severity")
+    }
+    field(OSV, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("One Error Severity")
+    }
+    field(COSV, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("Change of State Svr")
+    }
+    field(ZNAM, DBF_STRING) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        pp(TRUE)
+        size(26)
+        prompt("Zero Name")
+    }
+    field(ONAM, DBF_STRING) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        pp(TRUE)
+        size(26)
+        prompt("One Name")
+    }
+    field(RVAL, DBF_ULONG) {
+        pp(TRUE)
+        prompt("Raw Value")
+    }
+    field(ORAW, DBF_ULONG) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("prev Raw Value")
+    }
+    field(MASK, DBF_ULONG) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Hardware Mask")
+    }
+    field(LALM, DBF_USHORT) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Last Value Alarmed")
+    }
+    field(MLST, DBF_USHORT) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Last Value Monitored")
+    }
+    field(SIOL, DBF_INLINK) {
+        promptgroup("90 - Simulate")
+        interest(1)
+        prompt("Simulation Input Link")
+    }
+    field(SVAL, DBF_ULONG) {
+        prompt("Simulation Value")
+    }
+    field(SIML, DBF_INLINK) {
+        promptgroup("90 - Simulate")
+        interest(1)
+        prompt("Simulation Mode Link")
+    }
+    field(SIMM, DBF_MENU) {
+        special(SPC_MOD)
+        menu(menuSimm)
+        interest(1)
+        prompt("Simulation Mode")
+    }
+    field(SIMS, DBF_MENU) {
+        promptgroup("90 - Simulate")
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("Simulation Mode Severity")
+    }
+    field(OLDSIMM, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuSimm)
+        interest(4)
+        prompt("Prev. Simulation Mode")
+    }
+    field(SSCN, DBF_MENU) {
+        promptgroup("90 - Simulate")
+        menu(menuScan)
+        initial("65535")
+        interest(1)
+        prompt("Sim. Mode Scan")
+    }
+    field(SDLY, DBF_DOUBLE) {
+        promptgroup("90 - Simulate")
+        initial("-1.0")
+        interest(2)
+        prompt("Sim. Mode Async Delay")
+    }
+    field(SIMPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("CALLBACK            *simpvt")
+        interest(4)
+        prompt("Sim. Mode Private")
+    }
+}
+device(bi, CONSTANT, devBiSoft, "Soft Channel")
+device(bi, CONSTANT, devBiSoftRaw, "Raw Soft Channel")
+device(bi, CONSTANT, devBiSoftCallback, "Async Soft Channel")
+device(bi, INST_IO, devBiDbState, "Db State")
+device(bi, INST_IO, asynBiInt32, "asynInt32")
+device(bi, INST_IO, asynBiUInt32Digital, "asynUInt32Digital")
+recordtype(lso) {
+    %#include "epicsTypes.h"
+    %#include "link.h"
+    %#include "epicsMutex.h"
+    %#include "ellLib.h"
+    %#include "epicsTime.h"
+    %#include "devSup.h"
+    %
+    %/* Declare Device Support Entry Table */
+    %typedef struct lsodset {
+    %    long number;
+    %    DEVSUPFUN report;
+    %    DEVSUPFUN init;
+    %    DEVSUPFUN init_record;
+    %    DEVSUPFUN get_ioint_info;
+    %    DEVSUPFUN write_string;
+    %} lsodset;
+    %
+    %#include "callback.h"
+    field(NAME, DBF_STRING) {
+        special(SPC_NOMOD)
+        size(61)
+        prompt("Record Name")
+    }
+    field(DESC, DBF_STRING) {
+        promptgroup("10 - Common")
+        size(41)
+        prompt("Descriptor")
+    }
+    field(ASG, DBF_STRING) {
+        promptgroup("10 - Common")
+        special(SPC_AS)
+        size(29)
+        prompt("Access Security Group")
+    }
+    field(SCAN, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuScan)
+        interest(1)
+        prompt("Scan Mechanism")
+    }
+    field(PINI, DBF_MENU) {
+        promptgroup("20 - Scan")
+        menu(menuPini)
+        interest(1)
+        prompt("Process at iocInit")
+    }
+    field(PHAS, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        prompt("Scan Phase")
+    }
+    field(EVNT, DBF_STRING) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        size(40)
+        prompt("Event Name")
+    }
+    field(TSE, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Event")
+    }
+    field(TSEL, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Link")
+    }
+    field(DTYP, DBF_DEVICE) {
+        promptgroup("10 - Common")
+        interest(1)
+        prompt("Device Type")
+    }
+    field(DISV, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        initial("1")
+        prompt("Disable Value")
+    }
+    field(DISA, DBF_SHORT) {
+        prompt("Disable")
+    }
+    field(SDIS, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Scanning Disable")
+    }
+    field(MLOK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsMutexId        mlok")
+        interest(4)
+        prompt("Monitor lock")
+    }
+    field(MLIS, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             mlis")
+        interest(4)
+        prompt("Monitor List")
+    }
+    field(BKLNK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             bklnk")
+        interest(4)
+        prompt("Backwards link tracking")
+    }
+    field(DISP, DBF_UCHAR) {
+        prompt("Disable putField")
+    }
+    field(PROC, DBF_UCHAR) {
+        interest(3)
+        pp(TRUE)
+        prompt("Force Processing")
+    }
+    field(STAT, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        initial("UDF")
+        prompt("Alarm Status")
+    }
+    field(SEVR, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        prompt("Alarm Severity")
+    }
+    field(NSTA, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        interest(2)
+        prompt("New Alarm Status")
+    }
+    field(NSEV, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("New Alarm Severity")
+    }
+    field(ACKS, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("Alarm Ack Severity")
+    }
+    field(ACKT, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        special(SPC_NOMOD)
+        menu(menuYesNo)
+        initial("YES")
+        interest(2)
+        prompt("Alarm Ack Transient")
+    }
+    field(DISS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        prompt("Disable Alarm Sevrty")
+    }
+    field(LCNT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(2)
+        prompt("Lock Count")
+    }
+    field(PACT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Record active")
+    }
+    field(PUTF, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("dbPutField process")
+    }
+    field(RPRO, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Reprocess ")
+    }
+    field(ASP, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct asgMember    *asp")
+        interest(4)
+        prompt("Access Security Pvt")
+    }
+    field(PPN, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotify *ppn")
+        interest(4)
+        prompt("pprocessNotify")
+    }
+    field(PPNR, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotifyRecord *ppnr")
+        interest(4)
+        prompt("pprocessNotifyRecord")
+    }
+    field(SPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct scan_element *spvt")
+        interest(4)
+        prompt("Scan Private")
+    }
+    field(RSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct typed_rset   *rset")
+        interest(4)
+        prompt("Address of RSET")
+    }
+    field(DSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dset         *dset")
+        interest(4)
+        prompt("DSET address")
+    }
+    field(DPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("void                *dpvt")
+        interest(4)
+        prompt("Device Private")
+    }
+    field(RDES, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dbRecordType *rdes")
+        interest(4)
+        prompt("Address of dbRecordType")
+    }
+    field(LSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct lockRecord   *lset")
+        interest(4)
+        prompt("Lock Set")
+    }
+    field(PRIO, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuPriority)
+        interest(1)
+        prompt("Scheduling Priority")
+    }
+    field(TPRO, DBF_UCHAR) {
+        prompt("Trace Processing")
+    }
+    field(BKPT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("char                bkpt")
+        interest(1)
+        prompt("Break Point")
+    }
+    field(UDF, DBF_UCHAR) {
+        promptgroup("10 - Common")
+        initial("1")
+        interest(1)
+        pp(TRUE)
+        prompt("Undefined")
+    }
+    field(UDFS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        initial("INVALID")
+        interest(1)
+        prompt("Undefined Alarm Sevrty")
+    }
+    field(TIME, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsTimeStamp      time")
+        interest(2)
+        prompt("Time")
+    }
+    field(FLNK, DBF_FWDLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Forward Process Link")
+    }
+    field(VAL, DBF_NOACCESS) {
+        special(SPC_DBADDR)
+        asl(ASL0)
+        extra("char *val")
+        pp(TRUE)
+        prompt("Current Value")
+    }
+    field(OVAL, DBF_NOACCESS) {
+        special(SPC_DBADDR)
+        extra("char *oval")
+        interest(3)
+        prompt("Previous Value")
+    }
+    field(SIZV, DBF_USHORT) {
+        promptgroup("50 - Output")
+        special(SPC_NOMOD)
+        initial("41")
+        interest(1)
+        prompt("Size of buffers")
+    }
+    field(LEN, DBF_ULONG) {
+        special(SPC_NOMOD)
+        prompt("Length of VAL")
+    }
+    field(OLEN, DBF_ULONG) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Length of OVAL")
+    }
+    field(DOL, DBF_INLINK) {
+        promptgroup("40 - Input")
+        interest(1)
+        prompt("Desired Output Link")
+    }
+    field(IVOA, DBF_MENU) {
+        promptgroup("50 - Output")
+        menu(menuIvoa)
+        interest(2)
+        prompt("INVALID Output Action")
+    }
+    field(IVOV, DBF_STRING) {
+        promptgroup("50 - Output")
+        interest(2)
+        size(40)
+        prompt("INVALID Output Value")
+    }
+    field(OMSL, DBF_MENU) {
+        promptgroup("50 - Output")
+        menu(menuOmsl)
+        interest(1)
+        prompt("Output Mode Select")
+    }
+    field(OUT, DBF_OUTLINK) {
+        promptgroup("50 - Output")
+        interest(1)
+        prompt("Output Specification")
+    }
+    field(MPST, DBF_MENU) {
+        promptgroup("80 - Display")
+        menu(menuPost)
+        interest(1)
+        prompt("Post Value Monitors")
+    }
+    field(APST, DBF_MENU) {
+        promptgroup("80 - Display")
+        menu(menuPost)
+        interest(1)
+        prompt("Post Archive Monitors")
+    }
+    field(SIML, DBF_INLINK) {
+        promptgroup("90 - Simulate")
+        interest(1)
+        prompt("Simulation Mode link")
+    }
+    field(SIMM, DBF_MENU) {
+        special(SPC_MOD)
+        menu(menuYesNo)
+        interest(1)
+        prompt("Simulation Mode")
+    }
+    field(SIMS, DBF_MENU) {
+        promptgroup("90 - Simulate")
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("Simulation Mode Severity")
+    }
+    field(SIOL, DBF_OUTLINK) {
+        promptgroup("90 - Simulate")
+        interest(1)
+        prompt("Simulation Output Link")
+    }
+    field(OLDSIMM, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuSimm)
+        interest(4)
+        prompt("Prev. Simulation Mode")
+    }
+    field(SSCN, DBF_MENU) {
+        promptgroup("90 - Simulate")
+        menu(menuScan)
+        initial("65535")
+        interest(1)
+        prompt("Sim. Mode Scan")
+    }
+    field(SDLY, DBF_DOUBLE) {
+        promptgroup("90 - Simulate")
+        initial("-1.0")
+        interest(2)
+        prompt("Sim. Mode Async Delay")
+    }
+    field(SIMPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("CALLBACK            *simpvt")
+        interest(4)
+        prompt("Sim. Mode Private")
+    }
+}
+device(lso, CONSTANT, devLsoSoft, "Soft Channel")
+device(lso, CONSTANT, devLsoSoftCallback, "Async Soft Channel")
+device(lso, INST_IO, devLsoStdio, "stdio")
+recordtype(subArray) {
+    %#include "epicsTypes.h"
+    %#include "link.h"
+    %#include "epicsMutex.h"
+    %#include "ellLib.h"
+    %#include "epicsTime.h"
+    field(NAME, DBF_STRING) {
+        special(SPC_NOMOD)
+        size(61)
+        prompt("Record Name")
+    }
+    field(DESC, DBF_STRING) {
+        promptgroup("10 - Common")
+        size(41)
+        prompt("Descriptor")
+    }
+    field(ASG, DBF_STRING) {
+        promptgroup("10 - Common")
+        special(SPC_AS)
+        size(29)
+        prompt("Access Security Group")
+    }
+    field(SCAN, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuScan)
+        interest(1)
+        prompt("Scan Mechanism")
+    }
+    field(PINI, DBF_MENU) {
+        promptgroup("20 - Scan")
+        menu(menuPini)
+        interest(1)
+        prompt("Process at iocInit")
+    }
+    field(PHAS, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        prompt("Scan Phase")
+    }
+    field(EVNT, DBF_STRING) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        size(40)
+        prompt("Event Name")
+    }
+    field(TSE, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Event")
+    }
+    field(TSEL, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Link")
+    }
+    field(DTYP, DBF_DEVICE) {
+        promptgroup("10 - Common")
+        interest(1)
+        prompt("Device Type")
+    }
+    field(DISV, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        initial("1")
+        prompt("Disable Value")
+    }
+    field(DISA, DBF_SHORT) {
+        prompt("Disable")
+    }
+    field(SDIS, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Scanning Disable")
+    }
+    field(MLOK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsMutexId        mlok")
+        interest(4)
+        prompt("Monitor lock")
+    }
+    field(MLIS, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             mlis")
+        interest(4)
+        prompt("Monitor List")
+    }
+    field(BKLNK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             bklnk")
+        interest(4)
+        prompt("Backwards link tracking")
+    }
+    field(DISP, DBF_UCHAR) {
+        prompt("Disable putField")
+    }
+    field(PROC, DBF_UCHAR) {
+        interest(3)
+        pp(TRUE)
+        prompt("Force Processing")
+    }
+    field(STAT, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        initial("UDF")
+        prompt("Alarm Status")
+    }
+    field(SEVR, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        prompt("Alarm Severity")
+    }
+    field(NSTA, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        interest(2)
+        prompt("New Alarm Status")
+    }
+    field(NSEV, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("New Alarm Severity")
+    }
+    field(ACKS, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("Alarm Ack Severity")
+    }
+    field(ACKT, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        special(SPC_NOMOD)
+        menu(menuYesNo)
+        initial("YES")
+        interest(2)
+        prompt("Alarm Ack Transient")
+    }
+    field(DISS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        prompt("Disable Alarm Sevrty")
+    }
+    field(LCNT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(2)
+        prompt("Lock Count")
+    }
+    field(PACT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Record active")
+    }
+    field(PUTF, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("dbPutField process")
+    }
+    field(RPRO, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Reprocess ")
+    }
+    field(ASP, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct asgMember    *asp")
+        interest(4)
+        prompt("Access Security Pvt")
+    }
+    field(PPN, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotify *ppn")
+        interest(4)
+        prompt("pprocessNotify")
+    }
+    field(PPNR, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotifyRecord *ppnr")
+        interest(4)
+        prompt("pprocessNotifyRecord")
+    }
+    field(SPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct scan_element *spvt")
+        interest(4)
+        prompt("Scan Private")
+    }
+    field(RSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct typed_rset   *rset")
+        interest(4)
+        prompt("Address of RSET")
+    }
+    field(DSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dset         *dset")
+        interest(4)
+        prompt("DSET address")
+    }
+    field(DPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("void                *dpvt")
+        interest(4)
+        prompt("Device Private")
+    }
+    field(RDES, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dbRecordType *rdes")
+        interest(4)
+        prompt("Address of dbRecordType")
+    }
+    field(LSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct lockRecord   *lset")
+        interest(4)
+        prompt("Lock Set")
+    }
+    field(PRIO, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuPriority)
+        interest(1)
+        prompt("Scheduling Priority")
+    }
+    field(TPRO, DBF_UCHAR) {
+        prompt("Trace Processing")
+    }
+    field(BKPT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("char                bkpt")
+        interest(1)
+        prompt("Break Point")
+    }
+    field(UDF, DBF_UCHAR) {
+        promptgroup("10 - Common")
+        initial("1")
+        interest(1)
+        pp(TRUE)
+        prompt("Undefined")
+    }
+    field(UDFS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        initial("INVALID")
+        interest(1)
+        prompt("Undefined Alarm Sevrty")
+    }
+    field(TIME, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsTimeStamp      time")
+        interest(2)
+        prompt("Time")
+    }
+    field(FLNK, DBF_FWDLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Forward Process Link")
+    }
+    field(VAL, DBF_NOACCESS) {
+        special(SPC_DBADDR)
+        asl(ASL0)
+        extra("void *		val")
+        pp(TRUE)
+        prompt("Value")
+    }
+    field(PREC, DBF_SHORT) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("Display Precision")
+    }
+    field(FTVL, DBF_MENU) {
+        promptgroup("30 - Action")
+        special(SPC_NOMOD)
+        menu(menuFtype)
+        interest(1)
+        prompt("Field Type of Value")
+    }
+    field(INP, DBF_INLINK) {
+        promptgroup("40 - Input")
+        interest(1)
+        prompt("Input Specification")
+    }
+    field(EGU, DBF_STRING) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        size(16)
+        prompt("Engineering Units")
+    }
+    field(HOPR, DBF_DOUBLE) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("High Operating Range")
+    }
+    field(LOPR, DBF_DOUBLE) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("Low Operating Range")
+    }
+    field(MALM, DBF_ULONG) {
+        promptgroup("30 - Action")
+        special(SPC_NOMOD)
+        initial("1")
+        interest(1)
+        prompt("Maximum Elements")
+    }
+    field(NELM, DBF_ULONG) {
+        promptgroup("30 - Action")
+        initial("1")
+        pp(TRUE)
+        prompt("Number of Elements")
+    }
+    field(INDX, DBF_ULONG) {
+        promptgroup("30 - Action")
+        pp(TRUE)
+        prompt("Substring Index")
+    }
+    field(BUSY, DBF_SHORT) {
+        special(SPC_NOMOD)
+        prompt("Busy Indicator")
+    }
+    field(NORD, DBF_LONG) {
+        special(SPC_NOMOD)
+        prompt("Number elements read")
+    }
+    field(BPTR, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("void *		bptr")
+        interest(4)
+        prompt("Buffer Pointer")
+    }
+}
+device(subArray, CONSTANT, devSASoft, "Soft Channel")
+recordtype(calc) {
+    %#include "epicsTypes.h"
+    %#include "link.h"
+    %#include "epicsMutex.h"
+    %#include "ellLib.h"
+    %#include "epicsTime.h"
+    %#include "postfix.h"
+    field(NAME, DBF_STRING) {
+        special(SPC_NOMOD)
+        size(61)
+        prompt("Record Name")
+    }
+    field(DESC, DBF_STRING) {
+        promptgroup("10 - Common")
+        size(41)
+        prompt("Descriptor")
+    }
+    field(ASG, DBF_STRING) {
+        promptgroup("10 - Common")
+        special(SPC_AS)
+        size(29)
+        prompt("Access Security Group")
+    }
+    field(SCAN, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuScan)
+        interest(1)
+        prompt("Scan Mechanism")
+    }
+    field(PINI, DBF_MENU) {
+        promptgroup("20 - Scan")
+        menu(menuPini)
+        interest(1)
+        prompt("Process at iocInit")
+    }
+    field(PHAS, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        prompt("Scan Phase")
+    }
+    field(EVNT, DBF_STRING) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        size(40)
+        prompt("Event Name")
+    }
+    field(TSE, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Event")
+    }
+    field(TSEL, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Link")
+    }
+    field(DTYP, DBF_DEVICE) {
+        promptgroup("10 - Common")
+        interest(1)
+        prompt("Device Type")
+    }
+    field(DISV, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        initial("1")
+        prompt("Disable Value")
+    }
+    field(DISA, DBF_SHORT) {
+        prompt("Disable")
+    }
+    field(SDIS, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Scanning Disable")
+    }
+    field(MLOK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsMutexId        mlok")
+        interest(4)
+        prompt("Monitor lock")
+    }
+    field(MLIS, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             mlis")
+        interest(4)
+        prompt("Monitor List")
+    }
+    field(BKLNK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             bklnk")
+        interest(4)
+        prompt("Backwards link tracking")
+    }
+    field(DISP, DBF_UCHAR) {
+        prompt("Disable putField")
+    }
+    field(PROC, DBF_UCHAR) {
+        interest(3)
+        pp(TRUE)
+        prompt("Force Processing")
+    }
+    field(STAT, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        initial("UDF")
+        prompt("Alarm Status")
+    }
+    field(SEVR, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        prompt("Alarm Severity")
+    }
+    field(NSTA, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        interest(2)
+        prompt("New Alarm Status")
+    }
+    field(NSEV, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("New Alarm Severity")
+    }
+    field(ACKS, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("Alarm Ack Severity")
+    }
+    field(ACKT, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        special(SPC_NOMOD)
+        menu(menuYesNo)
+        initial("YES")
+        interest(2)
+        prompt("Alarm Ack Transient")
+    }
+    field(DISS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        prompt("Disable Alarm Sevrty")
+    }
+    field(LCNT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(2)
+        prompt("Lock Count")
+    }
+    field(PACT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Record active")
+    }
+    field(PUTF, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("dbPutField process")
+    }
+    field(RPRO, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Reprocess ")
+    }
+    field(ASP, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct asgMember    *asp")
+        interest(4)
+        prompt("Access Security Pvt")
+    }
+    field(PPN, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotify *ppn")
+        interest(4)
+        prompt("pprocessNotify")
+    }
+    field(PPNR, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotifyRecord *ppnr")
+        interest(4)
+        prompt("pprocessNotifyRecord")
+    }
+    field(SPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct scan_element *spvt")
+        interest(4)
+        prompt("Scan Private")
+    }
+    field(RSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct typed_rset   *rset")
+        interest(4)
+        prompt("Address of RSET")
+    }
+    field(DSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dset         *dset")
+        interest(4)
+        prompt("DSET address")
+    }
+    field(DPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("void                *dpvt")
+        interest(4)
+        prompt("Device Private")
+    }
+    field(RDES, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dbRecordType *rdes")
+        interest(4)
+        prompt("Address of dbRecordType")
+    }
+    field(LSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct lockRecord   *lset")
+        interest(4)
+        prompt("Lock Set")
+    }
+    field(PRIO, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuPriority)
+        interest(1)
+        prompt("Scheduling Priority")
+    }
+    field(TPRO, DBF_UCHAR) {
+        prompt("Trace Processing")
+    }
+    field(BKPT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("char                bkpt")
+        interest(1)
+        prompt("Break Point")
+    }
+    field(UDF, DBF_UCHAR) {
+        promptgroup("10 - Common")
+        initial("1")
+        interest(1)
+        pp(TRUE)
+        prompt("Undefined")
+    }
+    field(UDFS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        initial("INVALID")
+        interest(1)
+        prompt("Undefined Alarm Sevrty")
+    }
+    field(TIME, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsTimeStamp      time")
+        interest(2)
+        prompt("Time")
+    }
+    field(FLNK, DBF_FWDLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Forward Process Link")
+    }
+    field(VAL, DBF_DOUBLE) {
+        promptgroup("50 - Output")
+        asl(ASL0)
+        prompt("Result")
+    }
+    field(CALC, DBF_STRING) {
+        promptgroup("30 - Action")
+        special(SPC_CALC)
+        initial("0")
+        pp(TRUE)
+        size(80)
+        prompt("Calculation")
+    }
+    field(INPA, DBF_INLINK) {
+        promptgroup("41 - Input A-F")
+        interest(1)
+        prompt("Input A")
+    }
+    field(INPB, DBF_INLINK) {
+        promptgroup("41 - Input A-F")
+        interest(1)
+        prompt("Input B")
+    }
+    field(INPC, DBF_INLINK) {
+        promptgroup("41 - Input A-F")
+        interest(1)
+        prompt("Input C")
+    }
+    field(INPD, DBF_INLINK) {
+        promptgroup("41 - Input A-F")
+        interest(1)
+        prompt("Input D")
+    }
+    field(INPE, DBF_INLINK) {
+        promptgroup("41 - Input A-F")
+        interest(1)
+        prompt("Input E")
+    }
+    field(INPF, DBF_INLINK) {
+        promptgroup("41 - Input A-F")
+        interest(1)
+        prompt("Input F")
+    }
+    field(INPG, DBF_INLINK) {
+        promptgroup("42 - Input G-L")
+        interest(1)
+        prompt("Input G")
+    }
+    field(INPH, DBF_INLINK) {
+        promptgroup("42 - Input G-L")
+        interest(1)
+        prompt("Input H")
+    }
+    field(INPI, DBF_INLINK) {
+        promptgroup("42 - Input G-L")
+        interest(1)
+        prompt("Input I")
+    }
+    field(INPJ, DBF_INLINK) {
+        promptgroup("42 - Input G-L")
+        interest(1)
+        prompt("Input J")
+    }
+    field(INPK, DBF_INLINK) {
+        promptgroup("42 - Input G-L")
+        interest(1)
+        prompt("Input K")
+    }
+    field(INPL, DBF_INLINK) {
+        promptgroup("42 - Input G-L")
+        interest(1)
+        prompt("Input L")
+    }
+    field(EGU, DBF_STRING) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        size(16)
+        prompt("Engineering Units")
+    }
+    field(PREC, DBF_SHORT) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("Display Precision")
+    }
+    field(HOPR, DBF_DOUBLE) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("High Operating Rng")
+    }
+    field(LOPR, DBF_DOUBLE) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("Low Operating Range")
+    }
+    field(HIHI, DBF_DOUBLE) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        interest(1)
+        pp(TRUE)
+        prompt("Hihi Alarm Limit")
+    }
+    field(LOLO, DBF_DOUBLE) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        interest(1)
+        pp(TRUE)
+        prompt("Lolo Alarm Limit")
+    }
+    field(HIGH, DBF_DOUBLE) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        interest(1)
+        pp(TRUE)
+        prompt("High Alarm Limit")
+    }
+    field(LOW, DBF_DOUBLE) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        interest(1)
+        pp(TRUE)
+        prompt("Low Alarm Limit")
+    }
+    field(HHSV, DBF_MENU) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("Hihi Severity")
+    }
+    field(LLSV, DBF_MENU) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("Lolo Severity")
+    }
+    field(HSV, DBF_MENU) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("High Severity")
+    }
+    field(LSV, DBF_MENU) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("Low Severity")
+    }
+    field(AFTC, DBF_DOUBLE) {
+        promptgroup("70 - Alarm")
+        interest(1)
+        prompt("Alarm Filter Time Constant")
+    }
+    field(AFVL, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Alarm Filter Value")
+    }
+    field(HYST, DBF_DOUBLE) {
+        promptgroup("70 - Alarm")
+        interest(1)
+        prompt("Alarm Deadband")
+    }
+    field(ADEL, DBF_DOUBLE) {
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("Archive Deadband")
+    }
+    field(MDEL, DBF_DOUBLE) {
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("Monitor Deadband")
+    }
+    field(A, DBF_DOUBLE) {
+        pp(TRUE)
+        prompt("Value of Input A")
+    }
+    field(B, DBF_DOUBLE) {
+        pp(TRUE)
+        prompt("Value of Input B")
+    }
+    field(C, DBF_DOUBLE) {
+        pp(TRUE)
+        prompt("Value of Input C")
+    }
+    field(D, DBF_DOUBLE) {
+        pp(TRUE)
+        prompt("Value of Input D")
+    }
+    field(E, DBF_DOUBLE) {
+        pp(TRUE)
+        prompt("Value of Input E")
+    }
+    field(F, DBF_DOUBLE) {
+        pp(TRUE)
+        prompt("Value of Input F")
+    }
+    field(G, DBF_DOUBLE) {
+        pp(TRUE)
+        prompt("Value of Input G")
+    }
+    field(H, DBF_DOUBLE) {
+        pp(TRUE)
+        prompt("Value of Input H")
+    }
+    field(I, DBF_DOUBLE) {
+        pp(TRUE)
+        prompt("Value of Input I")
+    }
+    field(J, DBF_DOUBLE) {
+        pp(TRUE)
+        prompt("Value of Input J")
+    }
+    field(K, DBF_DOUBLE) {
+        pp(TRUE)
+        prompt("Value of Input K")
+    }
+    field(L, DBF_DOUBLE) {
+        pp(TRUE)
+        prompt("Value of Input L")
+    }
+    field(LA, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Prev Value of A")
+    }
+    field(LB, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Prev Value of B")
+    }
+    field(LC, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Prev Value of C")
+    }
+    field(LD, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Prev Value of D")
+    }
+    field(LE, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Prev Value of E")
+    }
+    field(LF, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Prev Value of F")
+    }
+    field(LG, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Prev Value of G")
+    }
+    field(LH, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Prev Value of H")
+    }
+    field(LI, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Prev Value of I")
+    }
+    field(LJ, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Prev Value of J")
+    }
+    field(LK, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Prev Value of K")
+    }
+    field(LL, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Prev Value of L")
+    }
+    field(LALM, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Last Value Alarmed")
+    }
+    field(ALST, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Last Value Archived")
+    }
+    field(MLST, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Last Val Monitored")
+    }
+    field(RPCL, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("char	rpcl[INFIX_TO_POSTFIX_SIZE(80)]")
+        interest(4)
+        prompt("Reverse Polish Calc")
+    }
+}
+recordtype(mbboDirect) {
+    %#include "epicsTypes.h"
+    %#include "link.h"
+    %#include "epicsMutex.h"
+    %#include "ellLib.h"
+    %#include "epicsTime.h"
+    %#include "callback.h"
+    field(NAME, DBF_STRING) {
+        special(SPC_NOMOD)
+        size(61)
+        prompt("Record Name")
+    }
+    field(DESC, DBF_STRING) {
+        promptgroup("10 - Common")
+        size(41)
+        prompt("Descriptor")
+    }
+    field(ASG, DBF_STRING) {
+        promptgroup("10 - Common")
+        special(SPC_AS)
+        size(29)
+        prompt("Access Security Group")
+    }
+    field(SCAN, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuScan)
+        interest(1)
+        prompt("Scan Mechanism")
+    }
+    field(PINI, DBF_MENU) {
+        promptgroup("20 - Scan")
+        menu(menuPini)
+        interest(1)
+        prompt("Process at iocInit")
+    }
+    field(PHAS, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        prompt("Scan Phase")
+    }
+    field(EVNT, DBF_STRING) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        size(40)
+        prompt("Event Name")
+    }
+    field(TSE, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Event")
+    }
+    field(TSEL, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Link")
+    }
+    field(DTYP, DBF_DEVICE) {
+        promptgroup("10 - Common")
+        interest(1)
+        prompt("Device Type")
+    }
+    field(DISV, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        initial("1")
+        prompt("Disable Value")
+    }
+    field(DISA, DBF_SHORT) {
+        prompt("Disable")
+    }
+    field(SDIS, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Scanning Disable")
+    }
+    field(MLOK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsMutexId        mlok")
+        interest(4)
+        prompt("Monitor lock")
+    }
+    field(MLIS, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             mlis")
+        interest(4)
+        prompt("Monitor List")
+    }
+    field(BKLNK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             bklnk")
+        interest(4)
+        prompt("Backwards link tracking")
+    }
+    field(DISP, DBF_UCHAR) {
+        prompt("Disable putField")
+    }
+    field(PROC, DBF_UCHAR) {
+        interest(3)
+        pp(TRUE)
+        prompt("Force Processing")
+    }
+    field(STAT, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        initial("UDF")
+        prompt("Alarm Status")
+    }
+    field(SEVR, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        prompt("Alarm Severity")
+    }
+    field(NSTA, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        interest(2)
+        prompt("New Alarm Status")
+    }
+    field(NSEV, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("New Alarm Severity")
+    }
+    field(ACKS, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("Alarm Ack Severity")
+    }
+    field(ACKT, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        special(SPC_NOMOD)
+        menu(menuYesNo)
+        initial("YES")
+        interest(2)
+        prompt("Alarm Ack Transient")
+    }
+    field(DISS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        prompt("Disable Alarm Sevrty")
+    }
+    field(LCNT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(2)
+        prompt("Lock Count")
+    }
+    field(PACT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Record active")
+    }
+    field(PUTF, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("dbPutField process")
+    }
+    field(RPRO, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Reprocess ")
+    }
+    field(ASP, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct asgMember    *asp")
+        interest(4)
+        prompt("Access Security Pvt")
+    }
+    field(PPN, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotify *ppn")
+        interest(4)
+        prompt("pprocessNotify")
+    }
+    field(PPNR, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotifyRecord *ppnr")
+        interest(4)
+        prompt("pprocessNotifyRecord")
+    }
+    field(SPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct scan_element *spvt")
+        interest(4)
+        prompt("Scan Private")
+    }
+    field(RSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct typed_rset   *rset")
+        interest(4)
+        prompt("Address of RSET")
+    }
+    field(DSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dset         *dset")
+        interest(4)
+        prompt("DSET address")
+    }
+    field(DPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("void                *dpvt")
+        interest(4)
+        prompt("Device Private")
+    }
+    field(RDES, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dbRecordType *rdes")
+        interest(4)
+        prompt("Address of dbRecordType")
+    }
+    field(LSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct lockRecord   *lset")
+        interest(4)
+        prompt("Lock Set")
+    }
+    field(PRIO, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuPriority)
+        interest(1)
+        prompt("Scheduling Priority")
+    }
+    field(TPRO, DBF_UCHAR) {
+        prompt("Trace Processing")
+    }
+    field(BKPT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("char                bkpt")
+        interest(1)
+        prompt("Break Point")
+    }
+    field(UDF, DBF_UCHAR) {
+        promptgroup("10 - Common")
+        initial("1")
+        interest(1)
+        pp(TRUE)
+        prompt("Undefined")
+    }
+    field(UDFS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        initial("INVALID")
+        interest(1)
+        prompt("Undefined Alarm Sevrty")
+    }
+    field(TIME, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsTimeStamp      time")
+        interest(2)
+        prompt("Time")
+    }
+    field(FLNK, DBF_FWDLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Forward Process Link")
+    }
+    field(VAL, DBF_LONG) {
+        promptgroup("50 - Output")
+        asl(ASL0)
+        pp(TRUE)
+        prompt("Word")
+    }
+    field(OMSL, DBF_MENU) {
+        promptgroup("50 - Output")
+        special(SPC_RESET)
+        menu(menuOmsl)
+        interest(1)
+        pp(TRUE)
+        prompt("Output Mode Select")
+    }
+    field(NOBT, DBF_SHORT) {
+        promptgroup("50 - Output")
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Number of Bits")
+    }
+    field(DOL, DBF_INLINK) {
+        promptgroup("40 - Input")
+        interest(1)
+        prompt("Desired Output Loc")
+    }
+    field(OUT, DBF_OUTLINK) {
+        promptgroup("50 - Output")
+        interest(1)
+        prompt("Output Specification")
+    }
+    field(RVAL, DBF_ULONG) {
+        special(SPC_NOMOD)
+        pp(TRUE)
+        prompt("Raw Value")
+    }
+    field(ORAW, DBF_ULONG) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Prev Raw Value")
+    }
+    field(RBV, DBF_ULONG) {
+        special(SPC_NOMOD)
+        prompt("Readback Value")
+    }
+    field(ORBV, DBF_ULONG) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Prev Readback Value")
+    }
+    field(MASK, DBF_ULONG) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Hardware Mask")
+    }
+    field(MLST, DBF_LONG) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Last Value Monitored")
+    }
+    field(SHFT, DBF_USHORT) {
+        promptgroup("50 - Output")
+        interest(1)
+        prompt("Shift")
+    }
+    field(SIOL, DBF_OUTLINK) {
+        promptgroup("90 - Simulate")
+        interest(1)
+        prompt("Simulation Output Link")
+    }
+    field(SIML, DBF_INLINK) {
+        promptgroup("90 - Simulate")
+        interest(1)
+        prompt("Simulation Mode Link")
+    }
+    field(SIMM, DBF_MENU) {
+        special(SPC_MOD)
+        menu(menuYesNo)
+        interest(1)
+        prompt("Simulation Mode")
+    }
+    field(SIMS, DBF_MENU) {
+        promptgroup("90 - Simulate")
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("Simulation Mode Severity")
+    }
+    field(OLDSIMM, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuSimm)
+        interest(4)
+        prompt("Prev. Simulation Mode")
+    }
+    field(SSCN, DBF_MENU) {
+        promptgroup("90 - Simulate")
+        menu(menuScan)
+        initial("65535")
+        interest(1)
+        prompt("Sim. Mode Scan")
+    }
+    field(SDLY, DBF_DOUBLE) {
+        promptgroup("90 - Simulate")
+        initial("-1.0")
+        interest(2)
+        prompt("Sim. Mode Async Delay")
+    }
+    field(SIMPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("CALLBACK            *simpvt")
+        interest(4)
+        prompt("Sim. Mode Private")
+    }
+    field(IVOA, DBF_MENU) {
+        promptgroup("50 - Output")
+        menu(menuIvoa)
+        interest(2)
+        prompt("INVALID outpt action")
+    }
+    field(IVOV, DBF_LONG) {
+        promptgroup("50 - Output")
+        interest(2)
+        prompt("INVALID output value")
+    }
+    field(B0, DBF_UCHAR) {
+        promptgroup("51 - Output 0-7")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 0")
+    }
+    field(B1, DBF_UCHAR) {
+        promptgroup("51 - Output 0-7")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 1")
+    }
+    field(B2, DBF_UCHAR) {
+        promptgroup("51 - Output 0-7")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 2")
+    }
+    field(B3, DBF_UCHAR) {
+        promptgroup("51 - Output 0-7")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 3")
+    }
+    field(B4, DBF_UCHAR) {
+        promptgroup("51 - Output 0-7")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 4")
+    }
+    field(B5, DBF_UCHAR) {
+        promptgroup("51 - Output 0-7")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 5")
+    }
+    field(B6, DBF_UCHAR) {
+        promptgroup("51 - Output 0-7")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 6")
+    }
+    field(B7, DBF_UCHAR) {
+        promptgroup("51 - Output 0-7")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 7")
+    }
+    field(B8, DBF_UCHAR) {
+        promptgroup("52 - Output 8-15")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 8")
+    }
+    field(B9, DBF_UCHAR) {
+        promptgroup("52 - Output 8-15")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 9")
+    }
+    field(BA, DBF_UCHAR) {
+        promptgroup("52 - Output 8-15")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 10")
+    }
+    field(BB, DBF_UCHAR) {
+        promptgroup("52 - Output 8-15")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 11")
+    }
+    field(BC, DBF_UCHAR) {
+        promptgroup("52 - Output 8-15")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 12")
+    }
+    field(BD, DBF_UCHAR) {
+        promptgroup("52 - Output 8-15")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 13")
+    }
+    field(BE, DBF_UCHAR) {
+        promptgroup("52 - Output 8-15")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 14")
+    }
+    field(BF, DBF_UCHAR) {
+        promptgroup("52 - Output 8-15")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 15")
+    }
+    field(B10, DBF_UCHAR) {
+        promptgroup("53 - Output 16-23")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 16")
+    }
+    field(B11, DBF_UCHAR) {
+        promptgroup("53 - Output 16-23")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 17")
+    }
+    field(B12, DBF_UCHAR) {
+        promptgroup("53 - Output 16-23")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 18")
+    }
+    field(B13, DBF_UCHAR) {
+        promptgroup("53 - Output 16-23")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 19")
+    }
+    field(B14, DBF_UCHAR) {
+        promptgroup("53 - Output 16-23")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 20")
+    }
+    field(B15, DBF_UCHAR) {
+        promptgroup("53 - Output 16-23")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 21")
+    }
+    field(B16, DBF_UCHAR) {
+        promptgroup("53 - Output 16-23")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 22")
+    }
+    field(B17, DBF_UCHAR) {
+        promptgroup("53 - Output 16-23")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 23")
+    }
+    field(B18, DBF_UCHAR) {
+        promptgroup("54 - Output 24-31")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 24")
+    }
+    field(B19, DBF_UCHAR) {
+        promptgroup("54 - Output 24-31")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 25")
+    }
+    field(B1A, DBF_UCHAR) {
+        promptgroup("54 - Output 24-31")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 26")
+    }
+    field(B1B, DBF_UCHAR) {
+        promptgroup("54 - Output 24-31")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 27")
+    }
+    field(B1C, DBF_UCHAR) {
+        promptgroup("54 - Output 24-31")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 28")
+    }
+    field(B1D, DBF_UCHAR) {
+        promptgroup("54 - Output 24-31")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 29")
+    }
+    field(B1E, DBF_UCHAR) {
+        promptgroup("54 - Output 24-31")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 30")
+    }
+    field(B1F, DBF_UCHAR) {
+        promptgroup("54 - Output 24-31")
+        special(SPC_MOD)
+        interest(1)
+        pp(TRUE)
+        prompt("Bit 31")
+    }
+}
+device(mbboDirect, CONSTANT, devMbboDirectSoft, "Soft Channel")
+device(mbboDirect, CONSTANT, devMbboDirectSoftRaw, "Raw Soft Channel")
+device(mbboDirect, CONSTANT, devMbboDirectSoftCallback, "Async Soft Channel")
+device(mbboDirect, INST_IO, asynMbboDirectUInt32Digital, "asynUInt32Digital")
+recordtype(longout) {
+    %#include "epicsTypes.h"
+    %#include "link.h"
+    %#include "epicsMutex.h"
+    %#include "ellLib.h"
+    %#include "epicsTime.h"
+    %#include "callback.h"
+    field(NAME, DBF_STRING) {
+        special(SPC_NOMOD)
+        size(61)
+        prompt("Record Name")
+    }
+    field(DESC, DBF_STRING) {
+        promptgroup("10 - Common")
+        size(41)
+        prompt("Descriptor")
+    }
+    field(ASG, DBF_STRING) {
+        promptgroup("10 - Common")
+        special(SPC_AS)
+        size(29)
+        prompt("Access Security Group")
+    }
+    field(SCAN, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuScan)
+        interest(1)
+        prompt("Scan Mechanism")
+    }
+    field(PINI, DBF_MENU) {
+        promptgroup("20 - Scan")
+        menu(menuPini)
+        interest(1)
+        prompt("Process at iocInit")
+    }
+    field(PHAS, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        prompt("Scan Phase")
+    }
+    field(EVNT, DBF_STRING) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        size(40)
+        prompt("Event Name")
+    }
+    field(TSE, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Event")
+    }
+    field(TSEL, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Link")
+    }
+    field(DTYP, DBF_DEVICE) {
+        promptgroup("10 - Common")
+        interest(1)
+        prompt("Device Type")
+    }
+    field(DISV, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        initial("1")
+        prompt("Disable Value")
+    }
+    field(DISA, DBF_SHORT) {
+        prompt("Disable")
+    }
+    field(SDIS, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Scanning Disable")
+    }
+    field(MLOK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsMutexId        mlok")
+        interest(4)
+        prompt("Monitor lock")
+    }
+    field(MLIS, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             mlis")
+        interest(4)
+        prompt("Monitor List")
+    }
+    field(BKLNK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             bklnk")
+        interest(4)
+        prompt("Backwards link tracking")
+    }
+    field(DISP, DBF_UCHAR) {
+        prompt("Disable putField")
+    }
+    field(PROC, DBF_UCHAR) {
+        interest(3)
+        pp(TRUE)
+        prompt("Force Processing")
+    }
+    field(STAT, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        initial("UDF")
+        prompt("Alarm Status")
+    }
+    field(SEVR, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        prompt("Alarm Severity")
+    }
+    field(NSTA, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        interest(2)
+        prompt("New Alarm Status")
+    }
+    field(NSEV, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("New Alarm Severity")
+    }
+    field(ACKS, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("Alarm Ack Severity")
+    }
+    field(ACKT, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        special(SPC_NOMOD)
+        menu(menuYesNo)
+        initial("YES")
+        interest(2)
+        prompt("Alarm Ack Transient")
+    }
+    field(DISS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        prompt("Disable Alarm Sevrty")
+    }
+    field(LCNT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(2)
+        prompt("Lock Count")
+    }
+    field(PACT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Record active")
+    }
+    field(PUTF, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("dbPutField process")
+    }
+    field(RPRO, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Reprocess ")
+    }
+    field(ASP, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct asgMember    *asp")
+        interest(4)
+        prompt("Access Security Pvt")
+    }
+    field(PPN, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotify *ppn")
+        interest(4)
+        prompt("pprocessNotify")
+    }
+    field(PPNR, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotifyRecord *ppnr")
+        interest(4)
+        prompt("pprocessNotifyRecord")
+    }
+    field(SPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct scan_element *spvt")
+        interest(4)
+        prompt("Scan Private")
+    }
+    field(RSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct typed_rset   *rset")
+        interest(4)
+        prompt("Address of RSET")
+    }
+    field(DSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dset         *dset")
+        interest(4)
+        prompt("DSET address")
+    }
+    field(DPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("void                *dpvt")
+        interest(4)
+        prompt("Device Private")
+    }
+    field(RDES, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dbRecordType *rdes")
+        interest(4)
+        prompt("Address of dbRecordType")
+    }
+    field(LSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct lockRecord   *lset")
+        interest(4)
+        prompt("Lock Set")
+    }
+    field(PRIO, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuPriority)
+        interest(1)
+        prompt("Scheduling Priority")
+    }
+    field(TPRO, DBF_UCHAR) {
+        prompt("Trace Processing")
+    }
+    field(BKPT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("char                bkpt")
+        interest(1)
+        prompt("Break Point")
+    }
+    field(UDF, DBF_UCHAR) {
+        promptgroup("10 - Common")
+        initial("1")
+        interest(1)
+        pp(TRUE)
+        prompt("Undefined")
+    }
+    field(UDFS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        initial("INVALID")
+        interest(1)
+        prompt("Undefined Alarm Sevrty")
+    }
+    field(TIME, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsTimeStamp      time")
+        interest(2)
+        prompt("Time")
+    }
+    field(FLNK, DBF_FWDLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Forward Process Link")
+    }
+    field(VAL, DBF_LONG) {
+        promptgroup("50 - Output")
+        asl(ASL0)
+        pp(TRUE)
+        prompt("Desired Output")
+    }
+    field(OUT, DBF_OUTLINK) {
+        promptgroup("50 - Output")
+        interest(1)
+        prompt("Output Specification")
+    }
+    field(DOL, DBF_INLINK) {
+        promptgroup("40 - Input")
+        interest(1)
+        prompt("Desired Output Loc")
+    }
+    field(OMSL, DBF_MENU) {
+        promptgroup("50 - Output")
+        menu(menuOmsl)
+        interest(1)
+        prompt("Output Mode Select")
+    }
+    field(EGU, DBF_STRING) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        size(16)
+        prompt("Engineering Units")
+    }
+    field(DRVH, DBF_LONG) {
+        prop(YES)
+        promptgroup("30 - Action")
+        interest(1)
+        pp(TRUE)
+        prompt("Drive High Limit")
+    }
+    field(DRVL, DBF_LONG) {
+        prop(YES)
+        promptgroup("30 - Action")
+        interest(1)
+        pp(TRUE)
+        prompt("Drive Low Limit")
+    }
+    field(HOPR, DBF_LONG) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("High Operating Range")
+    }
+    field(LOPR, DBF_LONG) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("Low Operating Range")
+    }
+    field(HIHI, DBF_LONG) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        interest(1)
+        pp(TRUE)
+        prompt("Hihi Alarm Limit")
+    }
+    field(LOLO, DBF_LONG) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        interest(1)
+        pp(TRUE)
+        prompt("Lolo Alarm Limit")
+    }
+    field(HIGH, DBF_LONG) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        interest(1)
+        pp(TRUE)
+        prompt("High Alarm Limit")
+    }
+    field(LOW, DBF_LONG) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        interest(1)
+        pp(TRUE)
+        prompt("Low Alarm Limit")
+    }
+    field(HHSV, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("Hihi Severity")
+    }
+    field(LLSV, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("Lolo Severity")
+    }
+    field(HSV, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("High Severity")
+    }
+    field(LSV, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("Low Severity")
+    }
+    field(HYST, DBF_LONG) {
+        promptgroup("70 - Alarm")
+        interest(1)
+        prompt("Alarm Deadband")
+    }
+    field(ADEL, DBF_LONG) {
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("Archive Deadband")
+    }
+    field(MDEL, DBF_LONG) {
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("Monitor Deadband")
+    }
+    field(LALM, DBF_LONG) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Last Value Alarmed")
+    }
+    field(ALST, DBF_LONG) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Last Value Archived")
+    }
+    field(MLST, DBF_LONG) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Last Val Monitored")
+    }
+    field(SIOL, DBF_OUTLINK) {
+        promptgroup("90 - Simulate")
+        interest(1)
+        prompt("Simulation Output Link")
+    }
+    field(SIML, DBF_INLINK) {
+        promptgroup("90 - Simulate")
+        interest(1)
+        prompt("Simulation Mode Link")
+    }
+    field(SIMM, DBF_MENU) {
+        special(SPC_MOD)
+        menu(menuYesNo)
+        interest(1)
+        prompt("Simulation Mode")
+    }
+    field(SIMS, DBF_MENU) {
+        promptgroup("90 - Simulate")
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("Simulation Mode Severity")
+    }
+    field(OLDSIMM, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuSimm)
+        interest(4)
+        prompt("Prev. Simulation Mode")
+    }
+    field(SSCN, DBF_MENU) {
+        promptgroup("90 - Simulate")
+        menu(menuScan)
+        initial("65535")
+        interest(1)
+        prompt("Sim. Mode Scan")
+    }
+    field(SDLY, DBF_DOUBLE) {
+        promptgroup("90 - Simulate")
+        initial("-1.0")
+        interest(2)
+        prompt("Sim. Mode Async Delay")
+    }
+    field(SIMPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("CALLBACK            *simpvt")
+        interest(4)
+        prompt("Sim. Mode Private")
+    }
+    field(IVOA, DBF_MENU) {
+        promptgroup("50 - Output")
+        menu(menuIvoa)
+        interest(2)
+        prompt("INVALID output action")
+    }
+    field(IVOV, DBF_LONG) {
+        promptgroup("50 - Output")
+        interest(2)
+        prompt("INVALID output value")
+    }
+}
+device(longout, CONSTANT, devLoSoft, "Soft Channel")
+device(longout, CONSTANT, devLoSoftCallback, "Async Soft Channel")
+device(longout, INST_IO, asynLoInt32, "asynInt32")
+device(longout, INST_IO, asynLoUInt32Digital, "asynUInt32Digital")
+recordtype(aSub) {
+    %#include "epicsTypes.h"
+    %#include "link.h"
+    %#include "epicsMutex.h"
+    %#include "ellLib.h"
+    %#include "epicsTime.h"
+    %struct aSubRecord;
+    field(NAME, DBF_STRING) {
+        special(SPC_NOMOD)
+        size(61)
+        prompt("Record Name")
+    }
+    field(DESC, DBF_STRING) {
+        promptgroup("10 - Common")
+        size(41)
+        prompt("Descriptor")
+    }
+    field(ASG, DBF_STRING) {
+        promptgroup("10 - Common")
+        special(SPC_AS)
+        size(29)
+        prompt("Access Security Group")
+    }
+    field(SCAN, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuScan)
+        interest(1)
+        prompt("Scan Mechanism")
+    }
+    field(PINI, DBF_MENU) {
+        promptgroup("20 - Scan")
+        menu(menuPini)
+        interest(1)
+        prompt("Process at iocInit")
+    }
+    field(PHAS, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        prompt("Scan Phase")
+    }
+    field(EVNT, DBF_STRING) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        size(40)
+        prompt("Event Name")
+    }
+    field(TSE, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Event")
+    }
+    field(TSEL, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Link")
+    }
+    field(DTYP, DBF_DEVICE) {
+        promptgroup("10 - Common")
+        interest(1)
+        prompt("Device Type")
+    }
+    field(DISV, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        initial("1")
+        prompt("Disable Value")
+    }
+    field(DISA, DBF_SHORT) {
+        prompt("Disable")
+    }
+    field(SDIS, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Scanning Disable")
+    }
+    field(MLOK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsMutexId        mlok")
+        interest(4)
+        prompt("Monitor lock")
+    }
+    field(MLIS, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             mlis")
+        interest(4)
+        prompt("Monitor List")
+    }
+    field(BKLNK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             bklnk")
+        interest(4)
+        prompt("Backwards link tracking")
+    }
+    field(DISP, DBF_UCHAR) {
+        prompt("Disable putField")
+    }
+    field(PROC, DBF_UCHAR) {
+        interest(3)
+        pp(TRUE)
+        prompt("Force Processing")
+    }
+    field(STAT, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        initial("UDF")
+        prompt("Alarm Status")
+    }
+    field(SEVR, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        prompt("Alarm Severity")
+    }
+    field(NSTA, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        interest(2)
+        prompt("New Alarm Status")
+    }
+    field(NSEV, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("New Alarm Severity")
+    }
+    field(ACKS, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("Alarm Ack Severity")
+    }
+    field(ACKT, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        special(SPC_NOMOD)
+        menu(menuYesNo)
+        initial("YES")
+        interest(2)
+        prompt("Alarm Ack Transient")
+    }
+    field(DISS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        prompt("Disable Alarm Sevrty")
+    }
+    field(LCNT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(2)
+        prompt("Lock Count")
+    }
+    field(PACT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Record active")
+    }
+    field(PUTF, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("dbPutField process")
+    }
+    field(RPRO, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Reprocess ")
+    }
+    field(ASP, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct asgMember    *asp")
+        interest(4)
+        prompt("Access Security Pvt")
+    }
+    field(PPN, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotify *ppn")
+        interest(4)
+        prompt("pprocessNotify")
+    }
+    field(PPNR, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotifyRecord *ppnr")
+        interest(4)
+        prompt("pprocessNotifyRecord")
+    }
+    field(SPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct scan_element *spvt")
+        interest(4)
+        prompt("Scan Private")
+    }
+    field(RSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct typed_rset   *rset")
+        interest(4)
+        prompt("Address of RSET")
+    }
+    field(DSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dset         *dset")
+        interest(4)
+        prompt("DSET address")
+    }
+    field(DPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("void                *dpvt")
+        interest(4)
+        prompt("Device Private")
+    }
+    field(RDES, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dbRecordType *rdes")
+        interest(4)
+        prompt("Address of dbRecordType")
+    }
+    field(LSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct lockRecord   *lset")
+        interest(4)
+        prompt("Lock Set")
+    }
+    field(PRIO, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuPriority)
+        interest(1)
+        prompt("Scheduling Priority")
+    }
+    field(TPRO, DBF_UCHAR) {
+        prompt("Trace Processing")
+    }
+    field(BKPT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("char                bkpt")
+        interest(1)
+        prompt("Break Point")
+    }
+    field(UDF, DBF_UCHAR) {
+        promptgroup("10 - Common")
+        initial("1")
+        interest(1)
+        pp(TRUE)
+        prompt("Undefined")
+    }
+    field(UDFS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        initial("INVALID")
+        interest(1)
+        prompt("Undefined Alarm Sevrty")
+    }
+    field(TIME, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsTimeStamp      time")
+        interest(2)
+        prompt("Time")
+    }
+    field(FLNK, DBF_FWDLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Forward Process Link")
+    }
+    field(VAL, DBF_LONG) {
+        asl(ASL0)
+        prompt("Subr. return value")
+    }
+    field(OVAL, DBF_LONG) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Old return value")
+    }
+    field(INAM, DBF_STRING) {
+        promptgroup("30 - Action")
+        special(SPC_NOMOD)
+        interest(1)
+        size(41)
+        prompt("Initialize Subr. Name")
+    }
+    field(LFLG, DBF_MENU) {
+        promptgroup("30 - Action")
+        menu(aSubLFLG)
+        interest(1)
+        prompt("Subr. Input Enable")
+    }
+    field(SUBL, DBF_INLINK) {
+        promptgroup("30 - Action")
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Subroutine Name Link")
+    }
+    field(SNAM, DBF_STRING) {
+        promptgroup("30 - Action")
+        special(SPC_MOD)
+        interest(1)
+        size(41)
+        prompt("Process Subr. Name")
+    }
+    field(ONAM, DBF_STRING) {
+        promptgroup("30 - Action")
+        special(SPC_NOMOD)
+        interest(3)
+        size(41)
+        prompt("Old Subr. Name")
+    }
+    field(SADR, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("long (*sadr)(struct aSubRecord *)")
+        interest(2)
+        prompt("Subroutine Address")
+    }
+    field(CADR, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("void (*cadr)(struct aSubRecord *)")
+        interest(2)
+        prompt("Subroutine Cleanup Address")
+    }
+    field(BRSV, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("Bad Return Severity")
+    }
+    field(PREC, DBF_SHORT) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("Display Precision")
+    }
+    field(EFLG, DBF_MENU) {
+        promptgroup("50 - Output")
+        menu(aSubEFLG)
+        initial("1")
+        interest(1)
+        prompt("Output Event Flag")
+    }
+    field(INPA, DBF_INLINK) {
+        promptgroup("41 - Input A-G")
+        interest(1)
+        prompt("Input Link A")
+    }
+    field(INPB, DBF_INLINK) {
+        promptgroup("41 - Input A-G")
+        interest(1)
+        prompt("Input Link B")
+    }
+    field(INPC, DBF_INLINK) {
+        promptgroup("41 - Input A-G")
+        interest(1)
+        prompt("Input Link C")
+    }
+    field(INPD, DBF_INLINK) {
+        promptgroup("41 - Input A-G")
+        interest(1)
+        prompt("Input Link D")
+    }
+    field(INPE, DBF_INLINK) {
+        promptgroup("41 - Input A-G")
+        interest(1)
+        prompt("Input Link E")
+    }
+    field(INPF, DBF_INLINK) {
+        promptgroup("41 - Input A-G")
+        interest(1)
+        prompt("Input Link F")
+    }
+    field(INPG, DBF_INLINK) {
+        promptgroup("41 - Input A-G")
+        interest(1)
+        prompt("Input Link G")
+    }
+    field(INPH, DBF_INLINK) {
+        promptgroup("42 - Input H-N")
+        interest(1)
+        prompt("Input Link H")
+    }
+    field(INPI, DBF_INLINK) {
+        promptgroup("42 - Input H-N")
+        interest(1)
+        prompt("Input Link I")
+    }
+    field(INPJ, DBF_INLINK) {
+        promptgroup("42 - Input H-N")
+        interest(1)
+        prompt("Input Link J")
+    }
+    field(INPK, DBF_INLINK) {
+        promptgroup("42 - Input H-N")
+        interest(1)
+        prompt("Input Link K")
+    }
+    field(INPL, DBF_INLINK) {
+        promptgroup("42 - Input H-N")
+        interest(1)
+        prompt("Input Link L")
+    }
+    field(INPM, DBF_INLINK) {
+        promptgroup("42 - Input H-N")
+        interest(1)
+        prompt("Input Link M")
+    }
+    field(INPN, DBF_INLINK) {
+        promptgroup("42 - Input H-N")
+        interest(1)
+        prompt("Input Link N")
+    }
+    field(INPO, DBF_INLINK) {
+        promptgroup("43 - Input O-U")
+        interest(1)
+        prompt("Input Link O")
+    }
+    field(INPP, DBF_INLINK) {
+        promptgroup("43 - Input O-U")
+        interest(1)
+        prompt("Input Link P")
+    }
+    field(INPQ, DBF_INLINK) {
+        promptgroup("43 - Input O-U")
+        interest(1)
+        prompt("Input Link Q")
+    }
+    field(INPR, DBF_INLINK) {
+        promptgroup("43 - Input O-U")
+        interest(1)
+        prompt("Input Link R")
+    }
+    field(INPS, DBF_INLINK) {
+        promptgroup("43 - Input O-U")
+        interest(1)
+        prompt("Input Link S")
+    }
+    field(INPT, DBF_INLINK) {
+        promptgroup("43 - Input O-U")
+        interest(1)
+        prompt("Input Link T")
+    }
+    field(INPU, DBF_INLINK) {
+        promptgroup("43 - Input O-U")
+        interest(1)
+        prompt("Input Link U")
+    }
+    field(A, DBF_NOACCESS) {
+        special(SPC_DBADDR)
+        asl(ASL0)
+        extra("void *a")
+        interest(2)
+        prompt("Input value A")
+    }
+    field(B, DBF_NOACCESS) {
+        special(SPC_DBADDR)
+        asl(ASL0)
+        extra("void *b")
+        interest(2)
+        prompt("Input value B")
+    }
+    field(C, DBF_NOACCESS) {
+        special(SPC_DBADDR)
+        asl(ASL0)
+        extra("void *c")
+        interest(2)
+        prompt("Input value C")
+    }
+    field(D, DBF_NOACCESS) {
+        special(SPC_DBADDR)
+        asl(ASL0)
+        extra("void *d")
+        interest(2)
+        prompt("Input value D")
+    }
+    field(E, DBF_NOACCESS) {
+        special(SPC_DBADDR)
+        asl(ASL0)
+        extra("void *e")
+        interest(2)
+        prompt("Input value E")
+    }
+    field(F, DBF_NOACCESS) {
+        special(SPC_DBADDR)
+        asl(ASL0)
+        extra("void *f")
+        interest(2)
+        prompt("Input value F")
+    }
+    field(G, DBF_NOACCESS) {
+        special(SPC_DBADDR)
+        asl(ASL0)
+        extra("void *g")
+        interest(2)
+        prompt("Input value G")
+    }
+    field(H, DBF_NOACCESS) {
+        special(SPC_DBADDR)
+        asl(ASL0)
+        extra("void *h")
+        interest(2)
+        prompt("Input value H")
+    }
+    field(I, DBF_NOACCESS) {
+        special(SPC_DBADDR)
+        asl(ASL0)
+        extra("void *i")
+        interest(2)
+        prompt("Input value I")
+    }
+    field(J, DBF_NOACCESS) {
+        special(SPC_DBADDR)
+        asl(ASL0)
+        extra("void *j")
+        interest(2)
+        prompt("Input value J")
+    }
+    field(K, DBF_NOACCESS) {
+        special(SPC_DBADDR)
+        asl(ASL0)
+        extra("void *k")
+        interest(2)
+        prompt("Input value K")
+    }
+    field(L, DBF_NOACCESS) {
+        special(SPC_DBADDR)
+        asl(ASL0)
+        extra("void *l")
+        interest(2)
+        prompt("Input value L")
+    }
+    field(M, DBF_NOACCESS) {
+        special(SPC_DBADDR)
+        asl(ASL0)
+        extra("void *m")
+        interest(2)
+        prompt("Input value M")
+    }
+    field(N, DBF_NOACCESS) {
+        special(SPC_DBADDR)
+        asl(ASL0)
+        extra("void *n")
+        interest(2)
+        prompt("Input value N")
+    }
+    field(O, DBF_NOACCESS) {
+        special(SPC_DBADDR)
+        asl(ASL0)
+        extra("void *o")
+        interest(2)
+        prompt("Input value O")
+    }
+    field(P, DBF_NOACCESS) {
+        special(SPC_DBADDR)
+        asl(ASL0)
+        extra("void *p")
+        interest(2)
+        prompt("Input value P")
+    }
+    field(Q, DBF_NOACCESS) {
+        special(SPC_DBADDR)
+        asl(ASL0)
+        extra("void *q")
+        interest(2)
+        prompt("Input value Q")
+    }
+    field(R, DBF_NOACCESS) {
+        special(SPC_DBADDR)
+        asl(ASL0)
+        extra("void *r")
+        interest(2)
+        prompt("Input value R")
+    }
+    field(S, DBF_NOACCESS) {
+        special(SPC_DBADDR)
+        asl(ASL0)
+        extra("void *s")
+        interest(2)
+        prompt("Input value S")
+    }
+    field(T, DBF_NOACCESS) {
+        special(SPC_DBADDR)
+        asl(ASL0)
+        extra("void *t")
+        interest(2)
+        prompt("Input value T")
+    }
+    field(U, DBF_NOACCESS) {
+        special(SPC_DBADDR)
+        asl(ASL0)
+        extra("void *u")
+        interest(2)
+        prompt("Input value U")
+    }
+    field(FTA, DBF_MENU) {
+        promptgroup("41 - Input A-G")
+        special(SPC_NOMOD)
+        menu(menuFtype)
+        initial("DOUBLE")
+        interest(1)
+        prompt("Type of A")
+    }
+    field(FTB, DBF_MENU) {
+        promptgroup("41 - Input A-G")
+        special(SPC_NOMOD)
+        menu(menuFtype)
+        initial("DOUBLE")
+        interest(1)
+        prompt("Type of B")
+    }
+    field(FTC, DBF_MENU) {
+        promptgroup("41 - Input A-G")
+        special(SPC_NOMOD)
+        menu(menuFtype)
+        initial("DOUBLE")
+        interest(1)
+        prompt("Type of C")
+    }
+    field(FTD, DBF_MENU) {
+        promptgroup("41 - Input A-G")
+        special(SPC_NOMOD)
+        menu(menuFtype)
+        initial("DOUBLE")
+        interest(1)
+        prompt("Type of D")
+    }
+    field(FTE, DBF_MENU) {
+        promptgroup("41 - Input A-G")
+        special(SPC_NOMOD)
+        menu(menuFtype)
+        initial("DOUBLE")
+        interest(1)
+        prompt("Type of E")
+    }
+    field(FTF, DBF_MENU) {
+        promptgroup("41 - Input A-G")
+        special(SPC_NOMOD)
+        menu(menuFtype)
+        initial("DOUBLE")
+        interest(1)
+        prompt("Type of F")
+    }
+    field(FTG, DBF_MENU) {
+        promptgroup("41 - Input A-G")
+        special(SPC_NOMOD)
+        menu(menuFtype)
+        initial("DOUBLE")
+        interest(1)
+        prompt("Type of G")
+    }
+    field(FTH, DBF_MENU) {
+        promptgroup("42 - Input H-N")
+        special(SPC_NOMOD)
+        menu(menuFtype)
+        initial("DOUBLE")
+        interest(1)
+        prompt("Type of H")
+    }
+    field(FTI, DBF_MENU) {
+        promptgroup("42 - Input H-N")
+        special(SPC_NOMOD)
+        menu(menuFtype)
+        initial("DOUBLE")
+        interest(1)
+        prompt("Type of I")
+    }
+    field(FTJ, DBF_MENU) {
+        promptgroup("42 - Input H-N")
+        special(SPC_NOMOD)
+        menu(menuFtype)
+        initial("DOUBLE")
+        interest(1)
+        prompt("Type of J")
+    }
+    field(FTK, DBF_MENU) {
+        promptgroup("42 - Input H-N")
+        special(SPC_NOMOD)
+        menu(menuFtype)
+        initial("DOUBLE")
+        interest(1)
+        prompt("Type of K")
+    }
+    field(FTL, DBF_MENU) {
+        promptgroup("42 - Input H-N")
+        special(SPC_NOMOD)
+        menu(menuFtype)
+        initial("DOUBLE")
+        interest(1)
+        prompt("Type of L")
+    }
+    field(FTM, DBF_MENU) {
+        promptgroup("42 - Input H-N")
+        special(SPC_NOMOD)
+        menu(menuFtype)
+        initial("DOUBLE")
+        interest(1)
+        prompt("Type of M")
+    }
+    field(FTN, DBF_MENU) {
+        promptgroup("42 - Input H-N")
+        special(SPC_NOMOD)
+        menu(menuFtype)
+        initial("DOUBLE")
+        interest(1)
+        prompt("Type of N")
+    }
+    field(FTO, DBF_MENU) {
+        promptgroup("43 - Input O-U")
+        special(SPC_NOMOD)
+        menu(menuFtype)
+        initial("DOUBLE")
+        interest(1)
+        prompt("Type of O")
+    }
+    field(FTP, DBF_MENU) {
+        promptgroup("43 - Input O-U")
+        special(SPC_NOMOD)
+        menu(menuFtype)
+        initial("DOUBLE")
+        interest(1)
+        prompt("Type of P")
+    }
+    field(FTQ, DBF_MENU) {
+        promptgroup("43 - Input O-U")
+        special(SPC_NOMOD)
+        menu(menuFtype)
+        initial("DOUBLE")
+        interest(1)
+        prompt("Type of Q")
+    }
+    field(FTR, DBF_MENU) {
+        promptgroup("43 - Input O-U")
+        special(SPC_NOMOD)
+        menu(menuFtype)
+        initial("DOUBLE")
+        interest(1)
+        prompt("Type of R")
+    }
+    field(FTS, DBF_MENU) {
+        promptgroup("43 - Input O-U")
+        special(SPC_NOMOD)
+        menu(menuFtype)
+        initial("DOUBLE")
+        interest(1)
+        prompt("Type of S")
+    }
+    field(FTT, DBF_MENU) {
+        promptgroup("43 - Input O-U")
+        special(SPC_NOMOD)
+        menu(menuFtype)
+        initial("DOUBLE")
+        interest(1)
+        prompt("Type of T")
+    }
+    field(FTU, DBF_MENU) {
+        promptgroup("43 - Input O-U")
+        special(SPC_NOMOD)
+        menu(menuFtype)
+        initial("DOUBLE")
+        interest(1)
+        prompt("Type of U")
+    }
+    field(NOA, DBF_ULONG) {
+        promptgroup("41 - Input A-G")
+        special(SPC_NOMOD)
+        initial("1")
+        interest(1)
+        prompt("Max. elements in A")
+    }
+    field(NOB, DBF_ULONG) {
+        promptgroup("41 - Input A-G")
+        special(SPC_NOMOD)
+        initial("1")
+        interest(1)
+        prompt("Max. elements in B")
+    }
+    field(NOC, DBF_ULONG) {
+        promptgroup("41 - Input A-G")
+        special(SPC_NOMOD)
+        initial("1")
+        interest(1)
+        prompt("Max. elements in C")
+    }
+    field(NOD, DBF_ULONG) {
+        promptgroup("41 - Input A-G")
+        special(SPC_NOMOD)
+        initial("1")
+        interest(1)
+        prompt("Max. elements in D")
+    }
+    field(NOE, DBF_ULONG) {
+        promptgroup("41 - Input A-G")
+        special(SPC_NOMOD)
+        initial("1")
+        interest(1)
+        prompt("Max. elements in E")
+    }
+    field(NOF, DBF_ULONG) {
+        promptgroup("41 - Input A-G")
+        special(SPC_NOMOD)
+        initial("1")
+        interest(1)
+        prompt("Max. elements in F")
+    }
+    field(NOG, DBF_ULONG) {
+        promptgroup("41 - Input A-G")
+        special(SPC_NOMOD)
+        initial("1")
+        interest(1)
+        prompt("Max. elements in G")
+    }
+    field(NOH, DBF_ULONG) {
+        promptgroup("42 - Input H-N")
+        special(SPC_NOMOD)
+        initial("1")
+        interest(1)
+        prompt("Max. elements in H")
+    }
+    field(NOI, DBF_ULONG) {
+        promptgroup("42 - Input H-N")
+        special(SPC_NOMOD)
+        initial("1")
+        interest(1)
+        prompt("Max. elements in I")
+    }
+    field(NOJ, DBF_ULONG) {
+        promptgroup("42 - Input H-N")
+        special(SPC_NOMOD)
+        initial("1")
+        interest(1)
+        prompt("Max. elements in J")
+    }
+    field(NOK, DBF_ULONG) {
+        promptgroup("42 - Input H-N")
+        special(SPC_NOMOD)
+        initial("1")
+        interest(1)
+        prompt("Max. elements in K")
+    }
+    field(NOL, DBF_ULONG) {
+        promptgroup("42 - Input H-N")
+        special(SPC_NOMOD)
+        initial("1")
+        interest(1)
+        prompt("Max. elements in L")
+    }
+    field(NOM, DBF_ULONG) {
+        promptgroup("42 - Input H-N")
+        special(SPC_NOMOD)
+        initial("1")
+        interest(1)
+        prompt("Max. elements in M")
+    }
+    field(NON, DBF_ULONG) {
+        promptgroup("42 - Input H-N")
+        special(SPC_NOMOD)
+        initial("1")
+        interest(1)
+        prompt("Max. elements in N")
+    }
+    field(NOO, DBF_ULONG) {
+        promptgroup("43 - Input O-U")
+        special(SPC_NOMOD)
+        initial("1")
+        interest(1)
+        prompt("Max. elements in O")
+    }
+    field(NOP, DBF_ULONG) {
+        promptgroup("43 - Input O-U")
+        special(SPC_NOMOD)
+        initial("1")
+        interest(1)
+        prompt("Max. elements in P")
+    }
+    field(NOQ, DBF_ULONG) {
+        promptgroup("43 - Input O-U")
+        special(SPC_NOMOD)
+        initial("1")
+        interest(1)
+        prompt("Max. elements in Q")
+    }
+    field(NOR, DBF_ULONG) {
+        promptgroup("43 - Input O-U")
+        special(SPC_NOMOD)
+        initial("1")
+        interest(1)
+        prompt("Max. elements in R")
+    }
+    field(NOS, DBF_ULONG) {
+        promptgroup("43 - Input O-U")
+        special(SPC_NOMOD)
+        initial("1")
+        interest(1)
+        prompt("Max. elements in S")
+    }
+    field(NOT, DBF_ULONG) {
+        promptgroup("43 - Input O-U")
+        special(SPC_NOMOD)
+        initial("1")
+        interest(1)
+        prompt("Max. elements in T")
+    }
+    field(NOU, DBF_ULONG) {
+        promptgroup("43 - Input O-U")
+        special(SPC_NOMOD)
+        initial("1")
+        interest(1)
+        prompt("Max. elements in U")
+    }
+    field(NEA, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(3)
+        prompt("Num. elements in A")
+    }
+    field(NEB, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(3)
+        prompt("Num. elements in B")
+    }
+    field(NEC, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(3)
+        prompt("Num. elements in C")
+    }
+    field(NED, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(3)
+        prompt("Num. elements in D")
+    }
+    field(NEE, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(3)
+        prompt("Num. elements in E")
+    }
+    field(NEF, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(3)
+        prompt("Num. elements in F")
+    }
+    field(NEG, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(3)
+        prompt("Num. elements in G")
+    }
+    field(NEH, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(3)
+        prompt("Num. elements in H")
+    }
+    field(NEI, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(3)
+        prompt("Num. elements in I")
+    }
+    field(NEJ, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(3)
+        prompt("Num. elements in J")
+    }
+    field(NEK, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(3)
+        prompt("Num. elements in K")
+    }
+    field(NEL, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(3)
+        prompt("Num. elements in L")
+    }
+    field(NEM, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(3)
+        prompt("Num. elements in M")
+    }
+    field(NEN, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(3)
+        prompt("Num. elements in N")
+    }
+    field(NEO, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(3)
+        prompt("Num. elements in O")
+    }
+    field(NEP, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(3)
+        prompt("Num. elements in P")
+    }
+    field(NEQ, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(3)
+        prompt("Num. elements in Q")
+    }
+    field(NER, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(3)
+        prompt("Num. elements in R")
+    }
+    field(NES, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(3)
+        prompt("Num. elements in S")
+    }
+    field(NET, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(3)
+        prompt("Num. elements in T")
+    }
+    field(NEU, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(3)
+        prompt("Num. elements in U")
+    }
+    field(OUTA, DBF_OUTLINK) {
+        promptgroup("51 - Output A-G")
+        interest(1)
+        prompt("Output Link A")
+    }
+    field(OUTB, DBF_OUTLINK) {
+        promptgroup("51 - Output A-G")
+        interest(1)
+        prompt("Output Link B")
+    }
+    field(OUTC, DBF_OUTLINK) {
+        promptgroup("51 - Output A-G")
+        interest(1)
+        prompt("Output Link C")
+    }
+    field(OUTD, DBF_OUTLINK) {
+        promptgroup("51 - Output A-G")
+        interest(1)
+        prompt("Output Link D")
+    }
+    field(OUTE, DBF_OUTLINK) {
+        promptgroup("51 - Output A-G")
+        interest(1)
+        prompt("Output Link E")
+    }
+    field(OUTF, DBF_OUTLINK) {
+        promptgroup("51 - Output A-G")
+        interest(1)
+        prompt("Output Link F")
+    }
+    field(OUTG, DBF_OUTLINK) {
+        promptgroup("51 - Output A-G")
+        interest(1)
+        prompt("Output Link G")
+    }
+    field(OUTH, DBF_OUTLINK) {
+        promptgroup("52 - Output H-N")
+        interest(1)
+        prompt("Output Link H")
+    }
+    field(OUTI, DBF_OUTLINK) {
+        promptgroup("52 - Output H-N")
+        interest(1)
+        prompt("Output Link I")
+    }
+    field(OUTJ, DBF_OUTLINK) {
+        promptgroup("52 - Output H-N")
+        interest(1)
+        prompt("Output Link J")
+    }
+    field(OUTK, DBF_OUTLINK) {
+        promptgroup("52 - Output H-N")
+        interest(1)
+        prompt("Output Link K")
+    }
+    field(OUTL, DBF_OUTLINK) {
+        promptgroup("52 - Output H-N")
+        interest(1)
+        prompt("Output Link L")
+    }
+    field(OUTM, DBF_OUTLINK) {
+        promptgroup("52 - Output H-N")
+        interest(1)
+        prompt("Output Link M")
+    }
+    field(OUTN, DBF_OUTLINK) {
+        promptgroup("52 - Output H-N")
+        interest(1)
+        prompt("Output Link N")
+    }
+    field(OUTO, DBF_OUTLINK) {
+        promptgroup("53 - Output O-U")
+        interest(1)
+        prompt("Output Link O")
+    }
+    field(OUTP, DBF_OUTLINK) {
+        promptgroup("53 - Output O-U")
+        interest(1)
+        prompt("Output Link P")
+    }
+    field(OUTQ, DBF_OUTLINK) {
+        promptgroup("53 - Output O-U")
+        interest(1)
+        prompt("Output Link Q")
+    }
+    field(OUTR, DBF_OUTLINK) {
+        promptgroup("53 - Output O-U")
+        interest(1)
+        prompt("Output Link R")
+    }
+    field(OUTS, DBF_OUTLINK) {
+        promptgroup("53 - Output O-U")
+        interest(1)
+        prompt("Output Link S")
+    }
+    field(OUTT, DBF_OUTLINK) {
+        promptgroup("53 - Output O-U")
+        interest(1)
+        prompt("Output Link T")
+    }
+    field(OUTU, DBF_OUTLINK) {
+        promptgroup("53 - Output O-U")
+        interest(1)
+        prompt("Output Link U")
+    }
+    field(VALA, DBF_NOACCESS) {
+        special(SPC_DBADDR)
+        asl(ASL0)
+        extra("void *vala")
+        interest(2)
+        prompt("Output value A")
+    }
+    field(VALB, DBF_NOACCESS) {
+        special(SPC_DBADDR)
+        asl(ASL0)
+        extra("void *valb")
+        interest(2)
+        prompt("Output value B")
+    }
+    field(VALC, DBF_NOACCESS) {
+        special(SPC_DBADDR)
+        asl(ASL0)
+        extra("void *valc")
+        interest(2)
+        prompt("Output value C")
+    }
+    field(VALD, DBF_NOACCESS) {
+        special(SPC_DBADDR)
+        asl(ASL0)
+        extra("void *vald")
+        interest(2)
+        prompt("Output value D")
+    }
+    field(VALE, DBF_NOACCESS) {
+        special(SPC_DBADDR)
+        asl(ASL0)
+        extra("void *vale")
+        interest(2)
+        prompt("Output value E")
+    }
+    field(VALF, DBF_NOACCESS) {
+        special(SPC_DBADDR)
+        asl(ASL0)
+        extra("void *valf")
+        interest(2)
+        prompt("Output value F")
+    }
+    field(VALG, DBF_NOACCESS) {
+        special(SPC_DBADDR)
+        asl(ASL0)
+        extra("void *valg")
+        interest(2)
+        prompt("Output value G")
+    }
+    field(VALH, DBF_NOACCESS) {
+        special(SPC_DBADDR)
+        asl(ASL0)
+        extra("void *valh")
+        interest(2)
+        prompt("Output value H")
+    }
+    field(VALI, DBF_NOACCESS) {
+        special(SPC_DBADDR)
+        asl(ASL0)
+        extra("void *vali")
+        interest(2)
+        prompt("Output value I")
+    }
+    field(VALJ, DBF_NOACCESS) {
+        special(SPC_DBADDR)
+        asl(ASL0)
+        extra("void *valj")
+        interest(2)
+        prompt("Output value J")
+    }
+    field(VALK, DBF_NOACCESS) {
+        special(SPC_DBADDR)
+        asl(ASL0)
+        extra("void *valk")
+        interest(2)
+        prompt("Output value K")
+    }
+    field(VALL, DBF_NOACCESS) {
+        special(SPC_DBADDR)
+        asl(ASL0)
+        extra("void *vall")
+        interest(2)
+        prompt("Output value L")
+    }
+    field(VALM, DBF_NOACCESS) {
+        special(SPC_DBADDR)
+        asl(ASL0)
+        extra("void *valm")
+        interest(2)
+        prompt("Output value M")
+    }
+    field(VALN, DBF_NOACCESS) {
+        special(SPC_DBADDR)
+        asl(ASL0)
+        extra("void *valn")
+        interest(2)
+        prompt("Output value N")
+    }
+    field(VALO, DBF_NOACCESS) {
+        special(SPC_DBADDR)
+        asl(ASL0)
+        extra("void *valo")
+        interest(2)
+        prompt("Output value O")
+    }
+    field(VALP, DBF_NOACCESS) {
+        special(SPC_DBADDR)
+        asl(ASL0)
+        extra("void *valp")
+        interest(2)
+        prompt("Output value P")
+    }
+    field(VALQ, DBF_NOACCESS) {
+        special(SPC_DBADDR)
+        asl(ASL0)
+        extra("void *valq")
+        interest(2)
+        prompt("Output value Q")
+    }
+    field(VALR, DBF_NOACCESS) {
+        special(SPC_DBADDR)
+        asl(ASL0)
+        extra("void *valr")
+        interest(2)
+        prompt("Output value R")
+    }
+    field(VALS, DBF_NOACCESS) {
+        special(SPC_DBADDR)
+        asl(ASL0)
+        extra("void *vals")
+        interest(2)
+        prompt("Output value S")
+    }
+    field(VALT, DBF_NOACCESS) {
+        special(SPC_DBADDR)
+        asl(ASL0)
+        extra("void *valt")
+        interest(2)
+        prompt("Output value T")
+    }
+    field(VALU, DBF_NOACCESS) {
+        special(SPC_DBADDR)
+        asl(ASL0)
+        extra("void *valu")
+        interest(2)
+        prompt("Output value U")
+    }
+    field(OVLA, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        asl(ASL0)
+        extra("void *ovla")
+        interest(4)
+        prompt("Old Output A")
+    }
+    field(OVLB, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        asl(ASL0)
+        extra("void *ovlb")
+        interest(4)
+        prompt("Old Output B")
+    }
+    field(OVLC, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        asl(ASL0)
+        extra("void *ovlc")
+        interest(4)
+        prompt("Old Output C")
+    }
+    field(OVLD, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        asl(ASL0)
+        extra("void *ovld")
+        interest(4)
+        prompt("Old Output D")
+    }
+    field(OVLE, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        asl(ASL0)
+        extra("void *ovle")
+        interest(4)
+        prompt("Old Output E")
+    }
+    field(OVLF, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        asl(ASL0)
+        extra("void *ovlf")
+        interest(4)
+        prompt("Old Output F")
+    }
+    field(OVLG, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        asl(ASL0)
+        extra("void *ovlg")
+        interest(4)
+        prompt("Old Output G")
+    }
+    field(OVLH, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        asl(ASL0)
+        extra("void *ovlh")
+        interest(4)
+        prompt("Old Output H")
+    }
+    field(OVLI, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        asl(ASL0)
+        extra("void *ovli")
+        interest(4)
+        prompt("Old Output I")
+    }
+    field(OVLJ, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        asl(ASL0)
+        extra("void *ovlj")
+        interest(4)
+        prompt("Old Output J")
+    }
+    field(OVLK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        asl(ASL0)
+        extra("void *ovlk")
+        interest(4)
+        prompt("Old Output K")
+    }
+    field(OVLL, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        asl(ASL0)
+        extra("void *ovll")
+        interest(4)
+        prompt("Old Output L")
+    }
+    field(OVLM, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        asl(ASL0)
+        extra("void *ovlm")
+        interest(4)
+        prompt("Old Output M")
+    }
+    field(OVLN, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        asl(ASL0)
+        extra("void *ovln")
+        interest(4)
+        prompt("Old Output N")
+    }
+    field(OVLO, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        asl(ASL0)
+        extra("void *ovlo")
+        interest(4)
+        prompt("Old Output O")
+    }
+    field(OVLP, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        asl(ASL0)
+        extra("void *ovlp")
+        interest(4)
+        prompt("Old Output P")
+    }
+    field(OVLQ, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        asl(ASL0)
+        extra("void *ovlq")
+        interest(4)
+        prompt("Old Output Q")
+    }
+    field(OVLR, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        asl(ASL0)
+        extra("void *ovlr")
+        interest(4)
+        prompt("Old Output R")
+    }
+    field(OVLS, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        asl(ASL0)
+        extra("void *ovls")
+        interest(4)
+        prompt("Old Output S")
+    }
+    field(OVLT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        asl(ASL0)
+        extra("void *ovlt")
+        interest(4)
+        prompt("Old Output T")
+    }
+    field(OVLU, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        asl(ASL0)
+        extra("void *ovlu")
+        interest(4)
+        prompt("Old Output U")
+    }
+    field(FTVA, DBF_MENU) {
+        promptgroup("51 - Output A-G")
+        special(SPC_NOMOD)
+        menu(menuFtype)
+        initial("DOUBLE")
+        interest(1)
+        prompt("Type of VALA")
+    }
+    field(FTVB, DBF_MENU) {
+        promptgroup("51 - Output A-G")
+        special(SPC_NOMOD)
+        menu(menuFtype)
+        initial("DOUBLE")
+        interest(1)
+        prompt("Type of VALB")
+    }
+    field(FTVC, DBF_MENU) {
+        promptgroup("51 - Output A-G")
+        special(SPC_NOMOD)
+        menu(menuFtype)
+        initial("DOUBLE")
+        interest(1)
+        prompt("Type of VALC")
+    }
+    field(FTVD, DBF_MENU) {
+        promptgroup("51 - Output A-G")
+        special(SPC_NOMOD)
+        menu(menuFtype)
+        initial("DOUBLE")
+        interest(1)
+        prompt("Type of VALD")
+    }
+    field(FTVE, DBF_MENU) {
+        promptgroup("51 - Output A-G")
+        special(SPC_NOMOD)
+        menu(menuFtype)
+        initial("DOUBLE")
+        interest(1)
+        prompt("Type of VALE")
+    }
+    field(FTVF, DBF_MENU) {
+        promptgroup("51 - Output A-G")
+        special(SPC_NOMOD)
+        menu(menuFtype)
+        initial("DOUBLE")
+        interest(1)
+        prompt("Type of VALF")
+    }
+    field(FTVG, DBF_MENU) {
+        promptgroup("51 - Output A-G")
+        special(SPC_NOMOD)
+        menu(menuFtype)
+        initial("DOUBLE")
+        interest(1)
+        prompt("Type of VALG")
+    }
+    field(FTVH, DBF_MENU) {
+        promptgroup("52 - Output H-N")
+        special(SPC_NOMOD)
+        menu(menuFtype)
+        initial("DOUBLE")
+        interest(1)
+        prompt("Type of VALH")
+    }
+    field(FTVI, DBF_MENU) {
+        promptgroup("52 - Output H-N")
+        special(SPC_NOMOD)
+        menu(menuFtype)
+        initial("DOUBLE")
+        interest(1)
+        prompt("Type of VALI")
+    }
+    field(FTVJ, DBF_MENU) {
+        promptgroup("52 - Output H-N")
+        special(SPC_NOMOD)
+        menu(menuFtype)
+        initial("DOUBLE")
+        interest(1)
+        prompt("Type of VALJ")
+    }
+    field(FTVK, DBF_MENU) {
+        promptgroup("52 - Output H-N")
+        special(SPC_NOMOD)
+        menu(menuFtype)
+        initial("DOUBLE")
+        interest(1)
+        prompt("Type of VALK")
+    }
+    field(FTVL, DBF_MENU) {
+        promptgroup("52 - Output H-N")
+        special(SPC_NOMOD)
+        menu(menuFtype)
+        initial("DOUBLE")
+        interest(1)
+        prompt("Type of VALL")
+    }
+    field(FTVM, DBF_MENU) {
+        promptgroup("52 - Output H-N")
+        special(SPC_NOMOD)
+        menu(menuFtype)
+        initial("DOUBLE")
+        interest(1)
+        prompt("Type of VALM")
+    }
+    field(FTVN, DBF_MENU) {
+        promptgroup("52 - Output H-N")
+        special(SPC_NOMOD)
+        menu(menuFtype)
+        initial("DOUBLE")
+        interest(1)
+        prompt("Type of VALN")
+    }
+    field(FTVO, DBF_MENU) {
+        promptgroup("53 - Output O-U")
+        special(SPC_NOMOD)
+        menu(menuFtype)
+        initial("DOUBLE")
+        interest(1)
+        prompt("Type of VALO")
+    }
+    field(FTVP, DBF_MENU) {
+        promptgroup("53 - Output O-U")
+        special(SPC_NOMOD)
+        menu(menuFtype)
+        initial("DOUBLE")
+        interest(1)
+        prompt("Type of VALP")
+    }
+    field(FTVQ, DBF_MENU) {
+        promptgroup("53 - Output O-U")
+        special(SPC_NOMOD)
+        menu(menuFtype)
+        initial("DOUBLE")
+        interest(1)
+        prompt("Type of VALQ")
+    }
+    field(FTVR, DBF_MENU) {
+        promptgroup("53 - Output O-U")
+        special(SPC_NOMOD)
+        menu(menuFtype)
+        initial("DOUBLE")
+        interest(1)
+        prompt("Type of VALR")
+    }
+    field(FTVS, DBF_MENU) {
+        promptgroup("53 - Output O-U")
+        special(SPC_NOMOD)
+        menu(menuFtype)
+        initial("DOUBLE")
+        interest(1)
+        prompt("Type of VALS")
+    }
+    field(FTVT, DBF_MENU) {
+        promptgroup("53 - Output O-U")
+        special(SPC_NOMOD)
+        menu(menuFtype)
+        initial("DOUBLE")
+        interest(1)
+        prompt("Type of VALT")
+    }
+    field(FTVU, DBF_MENU) {
+        promptgroup("53 - Output O-U")
+        special(SPC_NOMOD)
+        menu(menuFtype)
+        initial("DOUBLE")
+        interest(1)
+        prompt("Type of VALU")
+    }
+    field(NOVA, DBF_ULONG) {
+        promptgroup("51 - Output A-G")
+        special(SPC_NOMOD)
+        initial("1")
+        interest(1)
+        prompt("Max. elements in VALA")
+    }
+    field(NOVB, DBF_ULONG) {
+        promptgroup("51 - Output A-G")
+        special(SPC_NOMOD)
+        initial("1")
+        interest(1)
+        prompt("Max. elements in VALB")
+    }
+    field(NOVC, DBF_ULONG) {
+        promptgroup("51 - Output A-G")
+        special(SPC_NOMOD)
+        initial("1")
+        interest(1)
+        prompt("Max. elements in VALC")
+    }
+    field(NOVD, DBF_ULONG) {
+        promptgroup("51 - Output A-G")
+        special(SPC_NOMOD)
+        initial("1")
+        interest(1)
+        prompt("Max. elements in VALD")
+    }
+    field(NOVE, DBF_ULONG) {
+        promptgroup("51 - Output A-G")
+        special(SPC_NOMOD)
+        initial("1")
+        interest(1)
+        prompt("Max. elements in VALE")
+    }
+    field(NOVF, DBF_ULONG) {
+        promptgroup("51 - Output A-G")
+        special(SPC_NOMOD)
+        initial("1")
+        interest(1)
+        prompt("Max. elements in VALF")
+    }
+    field(NOVG, DBF_ULONG) {
+        promptgroup("51 - Output A-G")
+        special(SPC_NOMOD)
+        initial("1")
+        interest(1)
+        prompt("Max. elements in VALG")
+    }
+    field(NOVH, DBF_ULONG) {
+        promptgroup("52 - Output H-N")
+        special(SPC_NOMOD)
+        initial("1")
+        interest(1)
+        prompt("Max. elements in VAlH")
+    }
+    field(NOVI, DBF_ULONG) {
+        promptgroup("52 - Output H-N")
+        special(SPC_NOMOD)
+        initial("1")
+        interest(1)
+        prompt("Max. elements in VALI")
+    }
+    field(NOVJ, DBF_ULONG) {
+        promptgroup("52 - Output H-N")
+        special(SPC_NOMOD)
+        initial("1")
+        interest(1)
+        prompt("Max. elements in VALJ")
+    }
+    field(NOVK, DBF_ULONG) {
+        promptgroup("52 - Output H-N")
+        special(SPC_NOMOD)
+        initial("1")
+        interest(1)
+        prompt("Max. elements in VALK")
+    }
+    field(NOVL, DBF_ULONG) {
+        promptgroup("52 - Output H-N")
+        special(SPC_NOMOD)
+        initial("1")
+        interest(1)
+        prompt("Max. elements in VALL")
+    }
+    field(NOVM, DBF_ULONG) {
+        promptgroup("52 - Output H-N")
+        special(SPC_NOMOD)
+        initial("1")
+        interest(1)
+        prompt("Max. elements in VALM")
+    }
+    field(NOVN, DBF_ULONG) {
+        promptgroup("52 - Output H-N")
+        special(SPC_NOMOD)
+        initial("1")
+        interest(1)
+        prompt("Max. elements in VALN")
+    }
+    field(NOVO, DBF_ULONG) {
+        promptgroup("53 - Output O-U")
+        special(SPC_NOMOD)
+        initial("1")
+        interest(1)
+        prompt("Max. elements in VALO")
+    }
+    field(NOVP, DBF_ULONG) {
+        promptgroup("53 - Output O-U")
+        special(SPC_NOMOD)
+        initial("1")
+        interest(1)
+        prompt("Max. elements in VALP")
+    }
+    field(NOVQ, DBF_ULONG) {
+        promptgroup("53 - Output O-U")
+        special(SPC_NOMOD)
+        initial("1")
+        interest(1)
+        prompt("Max. elements in VALQ")
+    }
+    field(NOVR, DBF_ULONG) {
+        promptgroup("53 - Output O-U")
+        special(SPC_NOMOD)
+        initial("1")
+        interest(1)
+        prompt("Max. elements in VALR")
+    }
+    field(NOVS, DBF_ULONG) {
+        promptgroup("53 - Output O-U")
+        special(SPC_NOMOD)
+        initial("1")
+        interest(1)
+        prompt("Max. elements in VALS")
+    }
+    field(NOVT, DBF_ULONG) {
+        promptgroup("53 - Output O-U")
+        special(SPC_NOMOD)
+        initial("1")
+        interest(1)
+        prompt("Max. elements in VALT")
+    }
+    field(NOVU, DBF_ULONG) {
+        promptgroup("53 - Output O-U")
+        special(SPC_NOMOD)
+        initial("1")
+        interest(1)
+        prompt("Max. elements in VALU")
+    }
+    field(NEVA, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(3)
+        prompt("Num. elements in VALA")
+    }
+    field(NEVB, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(3)
+        prompt("Num. elements in VALB")
+    }
+    field(NEVC, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(3)
+        prompt("Num. elements in VALC")
+    }
+    field(NEVD, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(3)
+        prompt("Num. elements in VALD")
+    }
+    field(NEVE, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(3)
+        prompt("Num. elements in VALE")
+    }
+    field(NEVF, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(3)
+        prompt("Num. elements in VALF")
+    }
+    field(NEVG, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(3)
+        prompt("Num. elements in VALG")
+    }
+    field(NEVH, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(3)
+        prompt("Num. elements in VAlH")
+    }
+    field(NEVI, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(3)
+        prompt("Num. elements in VALI")
+    }
+    field(NEVJ, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(3)
+        prompt("Num. elements in VALJ")
+    }
+    field(NEVK, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(3)
+        prompt("Num. elements in VALK")
+    }
+    field(NEVL, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(3)
+        prompt("Num. elements in VALL")
+    }
+    field(NEVM, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(3)
+        prompt("Num. elements in VALM")
+    }
+    field(NEVN, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(3)
+        prompt("Num. elements in VALN")
+    }
+    field(NEVO, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(3)
+        prompt("Num. elements in VALO")
+    }
+    field(NEVP, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(3)
+        prompt("Num. elements in VALP")
+    }
+    field(NEVQ, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(3)
+        prompt("Num. elements in VALQ")
+    }
+    field(NEVR, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(3)
+        prompt("Num. elements in VALR")
+    }
+    field(NEVS, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(3)
+        prompt("Num. elements in VALS")
+    }
+    field(NEVT, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(3)
+        prompt("Num. elements in VALT")
+    }
+    field(NEVU, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(3)
+        prompt("Num. elements in VALU")
+    }
+    field(ONVA, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(4)
+        prompt("Num. elements in OVLA")
+    }
+    field(ONVB, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(4)
+        prompt("Num. elements in OVLB")
+    }
+    field(ONVC, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(4)
+        prompt("Num. elements in OVLC")
+    }
+    field(ONVD, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(4)
+        prompt("Num. elements in OVLD")
+    }
+    field(ONVE, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(4)
+        prompt("Num. elements in OVLE")
+    }
+    field(ONVF, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(4)
+        prompt("Num. elements in OVLF")
+    }
+    field(ONVG, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(4)
+        prompt("Num. elements in OVLG")
+    }
+    field(ONVH, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(4)
+        prompt("Num. elements in VAlH")
+    }
+    field(ONVI, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(4)
+        prompt("Num. elements in OVLI")
+    }
+    field(ONVJ, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(4)
+        prompt("Num. elements in OVLJ")
+    }
+    field(ONVK, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(4)
+        prompt("Num. elements in OVLK")
+    }
+    field(ONVL, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(4)
+        prompt("Num. elements in OVLL")
+    }
+    field(ONVM, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(4)
+        prompt("Num. elements in OVLM")
+    }
+    field(ONVN, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(4)
+        prompt("Num. elements in OVLN")
+    }
+    field(ONVO, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(4)
+        prompt("Num. elements in OVLO")
+    }
+    field(ONVP, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(4)
+        prompt("Num. elements in OVLP")
+    }
+    field(ONVQ, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(4)
+        prompt("Num. elements in OVLQ")
+    }
+    field(ONVR, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(4)
+        prompt("Num. elements in OVLR")
+    }
+    field(ONVS, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(4)
+        prompt("Num. elements in OVLS")
+    }
+    field(ONVT, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(4)
+        prompt("Num. elements in OVLT")
+    }
+    field(ONVU, DBF_ULONG) {
+        special(SPC_NOMOD)
+        initial("1")
+        interest(4)
+        prompt("Num. elements in OVLU")
+    }
 }
 recordtype(sub) {
-	field(NAME,DBF_STRING) {
-		prompt("Record Name")
-		special(SPC_NOMOD)
-		size(61)
-	}
-	field(DESC,DBF_STRING) {
-		prompt("Descriptor")
-		promptgroup(GUI_COMMON)
-		size(41)
-	}
-	field(ASG,DBF_STRING) {
-		prompt("Access Security Group")
-		promptgroup(GUI_COMMON)
-		special(SPC_AS)
-		size(29)
-	}
-	field(SCAN,DBF_MENU) {
-		prompt("Scan Mechanism")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuScan)
-		interest(1)
-	}
-	field(PINI,DBF_MENU) {
-		prompt("Process at iocInit")
-		promptgroup(GUI_SCAN)
-		menu(menuPini)
-		interest(1)
-	}
-	field(PHAS,DBF_SHORT) {
-		prompt("Scan Phase")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(EVNT,DBF_SHORT) {
-		prompt("Event Number")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(TSE,DBF_SHORT) {
-		prompt("Time Stamp Event")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(TSEL,DBF_INLINK) {
-		prompt("Time Stamp Link")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(DTYP,DBF_DEVICE) {
-		prompt("Device Type")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(DISV,DBF_SHORT) {
-		prompt("Disable Value")
-		initial("1")
-		promptgroup(GUI_SCAN)
-	}
-	field(DISA,DBF_SHORT) {
-		prompt("Disable")
-	}
-	field(SDIS,DBF_INLINK) {
-		prompt("Scanning Disable")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(MLOK,DBF_NOACCESS) {
-		prompt("Monitor lock")
-		special(SPC_NOMOD)
-		extra("epicsMutexId	mlok")
-		interest(4)
-	}
-	field(MLIS,DBF_NOACCESS) {
-		prompt("Monitor List")
-		special(SPC_NOMOD)
-		extra("ELLLIST		mlis")
-		interest(4)
-	}
-	field(DISP,DBF_UCHAR) {
-		prompt("Disable putField")
-	}
-	field(PROC,DBF_UCHAR) {
-		prompt("Force Processing")
-		pp(TRUE)
-		interest(3)
-	}
-	field(STAT,DBF_MENU) {
-		prompt("Alarm Status")
-		initial("UDF")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-	}
-	field(SEVR,DBF_MENU) {
-		prompt("Alarm Severity")
-		initial("INVALID")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-	}
-	field(NSTA,DBF_MENU) {
-		prompt("New Alarm Status")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-		interest(2)
-	}
-	field(NSEV,DBF_MENU) {
-		prompt("New Alarm Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKS,DBF_MENU) {
-		prompt("Alarm Ack Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKT,DBF_MENU) {
-		prompt("Alarm Ack Transient")
-		initial("YES")
-		promptgroup(GUI_ALARMS)
-		special(SPC_NOMOD)
-		menu(menuYesNo)
-		interest(2)
-	}
-	field(DISS,DBF_MENU) {
-		prompt("Disable Alarm Sevrty")
-		promptgroup(GUI_SCAN)
-		menu(menuAlarmSevr)
-		interest(1)
-	}
-	field(LCNT,DBF_UCHAR) {
-		prompt("Lock Count")
-		special(SPC_NOMOD)
-		interest(2)
-	}
-	field(PACT,DBF_UCHAR) {
-		prompt("Record active")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(PUTF,DBF_UCHAR) {
-		prompt("dbPutField process")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(RPRO,DBF_UCHAR) {
-		prompt("Reprocess ")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(ASP,DBF_NOACCESS) {
-		prompt("Access Security Pvt")
-		special(SPC_NOMOD)
-		extra("struct asgMember *asp")
-		interest(4)
-	}
-	field(PPN,DBF_NOACCESS) {
-		prompt("addr of PUTNOTIFY")
-		special(SPC_NOMOD)
-		extra("struct putNotify *ppn")
-		interest(4)
-	}
-	field(PPNR,DBF_NOACCESS) {
-		prompt("pputNotifyRecord")
-		special(SPC_NOMOD)
-		extra("struct putNotifyRecord *ppnr")
-		interest(4)
-	}
-	field(SPVT,DBF_NOACCESS) {
-		prompt("Scan Private")
-		special(SPC_NOMOD)
-		extra("struct scan_element *spvt")
-		interest(4)
-	}
-	field(RSET,DBF_NOACCESS) {
-		prompt("Address of RSET")
-		special(SPC_NOMOD)
-		extra("struct rset	*rset")
-		interest(4)
-	}
-	field(DSET,DBF_NOACCESS) {
-		prompt("DSET address")
-		special(SPC_NOMOD)
-		extra("struct dset	*dset")
-		interest(4)
-	}
-	field(DPVT,DBF_NOACCESS) {
-		prompt("Device Private")
-		special(SPC_NOMOD)
-		extra("void		*dpvt")
-		interest(4)
-	}
-	field(RDES,DBF_NOACCESS) {
-		prompt("Address of dbRecordType")
-		special(SPC_NOMOD)
-		extra("struct dbRecordType *rdes")
-		interest(4)
-	}
-	field(LSET,DBF_NOACCESS) {
-		prompt("Lock Set")
-		special(SPC_NOMOD)
-		extra("struct lockRecord *lset")
-		interest(4)
-	}
-	field(PRIO,DBF_MENU) {
-		prompt("Scheduling Priority")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuPriority)
-		interest(1)
-	}
-	field(TPRO,DBF_UCHAR) {
-		prompt("Trace Processing")
-	}
-	field(BKPT,DBF_NOACCESS) {
-		prompt("Break Point")
-		special(SPC_NOMOD)
-		extra("char bkpt")
-		interest(1)
-	}
-	field(UDF,DBF_UCHAR) {
-		prompt("Undefined")
-		initial("1")
-		promptgroup(GUI_COMMON)
-		pp(TRUE)
-		interest(1)
-	}
-	field(TIME,DBF_NOACCESS) {
-		prompt("Time")
-		special(SPC_NOMOD)
-		extra("epicsTimeStamp	time")
-		interest(2)
-	}
-	field(FLNK,DBF_FWDLINK) {
-		prompt("Forward Process Link")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(VAL,DBF_DOUBLE) {
-		prompt("Result")
-		pp(TRUE)
-		asl(ASL0)
-	}
-	field(INAM,DBF_STRING) {
-		prompt("Init Routine Name")
-		promptgroup(GUI_SUB)
-		special(SPC_NOMOD)
-		size(40)
-		interest(1)
-	}
-	field(SNAM,DBF_STRING) {
-		prompt("Subroutine Name")
-		promptgroup(GUI_SUB)
-		special(100)
-		size(40)
-		interest(1)
-	}
-	field(SADR,DBF_NOACCESS) {
-		prompt("Subroutine Address")
-		special(SPC_NOMOD)
-		extra("SUBFUNCPTR sadr")
-		interest(4)
-	}
-	field(INPA,DBF_INLINK) {
-		prompt("Input A")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(INPB,DBF_INLINK) {
-		prompt("Input B")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(INPC,DBF_INLINK) {
-		prompt("Input C")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(INPD,DBF_INLINK) {
-		prompt("Input D")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(INPE,DBF_INLINK) {
-		prompt("Input E")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(INPF,DBF_INLINK) {
-		prompt("Input F")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(INPG,DBF_INLINK) {
-		prompt("Input G")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(INPH,DBF_INLINK) {
-		prompt("Input H")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(INPI,DBF_INLINK) {
-		prompt("Input I")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(INPJ,DBF_INLINK) {
-		prompt("Input J")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(INPK,DBF_INLINK) {
-		prompt("Input K")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(INPL,DBF_INLINK) {
-		prompt("Input L")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(EGU,DBF_STRING) {
-		prompt("Units Name")
-		promptgroup(GUI_DISPLAY)
-		size(16)
-		interest(1)
-	}
-	field(HOPR,DBF_DOUBLE) {
-		prompt("High Operating Rng")
-		promptgroup(GUI_DISPLAY)
-		interest(1)
-	}
-	field(LOPR,DBF_DOUBLE) {
-		prompt("Low Operating Range")
-		promptgroup(GUI_DISPLAY)
-		interest(1)
-	}
-	field(HIHI,DBF_DOUBLE) {
-		prompt("Hihi Alarm Limit")
-		promptgroup(GUI_ALARMS)
-		pp(TRUE)
-		interest(1)
-	}
-	field(LOLO,DBF_DOUBLE) {
-		prompt("Lolo Alarm Limit")
-		promptgroup(GUI_ALARMS)
-		pp(TRUE)
-		interest(1)
-	}
-	field(HIGH,DBF_DOUBLE) {
-		prompt("High Alarm Limit")
-		promptgroup(GUI_ALARMS)
-		pp(TRUE)
-		interest(1)
-	}
-	field(LOW,DBF_DOUBLE) {
-		prompt("Low Alarm Limit")
-		promptgroup(GUI_ALARMS)
-		pp(TRUE)
-		interest(1)
-	}
-	field(PREC,DBF_SHORT) {
-		prompt("Display Precision")
-		promptgroup(GUI_DISPLAY)
-		interest(1)
-	}
-	field(BRSV,DBF_MENU) {
-		prompt("Bad Return Severity")
-		promptgroup(GUI_SUB)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(HHSV,DBF_MENU) {
-		prompt("Hihi Severity")
-		promptgroup(GUI_ALARMS)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(LLSV,DBF_MENU) {
-		prompt("Lolo Severity")
-		promptgroup(GUI_ALARMS)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(HSV,DBF_MENU) {
-		prompt("High Severity")
-		promptgroup(GUI_ALARMS)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(LSV,DBF_MENU) {
-		prompt("Low Severity")
-		promptgroup(GUI_ALARMS)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(1)
-	}
-	field(HYST,DBF_DOUBLE) {
-		prompt("Alarm Deadband")
-		promptgroup(GUI_ALARMS)
-		interest(1)
-	}
-	field(ADEL,DBF_DOUBLE) {
-		prompt("Archive Deadband")
-		promptgroup(GUI_DISPLAY)
-		interest(1)
-	}
-	field(MDEL,DBF_DOUBLE) {
-		prompt("Monitor Deadband")
-		promptgroup(GUI_DISPLAY)
-		interest(1)
-	}
-	field(A,DBF_DOUBLE) {
-		prompt("Value of Input A")
-		pp(TRUE)
-	}
-	field(B,DBF_DOUBLE) {
-		prompt("Value of Input B")
-		pp(TRUE)
-	}
-	field(C,DBF_DOUBLE) {
-		prompt("Value of Input C")
-		pp(TRUE)
-	}
-	field(D,DBF_DOUBLE) {
-		prompt("Value of Input D")
-		pp(TRUE)
-	}
-	field(E,DBF_DOUBLE) {
-		prompt("Value of Input E")
-		pp(TRUE)
-	}
-	field(F,DBF_DOUBLE) {
-		prompt("Value of Input F")
-		pp(TRUE)
-	}
-	field(G,DBF_DOUBLE) {
-		prompt("Value of Input G")
-		pp(TRUE)
-	}
-	field(H,DBF_DOUBLE) {
-		prompt("Value of Input H")
-		pp(TRUE)
-	}
-	field(I,DBF_DOUBLE) {
-		prompt("Value of Input I")
-		pp(TRUE)
-	}
-	field(J,DBF_DOUBLE) {
-		prompt("Value of Input J")
-		pp(TRUE)
-	}
-	field(K,DBF_DOUBLE) {
-		prompt("Value of Input K")
-		pp(TRUE)
-	}
-	field(L,DBF_DOUBLE) {
-		prompt("Value of Input L")
-		pp(TRUE)
-	}
-	field(LA,DBF_DOUBLE) {
-		prompt("Prev Value of A")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(LB,DBF_DOUBLE) {
-		prompt("Prev Value of B")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(LC,DBF_DOUBLE) {
-		prompt("Prev Value of C")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(LD,DBF_DOUBLE) {
-		prompt("Prev Value of D")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(LE,DBF_DOUBLE) {
-		prompt("Prev Value of E")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(LF,DBF_DOUBLE) {
-		prompt("Prev Value of F")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(LG,DBF_DOUBLE) {
-		prompt("Prev Value of G")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(LH,DBF_DOUBLE) {
-		prompt("Prev Value of H")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(LI,DBF_DOUBLE) {
-		prompt("Prev Value of I")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(LJ,DBF_DOUBLE) {
-		prompt("Prev Value of J")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(LK,DBF_DOUBLE) {
-		prompt("Prev Value of K")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(LL,DBF_DOUBLE) {
-		prompt("Prev Value of L")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(LALM,DBF_DOUBLE) {
-		prompt("Last Value Alarmed")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(ALST,DBF_DOUBLE) {
-		prompt("Last Value Archived")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(MLST,DBF_DOUBLE) {
-		prompt("Last Value Monitored")
-		special(SPC_NOMOD)
-		interest(3)
-	}
+    %#include "epicsTypes.h"
+    %#include "link.h"
+    %#include "epicsMutex.h"
+    %#include "ellLib.h"
+    %#include "epicsTime.h"
+    %struct subRecord;
+    %typedef long (*SUBFUNCPTR)(struct subRecord *);
+    field(NAME, DBF_STRING) {
+        special(SPC_NOMOD)
+        size(61)
+        prompt("Record Name")
+    }
+    field(DESC, DBF_STRING) {
+        promptgroup("10 - Common")
+        size(41)
+        prompt("Descriptor")
+    }
+    field(ASG, DBF_STRING) {
+        promptgroup("10 - Common")
+        special(SPC_AS)
+        size(29)
+        prompt("Access Security Group")
+    }
+    field(SCAN, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuScan)
+        interest(1)
+        prompt("Scan Mechanism")
+    }
+    field(PINI, DBF_MENU) {
+        promptgroup("20 - Scan")
+        menu(menuPini)
+        interest(1)
+        prompt("Process at iocInit")
+    }
+    field(PHAS, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        prompt("Scan Phase")
+    }
+    field(EVNT, DBF_STRING) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        size(40)
+        prompt("Event Name")
+    }
+    field(TSE, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Event")
+    }
+    field(TSEL, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Link")
+    }
+    field(DTYP, DBF_DEVICE) {
+        promptgroup("10 - Common")
+        interest(1)
+        prompt("Device Type")
+    }
+    field(DISV, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        initial("1")
+        prompt("Disable Value")
+    }
+    field(DISA, DBF_SHORT) {
+        prompt("Disable")
+    }
+    field(SDIS, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Scanning Disable")
+    }
+    field(MLOK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsMutexId        mlok")
+        interest(4)
+        prompt("Monitor lock")
+    }
+    field(MLIS, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             mlis")
+        interest(4)
+        prompt("Monitor List")
+    }
+    field(BKLNK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             bklnk")
+        interest(4)
+        prompt("Backwards link tracking")
+    }
+    field(DISP, DBF_UCHAR) {
+        prompt("Disable putField")
+    }
+    field(PROC, DBF_UCHAR) {
+        interest(3)
+        pp(TRUE)
+        prompt("Force Processing")
+    }
+    field(STAT, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        initial("UDF")
+        prompt("Alarm Status")
+    }
+    field(SEVR, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        prompt("Alarm Severity")
+    }
+    field(NSTA, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        interest(2)
+        prompt("New Alarm Status")
+    }
+    field(NSEV, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("New Alarm Severity")
+    }
+    field(ACKS, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("Alarm Ack Severity")
+    }
+    field(ACKT, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        special(SPC_NOMOD)
+        menu(menuYesNo)
+        initial("YES")
+        interest(2)
+        prompt("Alarm Ack Transient")
+    }
+    field(DISS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        prompt("Disable Alarm Sevrty")
+    }
+    field(LCNT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(2)
+        prompt("Lock Count")
+    }
+    field(PACT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Record active")
+    }
+    field(PUTF, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("dbPutField process")
+    }
+    field(RPRO, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Reprocess ")
+    }
+    field(ASP, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct asgMember    *asp")
+        interest(4)
+        prompt("Access Security Pvt")
+    }
+    field(PPN, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotify *ppn")
+        interest(4)
+        prompt("pprocessNotify")
+    }
+    field(PPNR, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotifyRecord *ppnr")
+        interest(4)
+        prompt("pprocessNotifyRecord")
+    }
+    field(SPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct scan_element *spvt")
+        interest(4)
+        prompt("Scan Private")
+    }
+    field(RSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct typed_rset   *rset")
+        interest(4)
+        prompt("Address of RSET")
+    }
+    field(DSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dset         *dset")
+        interest(4)
+        prompt("DSET address")
+    }
+    field(DPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("void                *dpvt")
+        interest(4)
+        prompt("Device Private")
+    }
+    field(RDES, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dbRecordType *rdes")
+        interest(4)
+        prompt("Address of dbRecordType")
+    }
+    field(LSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct lockRecord   *lset")
+        interest(4)
+        prompt("Lock Set")
+    }
+    field(PRIO, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuPriority)
+        interest(1)
+        prompt("Scheduling Priority")
+    }
+    field(TPRO, DBF_UCHAR) {
+        prompt("Trace Processing")
+    }
+    field(BKPT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("char                bkpt")
+        interest(1)
+        prompt("Break Point")
+    }
+    field(UDF, DBF_UCHAR) {
+        promptgroup("10 - Common")
+        initial("1")
+        interest(1)
+        pp(TRUE)
+        prompt("Undefined")
+    }
+    field(UDFS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        initial("INVALID")
+        interest(1)
+        prompt("Undefined Alarm Sevrty")
+    }
+    field(TIME, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsTimeStamp      time")
+        interest(2)
+        prompt("Time")
+    }
+    field(FLNK, DBF_FWDLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Forward Process Link")
+    }
+    field(VAL, DBF_DOUBLE) {
+        asl(ASL0)
+        pp(TRUE)
+        prompt("Result")
+    }
+    field(INAM, DBF_STRING) {
+        promptgroup("30 - Action")
+        special(SPC_NOMOD)
+        interest(1)
+        size(40)
+        prompt("Init Routine Name")
+    }
+    field(SNAM, DBF_STRING) {
+        promptgroup("30 - Action")
+        special(SPC_MOD)
+        interest(1)
+        size(40)
+        prompt("Subroutine Name")
+    }
+    field(SADR, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("SUBFUNCPTR sadr")
+        interest(4)
+        prompt("Subroutine Address")
+    }
+    field(INPA, DBF_INLINK) {
+        promptgroup("41 - Input A-F")
+        interest(1)
+        prompt("Input A")
+    }
+    field(INPB, DBF_INLINK) {
+        promptgroup("41 - Input A-F")
+        interest(1)
+        prompt("Input B")
+    }
+    field(INPC, DBF_INLINK) {
+        promptgroup("41 - Input A-F")
+        interest(1)
+        prompt("Input C")
+    }
+    field(INPD, DBF_INLINK) {
+        promptgroup("41 - Input A-F")
+        interest(1)
+        prompt("Input D")
+    }
+    field(INPE, DBF_INLINK) {
+        promptgroup("41 - Input A-F")
+        interest(1)
+        prompt("Input E")
+    }
+    field(INPF, DBF_INLINK) {
+        promptgroup("41 - Input A-F")
+        interest(1)
+        prompt("Input F")
+    }
+    field(INPG, DBF_INLINK) {
+        promptgroup("42 - Input G-L")
+        interest(1)
+        prompt("Input G")
+    }
+    field(INPH, DBF_INLINK) {
+        promptgroup("42 - Input G-L")
+        interest(1)
+        prompt("Input H")
+    }
+    field(INPI, DBF_INLINK) {
+        promptgroup("42 - Input G-L")
+        interest(1)
+        prompt("Input I")
+    }
+    field(INPJ, DBF_INLINK) {
+        promptgroup("42 - Input G-L")
+        interest(1)
+        prompt("Input J")
+    }
+    field(INPK, DBF_INLINK) {
+        promptgroup("42 - Input G-L")
+        interest(1)
+        prompt("Input K")
+    }
+    field(INPL, DBF_INLINK) {
+        promptgroup("42 - Input G-L")
+        interest(1)
+        prompt("Input L")
+    }
+    field(EGU, DBF_STRING) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        size(16)
+        prompt("Engineering Units")
+    }
+    field(HOPR, DBF_DOUBLE) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("High Operating Range")
+    }
+    field(LOPR, DBF_DOUBLE) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("Low Operating Range")
+    }
+    field(HIHI, DBF_DOUBLE) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        interest(1)
+        pp(TRUE)
+        prompt("Hihi Alarm Limit")
+    }
+    field(LOLO, DBF_DOUBLE) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        interest(1)
+        pp(TRUE)
+        prompt("Lolo Alarm Limit")
+    }
+    field(HIGH, DBF_DOUBLE) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        interest(1)
+        pp(TRUE)
+        prompt("High Alarm Limit")
+    }
+    field(LOW, DBF_DOUBLE) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        interest(1)
+        pp(TRUE)
+        prompt("Low Alarm Limit")
+    }
+    field(PREC, DBF_SHORT) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("Display Precision")
+    }
+    field(BRSV, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("Bad Return Severity")
+    }
+    field(HHSV, DBF_MENU) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("Hihi Severity")
+    }
+    field(LLSV, DBF_MENU) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("Lolo Severity")
+    }
+    field(HSV, DBF_MENU) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("High Severity")
+    }
+    field(LSV, DBF_MENU) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("Low Severity")
+    }
+    field(HYST, DBF_DOUBLE) {
+        promptgroup("70 - Alarm")
+        interest(1)
+        prompt("Alarm Deadband")
+    }
+    field(ADEL, DBF_DOUBLE) {
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("Archive Deadband")
+    }
+    field(MDEL, DBF_DOUBLE) {
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("Monitor Deadband")
+    }
+    field(A, DBF_DOUBLE) {
+        pp(TRUE)
+        prompt("Value of Input A")
+    }
+    field(B, DBF_DOUBLE) {
+        pp(TRUE)
+        prompt("Value of Input B")
+    }
+    field(C, DBF_DOUBLE) {
+        pp(TRUE)
+        prompt("Value of Input C")
+    }
+    field(D, DBF_DOUBLE) {
+        pp(TRUE)
+        prompt("Value of Input D")
+    }
+    field(E, DBF_DOUBLE) {
+        pp(TRUE)
+        prompt("Value of Input E")
+    }
+    field(F, DBF_DOUBLE) {
+        pp(TRUE)
+        prompt("Value of Input F")
+    }
+    field(G, DBF_DOUBLE) {
+        pp(TRUE)
+        prompt("Value of Input G")
+    }
+    field(H, DBF_DOUBLE) {
+        pp(TRUE)
+        prompt("Value of Input H")
+    }
+    field(I, DBF_DOUBLE) {
+        pp(TRUE)
+        prompt("Value of Input I")
+    }
+    field(J, DBF_DOUBLE) {
+        pp(TRUE)
+        prompt("Value of Input J")
+    }
+    field(K, DBF_DOUBLE) {
+        pp(TRUE)
+        prompt("Value of Input K")
+    }
+    field(L, DBF_DOUBLE) {
+        pp(TRUE)
+        prompt("Value of Input L")
+    }
+    field(LA, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Prev Value of A")
+    }
+    field(LB, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Prev Value of B")
+    }
+    field(LC, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Prev Value of C")
+    }
+    field(LD, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Prev Value of D")
+    }
+    field(LE, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Prev Value of E")
+    }
+    field(LF, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Prev Value of F")
+    }
+    field(LG, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Prev Value of G")
+    }
+    field(LH, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Prev Value of H")
+    }
+    field(LI, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Prev Value of I")
+    }
+    field(LJ, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Prev Value of J")
+    }
+    field(LK, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Prev Value of K")
+    }
+    field(LL, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Prev Value of L")
+    }
+    field(LALM, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Last Value Alarmed")
+    }
+    field(ALST, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Last Value Archived")
+    }
+    field(MLST, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Last Value Monitored")
+    }
 }
-recordtype(subArray) {
-	field(NAME,DBF_STRING) {
-		prompt("Record Name")
-		special(SPC_NOMOD)
-		size(61)
-	}
-	field(DESC,DBF_STRING) {
-		prompt("Descriptor")
-		promptgroup(GUI_COMMON)
-		size(41)
-	}
-	field(ASG,DBF_STRING) {
-		prompt("Access Security Group")
-		promptgroup(GUI_COMMON)
-		special(SPC_AS)
-		size(29)
-	}
-	field(SCAN,DBF_MENU) {
-		prompt("Scan Mechanism")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuScan)
-		interest(1)
-	}
-	field(PINI,DBF_MENU) {
-		prompt("Process at iocInit")
-		promptgroup(GUI_SCAN)
-		menu(menuPini)
-		interest(1)
-	}
-	field(PHAS,DBF_SHORT) {
-		prompt("Scan Phase")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(EVNT,DBF_SHORT) {
-		prompt("Event Number")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(TSE,DBF_SHORT) {
-		prompt("Time Stamp Event")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(TSEL,DBF_INLINK) {
-		prompt("Time Stamp Link")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(DTYP,DBF_DEVICE) {
-		prompt("Device Type")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(DISV,DBF_SHORT) {
-		prompt("Disable Value")
-		initial("1")
-		promptgroup(GUI_SCAN)
-	}
-	field(DISA,DBF_SHORT) {
-		prompt("Disable")
-	}
-	field(SDIS,DBF_INLINK) {
-		prompt("Scanning Disable")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(MLOK,DBF_NOACCESS) {
-		prompt("Monitor lock")
-		special(SPC_NOMOD)
-		extra("epicsMutexId	mlok")
-		interest(4)
-	}
-	field(MLIS,DBF_NOACCESS) {
-		prompt("Monitor List")
-		special(SPC_NOMOD)
-		extra("ELLLIST		mlis")
-		interest(4)
-	}
-	field(DISP,DBF_UCHAR) {
-		prompt("Disable putField")
-	}
-	field(PROC,DBF_UCHAR) {
-		prompt("Force Processing")
-		pp(TRUE)
-		interest(3)
-	}
-	field(STAT,DBF_MENU) {
-		prompt("Alarm Status")
-		initial("UDF")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-	}
-	field(SEVR,DBF_MENU) {
-		prompt("Alarm Severity")
-		initial("INVALID")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-	}
-	field(NSTA,DBF_MENU) {
-		prompt("New Alarm Status")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-		interest(2)
-	}
-	field(NSEV,DBF_MENU) {
-		prompt("New Alarm Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKS,DBF_MENU) {
-		prompt("Alarm Ack Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKT,DBF_MENU) {
-		prompt("Alarm Ack Transient")
-		initial("YES")
-		promptgroup(GUI_ALARMS)
-		special(SPC_NOMOD)
-		menu(menuYesNo)
-		interest(2)
-	}
-	field(DISS,DBF_MENU) {
-		prompt("Disable Alarm Sevrty")
-		promptgroup(GUI_SCAN)
-		menu(menuAlarmSevr)
-		interest(1)
-	}
-	field(LCNT,DBF_UCHAR) {
-		prompt("Lock Count")
-		special(SPC_NOMOD)
-		interest(2)
-	}
-	field(PACT,DBF_UCHAR) {
-		prompt("Record active")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(PUTF,DBF_UCHAR) {
-		prompt("dbPutField process")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(RPRO,DBF_UCHAR) {
-		prompt("Reprocess ")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(ASP,DBF_NOACCESS) {
-		prompt("Access Security Pvt")
-		special(SPC_NOMOD)
-		extra("struct asgMember *asp")
-		interest(4)
-	}
-	field(PPN,DBF_NOACCESS) {
-		prompt("addr of PUTNOTIFY")
-		special(SPC_NOMOD)
-		extra("struct putNotify *ppn")
-		interest(4)
-	}
-	field(PPNR,DBF_NOACCESS) {
-		prompt("pputNotifyRecord")
-		special(SPC_NOMOD)
-		extra("struct putNotifyRecord *ppnr")
-		interest(4)
-	}
-	field(SPVT,DBF_NOACCESS) {
-		prompt("Scan Private")
-		special(SPC_NOMOD)
-		extra("struct scan_element *spvt")
-		interest(4)
-	}
-	field(RSET,DBF_NOACCESS) {
-		prompt("Address of RSET")
-		special(SPC_NOMOD)
-		extra("struct rset	*rset")
-		interest(4)
-	}
-	field(DSET,DBF_NOACCESS) {
-		prompt("DSET address")
-		special(SPC_NOMOD)
-		extra("struct dset	*dset")
-		interest(4)
-	}
-	field(DPVT,DBF_NOACCESS) {
-		prompt("Device Private")
-		special(SPC_NOMOD)
-		extra("void		*dpvt")
-		interest(4)
-	}
-	field(RDES,DBF_NOACCESS) {
-		prompt("Address of dbRecordType")
-		special(SPC_NOMOD)
-		extra("struct dbRecordType *rdes")
-		interest(4)
-	}
-	field(LSET,DBF_NOACCESS) {
-		prompt("Lock Set")
-		special(SPC_NOMOD)
-		extra("struct lockRecord *lset")
-		interest(4)
-	}
-	field(PRIO,DBF_MENU) {
-		prompt("Scheduling Priority")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuPriority)
-		interest(1)
-	}
-	field(TPRO,DBF_UCHAR) {
-		prompt("Trace Processing")
-	}
-	field(BKPT,DBF_NOACCESS) {
-		prompt("Break Point")
-		special(SPC_NOMOD)
-		extra("char bkpt")
-		interest(1)
-	}
-	field(UDF,DBF_UCHAR) {
-		prompt("Undefined")
-		initial("1")
-		promptgroup(GUI_COMMON)
-		pp(TRUE)
-		interest(1)
-	}
-	field(TIME,DBF_NOACCESS) {
-		prompt("Time")
-		special(SPC_NOMOD)
-		extra("epicsTimeStamp	time")
-		interest(2)
-	}
-	field(FLNK,DBF_FWDLINK) {
-		prompt("Forward Process Link")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(VAL,DBF_NOACCESS) {
-		prompt("Value")
-		special(SPC_DBADDR)
-		extra("void *		val")
-		pp(TRUE)
-		asl(ASL0)
-	}
-	field(PREC,DBF_SHORT) {
-		prompt("Display Precision")
-		promptgroup(GUI_COMMON)
-		interest(1)
-	}
-	field(FTVL,DBF_MENU) {
-		prompt("Field Type of Value")
-		promptgroup(GUI_ALARMS)
-		special(SPC_NOMOD)
-		menu(menuFtype)
-		interest(1)
-	}
-	field(INP,DBF_INLINK) {
-		prompt("Input Specification")
-		promptgroup(GUI_BITS1)
-		interest(1)
-	}
-	field(EGU,DBF_STRING) {
-		prompt("Engineering Units Name")
-		promptgroup(GUI_BITS2)
-		size(16)
-		interest(1)
-	}
-	field(HOPR,DBF_DOUBLE) {
-		prompt("High Operating Range")
-		promptgroup(GUI_CALC)
-		interest(1)
-	}
-	field(LOPR,DBF_DOUBLE) {
-		prompt("Low Operating Range")
-		promptgroup(GUI_CLOCK)
-		interest(1)
-	}
-	field(MALM,DBF_ULONG) {
-		prompt("Maximum Elements  ")
-		initial("1")
-		promptgroup(GUI_CLOCK)
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(NELM,DBF_ULONG) {
-		prompt("Number of Elements")
-		initial("1")
-		promptgroup(GUI_COMPRESS)
-		pp(TRUE)
-	}
-	field(INDX,DBF_ULONG) {
-		prompt("Substring Index")
-		promptgroup(GUI_CONVERT)
-		pp(TRUE)
-	}
-	field(BUSY,DBF_SHORT) {
-		prompt("Busy Indicator")
-		special(SPC_NOMOD)
-	}
-	field(NORD,DBF_LONG) {
-		prompt("Number elements read")
-		special(SPC_NOMOD)
-	}
-	field(BPTR,DBF_NOACCESS) {
-		prompt("Buffer Pointer")
-		special(SPC_NOMOD)
-		extra("void *		bptr")
-		interest(4)
-	}
+recordtype(int64in) {
+    %#include "epicsTypes.h"
+    %#include "link.h"
+    %#include "epicsMutex.h"
+    %#include "ellLib.h"
+    %#include "epicsTime.h"
+    %#include "callback.h"
+    field(NAME, DBF_STRING) {
+        special(SPC_NOMOD)
+        size(61)
+        prompt("Record Name")
+    }
+    field(DESC, DBF_STRING) {
+        promptgroup("10 - Common")
+        size(41)
+        prompt("Descriptor")
+    }
+    field(ASG, DBF_STRING) {
+        promptgroup("10 - Common")
+        special(SPC_AS)
+        size(29)
+        prompt("Access Security Group")
+    }
+    field(SCAN, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuScan)
+        interest(1)
+        prompt("Scan Mechanism")
+    }
+    field(PINI, DBF_MENU) {
+        promptgroup("20 - Scan")
+        menu(menuPini)
+        interest(1)
+        prompt("Process at iocInit")
+    }
+    field(PHAS, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        prompt("Scan Phase")
+    }
+    field(EVNT, DBF_STRING) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        size(40)
+        prompt("Event Name")
+    }
+    field(TSE, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Event")
+    }
+    field(TSEL, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Link")
+    }
+    field(DTYP, DBF_DEVICE) {
+        promptgroup("10 - Common")
+        interest(1)
+        prompt("Device Type")
+    }
+    field(DISV, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        initial("1")
+        prompt("Disable Value")
+    }
+    field(DISA, DBF_SHORT) {
+        prompt("Disable")
+    }
+    field(SDIS, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Scanning Disable")
+    }
+    field(MLOK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsMutexId        mlok")
+        interest(4)
+        prompt("Monitor lock")
+    }
+    field(MLIS, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             mlis")
+        interest(4)
+        prompt("Monitor List")
+    }
+    field(BKLNK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             bklnk")
+        interest(4)
+        prompt("Backwards link tracking")
+    }
+    field(DISP, DBF_UCHAR) {
+        prompt("Disable putField")
+    }
+    field(PROC, DBF_UCHAR) {
+        interest(3)
+        pp(TRUE)
+        prompt("Force Processing")
+    }
+    field(STAT, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        initial("UDF")
+        prompt("Alarm Status")
+    }
+    field(SEVR, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        prompt("Alarm Severity")
+    }
+    field(NSTA, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        interest(2)
+        prompt("New Alarm Status")
+    }
+    field(NSEV, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("New Alarm Severity")
+    }
+    field(ACKS, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("Alarm Ack Severity")
+    }
+    field(ACKT, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        special(SPC_NOMOD)
+        menu(menuYesNo)
+        initial("YES")
+        interest(2)
+        prompt("Alarm Ack Transient")
+    }
+    field(DISS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        prompt("Disable Alarm Sevrty")
+    }
+    field(LCNT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(2)
+        prompt("Lock Count")
+    }
+    field(PACT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Record active")
+    }
+    field(PUTF, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("dbPutField process")
+    }
+    field(RPRO, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Reprocess ")
+    }
+    field(ASP, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct asgMember    *asp")
+        interest(4)
+        prompt("Access Security Pvt")
+    }
+    field(PPN, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotify *ppn")
+        interest(4)
+        prompt("pprocessNotify")
+    }
+    field(PPNR, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotifyRecord *ppnr")
+        interest(4)
+        prompt("pprocessNotifyRecord")
+    }
+    field(SPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct scan_element *spvt")
+        interest(4)
+        prompt("Scan Private")
+    }
+    field(RSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct typed_rset   *rset")
+        interest(4)
+        prompt("Address of RSET")
+    }
+    field(DSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dset         *dset")
+        interest(4)
+        prompt("DSET address")
+    }
+    field(DPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("void                *dpvt")
+        interest(4)
+        prompt("Device Private")
+    }
+    field(RDES, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dbRecordType *rdes")
+        interest(4)
+        prompt("Address of dbRecordType")
+    }
+    field(LSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct lockRecord   *lset")
+        interest(4)
+        prompt("Lock Set")
+    }
+    field(PRIO, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuPriority)
+        interest(1)
+        prompt("Scheduling Priority")
+    }
+    field(TPRO, DBF_UCHAR) {
+        prompt("Trace Processing")
+    }
+    field(BKPT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("char                bkpt")
+        interest(1)
+        prompt("Break Point")
+    }
+    field(UDF, DBF_UCHAR) {
+        promptgroup("10 - Common")
+        initial("1")
+        interest(1)
+        pp(TRUE)
+        prompt("Undefined")
+    }
+    field(UDFS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        initial("INVALID")
+        interest(1)
+        prompt("Undefined Alarm Sevrty")
+    }
+    field(TIME, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsTimeStamp      time")
+        interest(2)
+        prompt("Time")
+    }
+    field(FLNK, DBF_FWDLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Forward Process Link")
+    }
+    field(VAL, DBF_INT64) {
+        promptgroup("40 - Input")
+        asl(ASL0)
+        pp(TRUE)
+        prompt("Current value")
+    }
+    field(INP, DBF_INLINK) {
+        promptgroup("40 - Input")
+        interest(1)
+        prompt("Input Specification")
+    }
+    field(EGU, DBF_STRING) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        size(16)
+        prompt("Units name")
+    }
+    field(HOPR, DBF_INT64) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("High Operating Range")
+    }
+    field(LOPR, DBF_INT64) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("Low Operating Range")
+    }
+    field(HIHI, DBF_INT64) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        interest(1)
+        pp(TRUE)
+        prompt("Hihi Alarm Limit")
+    }
+    field(LOLO, DBF_INT64) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        interest(1)
+        pp(TRUE)
+        prompt("Lolo Alarm Limit")
+    }
+    field(HIGH, DBF_INT64) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        interest(1)
+        pp(TRUE)
+        prompt("High Alarm Limit")
+    }
+    field(LOW, DBF_INT64) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        interest(1)
+        pp(TRUE)
+        prompt("Low Alarm Limit")
+    }
+    field(HHSV, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("Hihi Severity")
+    }
+    field(LLSV, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("Lolo Severity")
+    }
+    field(HSV, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("High Severity")
+    }
+    field(LSV, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("Low Severity")
+    }
+    field(HYST, DBF_INT64) {
+        promptgroup("70 - Alarm")
+        interest(1)
+        prompt("Alarm Deadband")
+    }
+    field(AFTC, DBF_DOUBLE) {
+        promptgroup("70 - Alarm")
+        interest(1)
+        prompt("Alarm Filter Time Constant")
+    }
+    field(AFVL, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Alarm Filter Value")
+    }
+    field(ADEL, DBF_INT64) {
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("Archive Deadband")
+    }
+    field(MDEL, DBF_INT64) {
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("Monitor Deadband")
+    }
+    field(LALM, DBF_INT64) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Last Value Alarmed")
+    }
+    field(ALST, DBF_INT64) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Last Value Archived")
+    }
+    field(MLST, DBF_INT64) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Last Val Monitored")
+    }
+    field(SIOL, DBF_INLINK) {
+        promptgroup("90 - Simulate")
+        interest(1)
+        prompt("Simulation Input Link")
+    }
+    field(SVAL, DBF_INT64) {
+        prompt("Simulation Value")
+    }
+    field(SIML, DBF_INLINK) {
+        promptgroup("90 - Simulate")
+        interest(1)
+        prompt("Simulation Mode Link")
+    }
+    field(SIMM, DBF_MENU) {
+        special(SPC_MOD)
+        menu(menuYesNo)
+        interest(1)
+        prompt("Simulation Mode")
+    }
+    field(SIMS, DBF_MENU) {
+        promptgroup("90 - Simulate")
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("Simulation Mode Severity")
+    }
+    field(OLDSIMM, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuSimm)
+        interest(4)
+        prompt("Prev. Simulation Mode")
+    }
+    field(SSCN, DBF_MENU) {
+        promptgroup("90 - Simulate")
+        menu(menuScan)
+        initial("65535")
+        interest(1)
+        prompt("Sim. Mode Scan")
+    }
+    field(SDLY, DBF_DOUBLE) {
+        promptgroup("90 - Simulate")
+        initial("-1.0")
+        interest(2)
+        prompt("Sim. Mode Async Delay")
+    }
+    field(SIMPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("CALLBACK            *simpvt")
+        interest(4)
+        prompt("Sim. Mode Private")
+    }
 }
-recordtype(waveform) {
-	field(NAME,DBF_STRING) {
-		prompt("Record Name")
-		special(SPC_NOMOD)
-		size(61)
-	}
-	field(DESC,DBF_STRING) {
-		prompt("Descriptor")
-		promptgroup(GUI_COMMON)
-		size(41)
-	}
-	field(ASG,DBF_STRING) {
-		prompt("Access Security Group")
-		promptgroup(GUI_COMMON)
-		special(SPC_AS)
-		size(29)
-	}
-	field(SCAN,DBF_MENU) {
-		prompt("Scan Mechanism")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuScan)
-		interest(1)
-	}
-	field(PINI,DBF_MENU) {
-		prompt("Process at iocInit")
-		promptgroup(GUI_SCAN)
-		menu(menuPini)
-		interest(1)
-	}
-	field(PHAS,DBF_SHORT) {
-		prompt("Scan Phase")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(EVNT,DBF_SHORT) {
-		prompt("Event Number")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(TSE,DBF_SHORT) {
-		prompt("Time Stamp Event")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(TSEL,DBF_INLINK) {
-		prompt("Time Stamp Link")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(DTYP,DBF_DEVICE) {
-		prompt("Device Type")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(DISV,DBF_SHORT) {
-		prompt("Disable Value")
-		initial("1")
-		promptgroup(GUI_SCAN)
-	}
-	field(DISA,DBF_SHORT) {
-		prompt("Disable")
-	}
-	field(SDIS,DBF_INLINK) {
-		prompt("Scanning Disable")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(MLOK,DBF_NOACCESS) {
-		prompt("Monitor lock")
-		special(SPC_NOMOD)
-		extra("epicsMutexId	mlok")
-		interest(4)
-	}
-	field(MLIS,DBF_NOACCESS) {
-		prompt("Monitor List")
-		special(SPC_NOMOD)
-		extra("ELLLIST		mlis")
-		interest(4)
-	}
-	field(DISP,DBF_UCHAR) {
-		prompt("Disable putField")
-	}
-	field(PROC,DBF_UCHAR) {
-		prompt("Force Processing")
-		pp(TRUE)
-		interest(3)
-	}
-	field(STAT,DBF_MENU) {
-		prompt("Alarm Status")
-		initial("UDF")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-	}
-	field(SEVR,DBF_MENU) {
-		prompt("Alarm Severity")
-		initial("INVALID")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-	}
-	field(NSTA,DBF_MENU) {
-		prompt("New Alarm Status")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-		interest(2)
-	}
-	field(NSEV,DBF_MENU) {
-		prompt("New Alarm Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKS,DBF_MENU) {
-		prompt("Alarm Ack Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKT,DBF_MENU) {
-		prompt("Alarm Ack Transient")
-		initial("YES")
-		promptgroup(GUI_ALARMS)
-		special(SPC_NOMOD)
-		menu(menuYesNo)
-		interest(2)
-	}
-	field(DISS,DBF_MENU) {
-		prompt("Disable Alarm Sevrty")
-		promptgroup(GUI_SCAN)
-		menu(menuAlarmSevr)
-		interest(1)
-	}
-	field(LCNT,DBF_UCHAR) {
-		prompt("Lock Count")
-		special(SPC_NOMOD)
-		interest(2)
-	}
-	field(PACT,DBF_UCHAR) {
-		prompt("Record active")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(PUTF,DBF_UCHAR) {
-		prompt("dbPutField process")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(RPRO,DBF_UCHAR) {
-		prompt("Reprocess ")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(ASP,DBF_NOACCESS) {
-		prompt("Access Security Pvt")
-		special(SPC_NOMOD)
-		extra("struct asgMember *asp")
-		interest(4)
-	}
-	field(PPN,DBF_NOACCESS) {
-		prompt("addr of PUTNOTIFY")
-		special(SPC_NOMOD)
-		extra("struct putNotify *ppn")
-		interest(4)
-	}
-	field(PPNR,DBF_NOACCESS) {
-		prompt("pputNotifyRecord")
-		special(SPC_NOMOD)
-		extra("struct putNotifyRecord *ppnr")
-		interest(4)
-	}
-	field(SPVT,DBF_NOACCESS) {
-		prompt("Scan Private")
-		special(SPC_NOMOD)
-		extra("struct scan_element *spvt")
-		interest(4)
-	}
-	field(RSET,DBF_NOACCESS) {
-		prompt("Address of RSET")
-		special(SPC_NOMOD)
-		extra("struct rset	*rset")
-		interest(4)
-	}
-	field(DSET,DBF_NOACCESS) {
-		prompt("DSET address")
-		special(SPC_NOMOD)
-		extra("struct dset	*dset")
-		interest(4)
-	}
-	field(DPVT,DBF_NOACCESS) {
-		prompt("Device Private")
-		special(SPC_NOMOD)
-		extra("void		*dpvt")
-		interest(4)
-	}
-	field(RDES,DBF_NOACCESS) {
-		prompt("Address of dbRecordType")
-		special(SPC_NOMOD)
-		extra("struct dbRecordType *rdes")
-		interest(4)
-	}
-	field(LSET,DBF_NOACCESS) {
-		prompt("Lock Set")
-		special(SPC_NOMOD)
-		extra("struct lockRecord *lset")
-		interest(4)
-	}
-	field(PRIO,DBF_MENU) {
-		prompt("Scheduling Priority")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuPriority)
-		interest(1)
-	}
-	field(TPRO,DBF_UCHAR) {
-		prompt("Trace Processing")
-	}
-	field(BKPT,DBF_NOACCESS) {
-		prompt("Break Point")
-		special(SPC_NOMOD)
-		extra("char bkpt")
-		interest(1)
-	}
-	field(UDF,DBF_UCHAR) {
-		prompt("Undefined")
-		initial("1")
-		promptgroup(GUI_COMMON)
-		pp(TRUE)
-		interest(1)
-	}
-	field(TIME,DBF_NOACCESS) {
-		prompt("Time")
-		special(SPC_NOMOD)
-		extra("epicsTimeStamp	time")
-		interest(2)
-	}
-	field(FLNK,DBF_FWDLINK) {
-		prompt("Forward Process Link")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(VAL,DBF_NOACCESS) {
-		prompt("Value")
-		special(SPC_DBADDR)
-		extra("void *		val")
-		pp(TRUE)
-		asl(ASL0)
-	}
-	field(RARM,DBF_SHORT) {
-		prompt("Rearm the waveform")
-		promptgroup(GUI_WAVE)
-		pp(TRUE)
-		interest(1)
-	}
-	field(PREC,DBF_SHORT) {
-		prompt("Display Precision")
-		promptgroup(GUI_DISPLAY)
-		interest(1)
-	}
-	field(INP,DBF_INLINK) {
-		prompt("Input Specification")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(EGU,DBF_STRING) {
-		prompt("Engineering Units Name")
-		promptgroup(GUI_DISPLAY)
-		size(16)
-		interest(1)
-	}
-	field(HOPR,DBF_DOUBLE) {
-		prompt("High Operating Range")
-		promptgroup(GUI_DISPLAY)
-		interest(1)
-	}
-	field(LOPR,DBF_DOUBLE) {
-		prompt("Low Operating Range")
-		promptgroup(GUI_DISPLAY)
-		interest(1)
-	}
-	field(NELM,DBF_ULONG) {
-		prompt("Number of Elements")
-		initial("1")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(FTVL,DBF_MENU) {
-		prompt("Field Type of Value")
-		promptgroup(GUI_WAVE)
-		special(SPC_NOMOD)
-		menu(menuFtype)
-		interest(1)
-	}
-	field(BUSY,DBF_SHORT) {
-		prompt("Busy Indicator")
-		special(SPC_NOMOD)
-	}
-	field(NORD,DBF_ULONG) {
-		prompt("Number elements read")
-		special(SPC_NOMOD)
-	}
-	field(BPTR,DBF_NOACCESS) {
-		prompt("Buffer Pointer")
-		special(SPC_NOMOD)
-		extra("void *		bptr")
-		interest(4)
-	}
-	field(SIOL,DBF_INLINK) {
-		prompt("Sim Input Specifctn")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(SIML,DBF_INLINK) {
-		prompt("Sim Mode Location")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(SIMM,DBF_MENU) {
-		prompt("Simulation Mode")
-		menu(menuYesNo)
-		interest(1)
-	}
-	field(SIMS,DBF_MENU) {
-		prompt("Sim mode Alarm Svrty")
-		promptgroup(GUI_INPUTS)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(MPST,DBF_MENU) {
-		prompt("Post Value Monitors")
-		promptgroup(GUI_DISPLAY)
-		menu(waveformPOST)
-		interest(1)
-	}
-	field(APST,DBF_MENU) {
-		prompt("Post Archive Monitors")
-		promptgroup(GUI_DISPLAY)
-		menu(waveformPOST)
-		interest(1)
-	}
-	field(HASH,DBF_ULONG) {
-		prompt("Hash of OnChange data.")
-		interest(3)
-	}
+device(int64in, CONSTANT, devI64inSoft, "Soft Channel")
+device(int64in, CONSTANT, devI64inSoftCallback, "Async Soft Channel")
+recordtype(ai) {
+    %#include "epicsTypes.h"
+    %#include "link.h"
+    %#include "epicsMutex.h"
+    %#include "ellLib.h"
+    %#include "epicsTime.h"
+    %#include "callback.h"
+    field(NAME, DBF_STRING) {
+        special(SPC_NOMOD)
+        size(61)
+        prompt("Record Name")
+    }
+    field(DESC, DBF_STRING) {
+        promptgroup("10 - Common")
+        size(41)
+        prompt("Descriptor")
+    }
+    field(ASG, DBF_STRING) {
+        promptgroup("10 - Common")
+        special(SPC_AS)
+        size(29)
+        prompt("Access Security Group")
+    }
+    field(SCAN, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuScan)
+        interest(1)
+        prompt("Scan Mechanism")
+    }
+    field(PINI, DBF_MENU) {
+        promptgroup("20 - Scan")
+        menu(menuPini)
+        interest(1)
+        prompt("Process at iocInit")
+    }
+    field(PHAS, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        prompt("Scan Phase")
+    }
+    field(EVNT, DBF_STRING) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        size(40)
+        prompt("Event Name")
+    }
+    field(TSE, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Event")
+    }
+    field(TSEL, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Link")
+    }
+    field(DTYP, DBF_DEVICE) {
+        promptgroup("10 - Common")
+        interest(1)
+        prompt("Device Type")
+    }
+    field(DISV, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        initial("1")
+        prompt("Disable Value")
+    }
+    field(DISA, DBF_SHORT) {
+        prompt("Disable")
+    }
+    field(SDIS, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Scanning Disable")
+    }
+    field(MLOK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsMutexId        mlok")
+        interest(4)
+        prompt("Monitor lock")
+    }
+    field(MLIS, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             mlis")
+        interest(4)
+        prompt("Monitor List")
+    }
+    field(BKLNK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             bklnk")
+        interest(4)
+        prompt("Backwards link tracking")
+    }
+    field(DISP, DBF_UCHAR) {
+        prompt("Disable putField")
+    }
+    field(PROC, DBF_UCHAR) {
+        interest(3)
+        pp(TRUE)
+        prompt("Force Processing")
+    }
+    field(STAT, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        initial("UDF")
+        prompt("Alarm Status")
+    }
+    field(SEVR, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        prompt("Alarm Severity")
+    }
+    field(NSTA, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        interest(2)
+        prompt("New Alarm Status")
+    }
+    field(NSEV, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("New Alarm Severity")
+    }
+    field(ACKS, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("Alarm Ack Severity")
+    }
+    field(ACKT, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        special(SPC_NOMOD)
+        menu(menuYesNo)
+        initial("YES")
+        interest(2)
+        prompt("Alarm Ack Transient")
+    }
+    field(DISS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        prompt("Disable Alarm Sevrty")
+    }
+    field(LCNT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(2)
+        prompt("Lock Count")
+    }
+    field(PACT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Record active")
+    }
+    field(PUTF, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("dbPutField process")
+    }
+    field(RPRO, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Reprocess ")
+    }
+    field(ASP, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct asgMember    *asp")
+        interest(4)
+        prompt("Access Security Pvt")
+    }
+    field(PPN, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotify *ppn")
+        interest(4)
+        prompt("pprocessNotify")
+    }
+    field(PPNR, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotifyRecord *ppnr")
+        interest(4)
+        prompt("pprocessNotifyRecord")
+    }
+    field(SPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct scan_element *spvt")
+        interest(4)
+        prompt("Scan Private")
+    }
+    field(RSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct typed_rset   *rset")
+        interest(4)
+        prompt("Address of RSET")
+    }
+    field(DSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dset         *dset")
+        interest(4)
+        prompt("DSET address")
+    }
+    field(DPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("void                *dpvt")
+        interest(4)
+        prompt("Device Private")
+    }
+    field(RDES, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dbRecordType *rdes")
+        interest(4)
+        prompt("Address of dbRecordType")
+    }
+    field(LSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct lockRecord   *lset")
+        interest(4)
+        prompt("Lock Set")
+    }
+    field(PRIO, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuPriority)
+        interest(1)
+        prompt("Scheduling Priority")
+    }
+    field(TPRO, DBF_UCHAR) {
+        prompt("Trace Processing")
+    }
+    field(BKPT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("char                bkpt")
+        interest(1)
+        prompt("Break Point")
+    }
+    field(UDF, DBF_UCHAR) {
+        promptgroup("10 - Common")
+        initial("1")
+        interest(1)
+        pp(TRUE)
+        prompt("Undefined")
+    }
+    field(UDFS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        initial("INVALID")
+        interest(1)
+        prompt("Undefined Alarm Sevrty")
+    }
+    field(TIME, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsTimeStamp      time")
+        interest(2)
+        prompt("Time")
+    }
+    field(FLNK, DBF_FWDLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Forward Process Link")
+    }
+    field(VAL, DBF_DOUBLE) {
+        promptgroup("40 - Input")
+        asl(ASL0)
+        pp(TRUE)
+        prompt("Current EGU Value")
+    }
+    field(INP, DBF_INLINK) {
+        promptgroup("40 - Input")
+        interest(1)
+        prompt("Input Specification")
+    }
+    field(PREC, DBF_SHORT) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("Display Precision")
+    }
+    field(LINR, DBF_MENU) {
+        promptgroup("60 - Convert")
+        special(SPC_LINCONV)
+        menu(menuConvert)
+        interest(1)
+        pp(TRUE)
+        prompt("Linearization")
+    }
+    field(EGUF, DBF_DOUBLE) {
+        promptgroup("60 - Convert")
+        special(SPC_LINCONV)
+        interest(1)
+        pp(TRUE)
+        prompt("Engineer Units Full")
+    }
+    field(EGUL, DBF_DOUBLE) {
+        promptgroup("60 - Convert")
+        special(SPC_LINCONV)
+        interest(1)
+        pp(TRUE)
+        prompt("Engineer Units Low")
+    }
+    field(EGU, DBF_STRING) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        size(16)
+        prompt("Engineering Units")
+    }
+    field(HOPR, DBF_DOUBLE) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("High Operating Range")
+    }
+    field(LOPR, DBF_DOUBLE) {
+        prop(YES)
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("Low Operating Range")
+    }
+    field(AOFF, DBF_DOUBLE) {
+        promptgroup("60 - Convert")
+        interest(1)
+        pp(TRUE)
+        prompt("Adjustment Offset")
+    }
+    field(ASLO, DBF_DOUBLE) {
+        promptgroup("60 - Convert")
+        initial("1")
+        interest(1)
+        pp(TRUE)
+        prompt("Adjustment Slope")
+    }
+    field(SMOO, DBF_DOUBLE) {
+        promptgroup("60 - Convert")
+        interest(1)
+        prompt("Smoothing")
+    }
+    field(HIHI, DBF_DOUBLE) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        interest(1)
+        pp(TRUE)
+        prompt("Hihi Alarm Limit")
+    }
+    field(LOLO, DBF_DOUBLE) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        interest(1)
+        pp(TRUE)
+        prompt("Lolo Alarm Limit")
+    }
+    field(HIGH, DBF_DOUBLE) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        interest(1)
+        pp(TRUE)
+        prompt("High Alarm Limit")
+    }
+    field(LOW, DBF_DOUBLE) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        interest(1)
+        pp(TRUE)
+        prompt("Low Alarm Limit")
+    }
+    field(HHSV, DBF_MENU) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("Hihi Severity")
+    }
+    field(LLSV, DBF_MENU) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("Lolo Severity")
+    }
+    field(HSV, DBF_MENU) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("High Severity")
+    }
+    field(LSV, DBF_MENU) {
+        prop(YES)
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        pp(TRUE)
+        prompt("Low Severity")
+    }
+    field(HYST, DBF_DOUBLE) {
+        promptgroup("70 - Alarm")
+        interest(1)
+        prompt("Alarm Deadband")
+    }
+    field(AFTC, DBF_DOUBLE) {
+        promptgroup("70 - Alarm")
+        interest(1)
+        prompt("Alarm Filter Time Constant")
+    }
+    field(ADEL, DBF_DOUBLE) {
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("Archive Deadband")
+    }
+    field(MDEL, DBF_DOUBLE) {
+        promptgroup("80 - Display")
+        interest(1)
+        prompt("Monitor Deadband")
+    }
+    field(LALM, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Last Value Alarmed")
+    }
+    field(AFVL, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Alarm Filter Value")
+    }
+    field(ALST, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Last Value Archived")
+    }
+    field(MLST, DBF_DOUBLE) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Last Val Monitored")
+    }
+    field(ESLO, DBF_DOUBLE) {
+        promptgroup("60 - Convert")
+        initial("1")
+        interest(2)
+        pp(TRUE)
+        prompt("Raw to EGU Slope")
+    }
+    field(EOFF, DBF_DOUBLE) {
+        promptgroup("60 - Convert")
+        interest(2)
+        pp(TRUE)
+        prompt("Raw to EGU Offset")
+    }
+    field(ROFF, DBF_ULONG) {
+        interest(2)
+        pp(TRUE)
+        prompt("Raw Offset")
+    }
+    field(PBRK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("void *   pbrk")
+        interest(4)
+        prompt("Ptrto brkTable")
+    }
+    field(INIT, DBF_SHORT) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Initialized?")
+    }
+    field(LBRK, DBF_SHORT) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("LastBreak Point")
+    }
+    field(RVAL, DBF_LONG) {
+        pp(TRUE)
+        prompt("Current Raw Value")
+    }
+    field(ORAW, DBF_LONG) {
+        special(SPC_NOMOD)
+        interest(3)
+        prompt("Previous Raw Value")
+    }
+    field(SIOL, DBF_INLINK) {
+        promptgroup("90 - Simulate")
+        interest(1)
+        prompt("Simulation Input Link")
+    }
+    field(SVAL, DBF_DOUBLE) {
+        prompt("Simulation Value")
+    }
+    field(SIML, DBF_INLINK) {
+        promptgroup("90 - Simulate")
+        interest(1)
+        prompt("Simulation Mode Link")
+    }
+    field(SIMM, DBF_MENU) {
+        special(SPC_MOD)
+        menu(menuSimm)
+        interest(1)
+        prompt("Simulation Mode")
+    }
+    field(SIMS, DBF_MENU) {
+        promptgroup("90 - Simulate")
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("Simulation Mode Severity")
+    }
+    field(OLDSIMM, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuSimm)
+        interest(4)
+        prompt("Prev. Simulation Mode")
+    }
+    field(SSCN, DBF_MENU) {
+        promptgroup("90 - Simulate")
+        menu(menuScan)
+        initial("65535")
+        interest(1)
+        prompt("Sim. Mode Scan")
+    }
+    field(SDLY, DBF_DOUBLE) {
+        promptgroup("90 - Simulate")
+        initial("-1.0")
+        interest(2)
+        prompt("Sim. Mode Async Delay")
+    }
+    field(SIMPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("CALLBACK            *simpvt")
+        interest(4)
+        prompt("Sim. Mode Private")
+    }
 }
-recordtype(axis) {
-	field(NAME,DBF_STRING) {
-		prompt("Record Name")
-		special(SPC_NOMOD)
-		size(61)
-	}
-	field(DESC,DBF_STRING) {
-		prompt("Descriptor")
-		promptgroup(GUI_COMMON)
-		size(41)
-	}
-	field(ASG,DBF_STRING) {
-		prompt("Access Security Group")
-		promptgroup(GUI_COMMON)
-		special(SPC_AS)
-		size(29)
-	}
-	field(SCAN,DBF_MENU) {
-		prompt("Scan Mechanism")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuScan)
-		interest(1)
-	}
-	field(PINI,DBF_MENU) {
-		prompt("Process at iocInit")
-		promptgroup(GUI_SCAN)
-		menu(menuPini)
-		interest(1)
-	}
-	field(PHAS,DBF_SHORT) {
-		prompt("Scan Phase")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(EVNT,DBF_SHORT) {
-		prompt("Event Number")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(TSE,DBF_SHORT) {
-		prompt("Time Stamp Event")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(TSEL,DBF_INLINK) {
-		prompt("Time Stamp Link")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(DTYP,DBF_DEVICE) {
-		prompt("Device Type")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(DISV,DBF_SHORT) {
-		prompt("Disable Value")
-		initial("1")
-		promptgroup(GUI_SCAN)
-	}
-	field(DISA,DBF_SHORT) {
-		prompt("Disable")
-	}
-	field(SDIS,DBF_INLINK) {
-		prompt("Scanning Disable")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(MLOK,DBF_NOACCESS) {
-		prompt("Monitor lock")
-		special(SPC_NOMOD)
-		extra("epicsMutexId	mlok")
-		interest(4)
-	}
-	field(MLIS,DBF_NOACCESS) {
-		prompt("Monitor List")
-		special(SPC_NOMOD)
-		extra("ELLLIST		mlis")
-		interest(4)
-	}
-	field(DISP,DBF_UCHAR) {
-		prompt("Disable putField")
-	}
-	field(PROC,DBF_UCHAR) {
-		prompt("Force Processing")
-		pp(TRUE)
-		interest(3)
-	}
-	field(STAT,DBF_MENU) {
-		prompt("Alarm Status")
-		initial("UDF")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-	}
-	field(SEVR,DBF_MENU) {
-		prompt("Alarm Severity")
-		initial("INVALID")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-	}
-	field(NSTA,DBF_MENU) {
-		prompt("New Alarm Status")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-		interest(2)
-	}
-	field(NSEV,DBF_MENU) {
-		prompt("New Alarm Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKS,DBF_MENU) {
-		prompt("Alarm Ack Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKT,DBF_MENU) {
-		prompt("Alarm Ack Transient")
-		initial("YES")
-		promptgroup(GUI_ALARMS)
-		special(SPC_NOMOD)
-		menu(menuYesNo)
-		interest(2)
-	}
-	field(DISS,DBF_MENU) {
-		prompt("Disable Alarm Sevrty")
-		promptgroup(GUI_SCAN)
-		menu(menuAlarmSevr)
-		interest(1)
-	}
-	field(LCNT,DBF_UCHAR) {
-		prompt("Lock Count")
-		special(SPC_NOMOD)
-		interest(2)
-	}
-	field(PACT,DBF_UCHAR) {
-		prompt("Record active")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(PUTF,DBF_UCHAR) {
-		prompt("dbPutField process")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(RPRO,DBF_UCHAR) {
-		prompt("Reprocess ")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(ASP,DBF_NOACCESS) {
-		prompt("Access Security Pvt")
-		special(SPC_NOMOD)
-		extra("struct asgMember *asp")
-		interest(4)
-	}
-	field(PPN,DBF_NOACCESS) {
-		prompt("addr of PUTNOTIFY")
-		special(SPC_NOMOD)
-		extra("struct putNotify *ppn")
-		interest(4)
-	}
-	field(PPNR,DBF_NOACCESS) {
-		prompt("pputNotifyRecord")
-		special(SPC_NOMOD)
-		extra("struct putNotifyRecord *ppnr")
-		interest(4)
-	}
-	field(SPVT,DBF_NOACCESS) {
-		prompt("Scan Private")
-		special(SPC_NOMOD)
-		extra("struct scan_element *spvt")
-		interest(4)
-	}
-	field(RSET,DBF_NOACCESS) {
-		prompt("Address of RSET")
-		special(SPC_NOMOD)
-		extra("struct rset	*rset")
-		interest(4)
-	}
-	field(DSET,DBF_NOACCESS) {
-		prompt("DSET address")
-		special(SPC_NOMOD)
-		extra("struct dset	*dset")
-		interest(4)
-	}
-	field(DPVT,DBF_NOACCESS) {
-		prompt("Device Private")
-		special(SPC_NOMOD)
-		extra("void		*dpvt")
-		interest(4)
-	}
-	field(RDES,DBF_NOACCESS) {
-		prompt("Address of dbRecordType")
-		special(SPC_NOMOD)
-		extra("struct dbRecordType *rdes")
-		interest(4)
-	}
-	field(LSET,DBF_NOACCESS) {
-		prompt("Lock Set")
-		special(SPC_NOMOD)
-		extra("struct lockRecord *lset")
-		interest(4)
-	}
-	field(PRIO,DBF_MENU) {
-		prompt("Scheduling Priority")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuPriority)
-		interest(1)
-	}
-	field(TPRO,DBF_UCHAR) {
-		prompt("Trace Processing")
-	}
-	field(BKPT,DBF_NOACCESS) {
-		prompt("Break Point")
-		special(SPC_NOMOD)
-		extra("char bkpt")
-		interest(1)
-	}
-	field(UDF,DBF_UCHAR) {
-		prompt("Undefined")
-		initial("1")
-		promptgroup(GUI_COMMON)
-		pp(TRUE)
-		interest(1)
-	}
-	field(TIME,DBF_NOACCESS) {
-		prompt("Time")
-		special(SPC_NOMOD)
-		extra("epicsTimeStamp	time")
-		interest(2)
-	}
-	field(FLNK,DBF_FWDLINK) {
-		prompt("Forward Process Link")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(VERS,DBF_FLOAT) {
-		prompt("Code Version")
-		initial("1")
-		special(SPC_NOMOD)
-	}
-	field(OFF,DBF_DOUBLE) {
-		prompt("User Offset (EGU)")
-		special(100)
-		pp(TRUE)
-		asl(ASL0)
-	}
-	field(FOFF,DBF_MENU) {
-		prompt("Offset-Freeze Switch")
-		promptgroup(GUI_COMMON)
-		special(100)
-		menu(motorFOFF)
-		interest(1)
-		asl(ASL0)
-	}
-	field(FOF,DBF_SHORT) {
-		prompt("Freeze Offset")
-		special(100)
-		interest(1)
-		asl(ASL0)
-	}
-	field(VOF,DBF_SHORT) {
-		prompt("Variable Offset")
-		special(100)
-		interest(1)
-		asl(ASL0)
-	}
-	field(DIR,DBF_MENU) {
-		prompt("User Direction")
-		promptgroup(GUI_COMMON)
-		special(100)
-		menu(motorDIR)
-		pp(TRUE)
-		interest(1)
-	}
-	field(SET,DBF_MENU) {
-		prompt("Set/Use Switch")
-		menu(motorSET)
-		interest(1)
-		asl(ASL0)
-	}
-	field(SSET,DBF_SHORT) {
-		prompt("Set SET Mode")
-		special(100)
-		interest(1)
-		asl(ASL0)
-	}
-	field(SUSE,DBF_SHORT) {
-		prompt("Set USE Mode")
-		special(100)
-		interest(1)
-		asl(ASL0)
-	}
-	field(VELO,DBF_DOUBLE) {
-		prompt("Velocity (EGU/s)")
-		promptgroup(GUI_COMMON)
-		special(100)
-		interest(1)
-	}
-	field(VBAS,DBF_DOUBLE) {
-		prompt("Base Velocity (EGU/s)")
-		promptgroup(GUI_COMMON)
-		special(100)
-		interest(1)
-	}
-	field(VMAX,DBF_DOUBLE) {
-		prompt("Max. Velocity (EGU/s)")
-		promptgroup(GUI_COMMON)
-		special(100)
-		interest(1)
-	}
-	field(S,DBF_DOUBLE) {
-		prompt("Speed (revolutions/sec)")
-		promptgroup(GUI_COMMON)
-		special(100)
-		interest(1)
-	}
-	field(SBAS,DBF_DOUBLE) {
-		prompt("Base Speed (RPS)")
-		promptgroup(GUI_COMMON)
-		special(100)
-		interest(1)
-	}
-	field(SMAX,DBF_DOUBLE) {
-		prompt("Max. Speed (RPS)")
-		promptgroup(GUI_COMMON)
-		special(100)
-		interest(1)
-	}
-	field(ACCL,DBF_DOUBLE) {
-		prompt("Seconds to Velocity")
-		initial("0.2")
-		promptgroup(GUI_COMMON)
-		special(100)
-		interest(1)
-	}
-	field(BDST,DBF_DOUBLE) {
-		prompt("BL Distance (EGU)")
-		promptgroup(GUI_COMMON)
-		special(100)
-		interest(1)
-		asl(ASL0)
-	}
-	field(BVEL,DBF_DOUBLE) {
-		prompt("BL Velocity (EGU/s)")
-		promptgroup(GUI_COMMON)
-		special(100)
-		interest(1)
-	}
-	field(SBAK,DBF_DOUBLE) {
-		prompt("BL Speed (RPS)")
-		promptgroup(GUI_COMMON)
-		special(100)
-		interest(1)
-	}
-	field(BACC,DBF_DOUBLE) {
-		prompt("BL Seconds to Velocity")
-		initial("0.5")
-		promptgroup(GUI_COMMON)
-		special(100)
-		interest(1)
-	}
-	field(FRAC,DBF_FLOAT) {
-		prompt("Move Fraction")
-		initial("1")
-		promptgroup(GUI_COMMON)
-		special(100)
-		interest(1)
-	}
-	field(OUT,DBF_OUTLINK) {
-		prompt("Output Specification")
-		promptgroup(GUI_COMMON)
-		special(100)
-		interest(1)
-	}
-	field(CARD,DBF_SHORT) {
-		prompt("Card Number")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(RDBL,DBF_INLINK) {
-		prompt("Readback Location")
-		promptgroup(GUI_COMMON)
-		special(100)
-		interest(1)
-	}
-	field(DOL,DBF_INLINK) {
-		prompt("Desired Output Loc")
-		promptgroup(GUI_COMMON)
-		special(100)
-		interest(1)
-	}
-	field(OMSL,DBF_MENU) {
-		prompt("Output Mode Select")
-		promptgroup(GUI_COMMON)
-		menu(menuOmsl)
-		interest(1)
-	}
-	field(RLNK,DBF_OUTLINK) {
-		prompt("Readback OutLink")
-		promptgroup(GUI_COMMON)
-		special(100)
-		interest(1)
-	}
-	field(SREV,DBF_LONG) {
-		prompt("Steps per Revolution")
-		initial("200")
-		promptgroup(GUI_COMMON)
-		special(100)
-		pp(TRUE)
-		interest(1)
-	}
-	field(UREV,DBF_DOUBLE) {
-		prompt("EGU's per Revolution")
-		promptgroup(GUI_COMMON)
-		special(100)
-		pp(TRUE)
-		interest(1)
-	}
-	field(MRES,DBF_DOUBLE) {
-		prompt("Motor Step Size (EGU)")
-		promptgroup(GUI_COMMON)
-		special(100)
-		pp(TRUE)
-		interest(1)
-	}
-	field(ERES,DBF_DOUBLE) {
-		prompt("Encoder Step Size (EGU)")
-		promptgroup(GUI_COMMON)
-		special(100)
-		pp(TRUE)
-		interest(1)
-	}
-	field(RRES,DBF_DOUBLE) {
-		prompt("Readback Step Size (EGU")
-		promptgroup(GUI_COMMON)
-		interest(1)
-	}
-	field(UEIP,DBF_MENU) {
-		prompt("Use Encoder If Present")
-		promptgroup(GUI_COMMON)
-		special(100)
-		menu(motorUEIP)
-		pp(TRUE)
-		interest(1)
-	}
-	field(URIP,DBF_MENU) {
-		prompt("Use RDBL Link If Present")
-		promptgroup(GUI_COMMON)
-		special(100)
-		menu(motorUEIP)
-		pp(TRUE)
-		interest(1)
-	}
-	field(PREC,DBF_SHORT) {
-		prompt("Display Precision")
-		promptgroup(GUI_COMMON)
-		interest(1)
-	}
-	field(EGU,DBF_STRING) {
-		prompt("Engineering Units")
-		promptgroup(GUI_COMMON)
-		size(16)
-		interest(1)
-	}
-	field(HLM,DBF_DOUBLE) {
-		prompt("User High Limit")
-		special(100)
-		pp(TRUE)
-	}
-	field(LLM,DBF_DOUBLE) {
-		prompt("User Low Limit")
-		special(100)
-		pp(TRUE)
-	}
-	field(DHLM,DBF_DOUBLE) {
-		prompt("Dial High Limit")
-		promptgroup(GUI_COMMON)
-		special(100)
-		pp(TRUE)
-	}
-	field(DLLM,DBF_DOUBLE) {
-		prompt("Dial Low Limit")
-		promptgroup(GUI_COMMON)
-		special(100)
-		pp(TRUE)
-	}
-	field(HOPR,DBF_DOUBLE) {
-		prompt("High Operating Range")
-		promptgroup(GUI_COMMON)
-		interest(1)
-	}
-	field(LOPR,DBF_DOUBLE) {
-		prompt("Low Operating Range")
-		promptgroup(GUI_COMMON)
-		interest(1)
-	}
-	field(HLS,DBF_SHORT) {
-		prompt("User High Limit Switch")
-		special(SPC_NOMOD)
-	}
-	field(LLS,DBF_SHORT) {
-		prompt("User Low Limit Switch")
-		special(SPC_NOMOD)
-	}
-	field(RHLS,DBF_SHORT) {
-		prompt("Raw High Limit Switch")
-		special(SPC_NOMOD)
-	}
-	field(RLLS,DBF_SHORT) {
-		prompt("Raw Low Limit Switch")
-		special(SPC_NOMOD)
-	}
-	field(HIHI,DBF_DOUBLE) {
-		prompt("Hihi Alarm Limit (EGU)")
-		promptgroup(GUI_COMMON)
-		pp(TRUE)
-		interest(2)
-	}
-	field(LOLO,DBF_DOUBLE) {
-		prompt("Lolo Alarm Limit (EGU)")
-		promptgroup(GUI_COMMON)
-		pp(TRUE)
-		interest(2)
-	}
-	field(HIGH,DBF_DOUBLE) {
-		prompt("High Alarm Limit (EGU)")
-		promptgroup(GUI_COMMON)
-		pp(TRUE)
-		interest(2)
-	}
-	field(LOW,DBF_DOUBLE) {
-		prompt("Low Alarm Limit (EGU)")
-		promptgroup(GUI_COMMON)
-		pp(TRUE)
-		interest(2)
-	}
-	field(HHSV,DBF_MENU) {
-		prompt("Hihi Severity")
-		promptgroup(GUI_COMMON)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(2)
-	}
-	field(LLSV,DBF_MENU) {
-		prompt("Lolo Severity")
-		promptgroup(GUI_COMMON)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(2)
-	}
-	field(HSV,DBF_MENU) {
-		prompt("High Severity")
-		promptgroup(GUI_COMMON)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(2)
-	}
-	field(LSV,DBF_MENU) {
-		prompt("Low Severity")
-		promptgroup(GUI_COMMON)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(2)
-	}
-	field(HLSV,DBF_MENU) {
-		prompt("HW Limit Violation Svr")
-		promptgroup(GUI_COMMON)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(2)
-	}
-	field(MISV,DBF_MENU) {
-		prompt("MISS Severity")
-		promptgroup(GUI_COMMON)
-		menu(menuAlarmSevr)
-		pp(TRUE)
-		interest(2)
-	}
-	field(RDBD,DBF_DOUBLE) {
-		prompt("Retry Deadband (EGU)")
-		promptgroup(GUI_COMMON)
-		special(100)
-		interest(1)
-	}
-	field(SDBD,DBF_DOUBLE) {
-		prompt("Setpoint Deadband (EGU)")
-		promptgroup(GUI_COMMON)
-		special(100)
-		interest(1)
-	}
-	field(RCNT,DBF_SHORT) {
-		prompt("Retry count")
-		special(SPC_NOMOD)
-		interest(2)
-	}
-	field(RTRY,DBF_SHORT) {
-		prompt("Max retry count")
-		initial("10")
-		promptgroup(GUI_COMMON)
-		interest(1)
-	}
-	field(MISS,DBF_SHORT) {
-		prompt("Ran out of retries")
-		special(SPC_NOMOD)
-		interest(2)
-	}
-	field(SPMG,DBF_MENU) {
-		prompt("Stop/Pause/Move/Go")
-		initial("3")
-		menu(motorSPMG)
-		pp(TRUE)
-		interest(1)
-		asl(ASL0)
-	}
-	field(LSPG,DBF_MENU) {
-		prompt("Last SPMG")
-		initial("3")
-		special(SPC_NOMOD)
-		menu(motorSPMG)
-		interest(1)
-	}
-	field(STOP,DBF_SHORT) {
-		prompt("Stop")
-		pp(TRUE)
-		interest(1)
-		asl(ASL0)
-	}
-	field(HOMF,DBF_SHORT) {
-		prompt("Home Forward")
-		special(100)
-		pp(TRUE)
-		interest(1)
-	}
-	field(HOMR,DBF_SHORT) {
-		prompt("Home Reverse")
-		special(100)
-		pp(TRUE)
-		interest(1)
-	}
-	field(JOGF,DBF_SHORT) {
-		prompt("Jog motor Forward")
-		special(100)
-		pp(TRUE)
-		interest(1)
-		asl(ASL0)
-	}
-	field(JOGR,DBF_SHORT) {
-		prompt("Jog motor Reverse")
-		special(100)
-		pp(TRUE)
-		interest(1)
-		asl(ASL0)
-	}
-	field(TWF,DBF_SHORT) {
-		prompt("Tweak motor Forward")
-		special(100)
-		pp(TRUE)
-		interest(1)
-		asl(ASL0)
-	}
-	field(TWR,DBF_SHORT) {
-		prompt("Tweak motor Reverse")
-		special(100)
-		pp(TRUE)
-		interest(1)
-		asl(ASL0)
-	}
-	field(TWV,DBF_DOUBLE) {
-		prompt("Tweak Step Size (EGU)")
-		promptgroup(GUI_COMMON)
-		interest(1)
-		asl(ASL0)
-	}
-	field(VAL,DBF_DOUBLE) {
-		prompt("User Desired Value (EGU")
-		special(100)
-		pp(TRUE)
-		asl(ASL0)
-	}
-	field(DVAL,DBF_DOUBLE) {
-		prompt("Dial Desired Value (EGU")
-		special(100)
-		pp(TRUE)
-		asl(ASL0)
-	}
-	field(RVAL,DBF_LONG) {
-		prompt("Raw Desired Value (step")
-		special(100)
-		pp(TRUE)
-		asl(ASL0)
-	}
-	field(RLV,DBF_DOUBLE) {
-		prompt("Relative Value (EGU)")
-		special(100)
-		pp(TRUE)
-		asl(ASL0)
-	}
-	field(RBV,DBF_DOUBLE) {
-		prompt("User Readback Value")
-		special(SPC_NOMOD)
-	}
-	field(DRBV,DBF_DOUBLE) {
-		prompt("Dial Readback Value")
-		special(SPC_NOMOD)
-	}
-	field(CDIR,DBF_SHORT) {
-		prompt("Raw cmnd direction")
-		special(SPC_NOMOD)
-	}
-	field(RRBV,DBF_LONG) {
-		prompt("Raw Readback Value")
-		special(SPC_NOMOD)
-	}
-	field(RMP,DBF_LONG) {
-		prompt("Raw Motor Position")
-		special(SPC_NOMOD)
-	}
-	field(REP,DBF_LONG) {
-		prompt("Raw Encoder Position")
-		special(SPC_NOMOD)
-	}
-	field(RVEL,DBF_LONG) {
-		prompt("Raw Velocity")
-		promptgroup(GUI_COMMON)
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(DMOV,DBF_SHORT) {
-		prompt("Done moving to value")
-		initial("1")
-		promptgroup(GUI_COMMON)
-		special(SPC_NOMOD)
-	}
-	field(MOVN,DBF_SHORT) {
-		prompt("Motor is moving")
-		special(SPC_NOMOD)
-	}
-	field(MSTA,DBF_ULONG) {
-		prompt("Motor Status")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(MFLG,DBF_ULONG) {
-		prompt("Motor Flags")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(LVIO,DBF_SHORT) {
-		prompt("Limit violation")
-		initial("1")
-		special(SPC_NOMOD)
-	}
-	field(TDIR,DBF_SHORT) {
-		prompt("Direction of Travel")
-		special(SPC_NOMOD)
-	}
-	field(ATHM,DBF_SHORT) {
-		prompt("At HOME")
-		special(SPC_NOMOD)
-	}
-	field(PP,DBF_SHORT) {
-		prompt("Post process command")
-		initial("0")
-		special(SPC_NOMOD)
-		interest(2)
-	}
-	field(MIP,DBF_USHORT) {
-		prompt("Motion In Progress")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(MMAP,DBF_ULONG) {
-		prompt("Monitor Mask")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(NMAP,DBF_ULONG) {
-		prompt("Monitor Mask (more)")
-		special(SPC_NOMOD)
-		interest(3)
-	}
-	field(DLY,DBF_DOUBLE) {
-		prompt("Readback settle time (s)")
-		promptgroup(GUI_COMMON)
-		special(100)
-		interest(1)
-	}
-	field(CBAK,DBF_NOACCESS) {
-		prompt("Callback structure")
-		special(SPC_NOMOD)
-		extra("void             *cbak")
-		interest(4)
-	}
-	field(priv,DBF_NOACCESS) {
-		prompt("Private data")
-		special(SPC_NOMOD)
-		extra("struct axis_priv *priv")
-		interest(4)
-	}
-	field(PCOF,DBF_DOUBLE) {
-		prompt("Proportional Gain")
-		initial("0")
-		promptgroup(GUI_COMMON)
-		special(100)
-		interest(1)
-	}
-	field(ICOF,DBF_DOUBLE) {
-		prompt("Integral Gain")
-		initial("0")
-		promptgroup(GUI_COMMON)
-		special(100)
-		interest(1)
-	}
-	field(DCOF,DBF_DOUBLE) {
-		prompt("Derivative Gain")
-		initial("0")
-		promptgroup(GUI_COMMON)
-		special(100)
-		interest(1)
-	}
-	field(CNEN,DBF_MENU) {
-		prompt("Enable control")
-		promptgroup(GUI_COMMON)
-		special(100)
-		menu(motorTORQ)
-		pp(TRUE)
-		asl(ASL0)
-	}
-	field(INIT,DBF_STRING) {
-		prompt("Startup commands")
-		promptgroup(GUI_COMMON)
-		size(40)
-		interest(1)
-	}
-	field(PREM,DBF_STRING) {
-		prompt("Pre-move commands")
-		promptgroup(GUI_COMMON)
-		size(40)
-		interest(1)
-	}
-	field(POST,DBF_STRING) {
-		prompt("Post-move commands")
-		promptgroup(GUI_COMMON)
-		size(40)
-		interest(1)
-	}
-	field(STOO,DBF_OUTLINK) {
-		prompt("STOP OutLink")
-		promptgroup(GUI_COMMON)
-		special(100)
-		interest(1)
-	}
-	field(DINP,DBF_INLINK) {
-		prompt("DMOV Input Link")
-		promptgroup(GUI_COMMON)
-		special(100)
-		interest(1)
-	}
-	field(RINP,DBF_INLINK) {
-		prompt("RMP Input Link")
-		promptgroup(GUI_COMMON)
-		special(100)
-		interest(1)
-	}
-	field(JVEL,DBF_DOUBLE) {
-		prompt("Jog Velocity (EGU/s)")
-		promptgroup(GUI_COMMON)
-		special(100)
-		interest(1)
-	}
-	field(JAR,DBF_DOUBLE) {
-		prompt("Jog Accel. (EGU/s^2)")
-		promptgroup(GUI_COMMON)
-		special(100)
-		interest(1)
-	}
-	field(LOCK,DBF_MENU) {
-		prompt("Soft Channel Position Lock")
-		initial("NO")
-		promptgroup(GUI_COMMON)
-		menu(menuYesNo)
-		interest(1)
-	}
-	field(HVEL,DBF_DOUBLE) {
-		prompt("Home Velocity (EGU/s)")
-		promptgroup(GUI_COMMON)
-		special(100)
-		interest(1)
-	}
-	field(STUP,DBF_MENU) {
-		prompt("Status Update")
-		initial("OFF")
-		promptgroup(GUI_COMMON)
-		special(100)
-		menu(motorSTUP)
-		pp(TRUE)
-		interest(3)
-		asl(ASL0)
-	}
-	field(RMOD,DBF_MENU) {
-		prompt("Retry Mode")
-		initial("Default")
-		promptgroup(GUI_COMMON)
-		menu(motorRMOD)
-		interest(1)
-	}
-	field(ADEL,DBF_DOUBLE) {
-		prompt("Archive Deadband")
-		promptgroup(GUI_COMMON)
-		interest(1)
-	}
-	field(MDEL,DBF_DOUBLE) {
-		prompt("Monitor Deadband")
-		promptgroup(GUI_COMMON)
-		interest(1)
-	}
-	field(SYNC,DBF_SHORT) {
-		prompt("Sync position")
-		pp(TRUE)
-		interest(1)
-	}
+device(ai, CONSTANT, devAiSoft, "Soft Channel")
+device(ai, CONSTANT, devAiSoftRaw, "Raw Soft Channel")
+device(ai, CONSTANT, devAiSoftCallback, "Async Soft Channel")
+device(ai, INST_IO, devTimestampAI, "Soft Timestamp")
+device(ai, INST_IO, devAiGeneralTime, "General Time")
+device(ai, INST_IO, devAiStats, "IOC stats")
+device(ai, INST_IO, devAiClusts, "IOC stats clusts")
+device(ai, INST_IO, asynAiInt32, "asynInt32")
+device(ai, INST_IO, asynAiInt32Average, "asynInt32Average")
+device(ai, INST_IO, asynAiFloat64, "asynFloat64")
+device(ai, INST_IO, asynAiFloat64Average, "asynFloat64Average")
+recordtype(stringin) {
+    %#include "epicsTypes.h"
+    %#include "link.h"
+    %#include "epicsMutex.h"
+    %#include "ellLib.h"
+    %#include "epicsTime.h"
+    %#include "callback.h"
+    field(NAME, DBF_STRING) {
+        special(SPC_NOMOD)
+        size(61)
+        prompt("Record Name")
+    }
+    field(DESC, DBF_STRING) {
+        promptgroup("10 - Common")
+        size(41)
+        prompt("Descriptor")
+    }
+    field(ASG, DBF_STRING) {
+        promptgroup("10 - Common")
+        special(SPC_AS)
+        size(29)
+        prompt("Access Security Group")
+    }
+    field(SCAN, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuScan)
+        interest(1)
+        prompt("Scan Mechanism")
+    }
+    field(PINI, DBF_MENU) {
+        promptgroup("20 - Scan")
+        menu(menuPini)
+        interest(1)
+        prompt("Process at iocInit")
+    }
+    field(PHAS, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        prompt("Scan Phase")
+    }
+    field(EVNT, DBF_STRING) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        interest(1)
+        size(40)
+        prompt("Event Name")
+    }
+    field(TSE, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Event")
+    }
+    field(TSEL, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Time Stamp Link")
+    }
+    field(DTYP, DBF_DEVICE) {
+        promptgroup("10 - Common")
+        interest(1)
+        prompt("Device Type")
+    }
+    field(DISV, DBF_SHORT) {
+        promptgroup("20 - Scan")
+        initial("1")
+        prompt("Disable Value")
+    }
+    field(DISA, DBF_SHORT) {
+        prompt("Disable")
+    }
+    field(SDIS, DBF_INLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Scanning Disable")
+    }
+    field(MLOK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsMutexId        mlok")
+        interest(4)
+        prompt("Monitor lock")
+    }
+    field(MLIS, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             mlis")
+        interest(4)
+        prompt("Monitor List")
+    }
+    field(BKLNK, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("ELLLIST             bklnk")
+        interest(4)
+        prompt("Backwards link tracking")
+    }
+    field(DISP, DBF_UCHAR) {
+        prompt("Disable putField")
+    }
+    field(PROC, DBF_UCHAR) {
+        interest(3)
+        pp(TRUE)
+        prompt("Force Processing")
+    }
+    field(STAT, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        initial("UDF")
+        prompt("Alarm Status")
+    }
+    field(SEVR, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        prompt("Alarm Severity")
+    }
+    field(NSTA, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmStat)
+        interest(2)
+        prompt("New Alarm Status")
+    }
+    field(NSEV, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("New Alarm Severity")
+    }
+    field(ACKS, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("Alarm Ack Severity")
+    }
+    field(ACKT, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        special(SPC_NOMOD)
+        menu(menuYesNo)
+        initial("YES")
+        interest(2)
+        prompt("Alarm Ack Transient")
+    }
+    field(DISS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        interest(1)
+        prompt("Disable Alarm Sevrty")
+    }
+    field(LCNT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(2)
+        prompt("Lock Count")
+    }
+    field(PACT, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Record active")
+    }
+    field(PUTF, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("dbPutField process")
+    }
+    field(RPRO, DBF_UCHAR) {
+        special(SPC_NOMOD)
+        interest(1)
+        prompt("Reprocess ")
+    }
+    field(ASP, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct asgMember    *asp")
+        interest(4)
+        prompt("Access Security Pvt")
+    }
+    field(PPN, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotify *ppn")
+        interest(4)
+        prompt("pprocessNotify")
+    }
+    field(PPNR, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct processNotifyRecord *ppnr")
+        interest(4)
+        prompt("pprocessNotifyRecord")
+    }
+    field(SPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct scan_element *spvt")
+        interest(4)
+        prompt("Scan Private")
+    }
+    field(RSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct typed_rset   *rset")
+        interest(4)
+        prompt("Address of RSET")
+    }
+    field(DSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dset         *dset")
+        interest(4)
+        prompt("DSET address")
+    }
+    field(DPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("void                *dpvt")
+        interest(4)
+        prompt("Device Private")
+    }
+    field(RDES, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct dbRecordType *rdes")
+        interest(4)
+        prompt("Address of dbRecordType")
+    }
+    field(LSET, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("struct lockRecord   *lset")
+        interest(4)
+        prompt("Lock Set")
+    }
+    field(PRIO, DBF_MENU) {
+        promptgroup("20 - Scan")
+        special(SPC_SCAN)
+        menu(menuPriority)
+        interest(1)
+        prompt("Scheduling Priority")
+    }
+    field(TPRO, DBF_UCHAR) {
+        prompt("Trace Processing")
+    }
+    field(BKPT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("char                bkpt")
+        interest(1)
+        prompt("Break Point")
+    }
+    field(UDF, DBF_UCHAR) {
+        promptgroup("10 - Common")
+        initial("1")
+        interest(1)
+        pp(TRUE)
+        prompt("Undefined")
+    }
+    field(UDFS, DBF_MENU) {
+        promptgroup("70 - Alarm")
+        menu(menuAlarmSevr)
+        initial("INVALID")
+        interest(1)
+        prompt("Undefined Alarm Sevrty")
+    }
+    field(TIME, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("epicsTimeStamp      time")
+        interest(2)
+        prompt("Time")
+    }
+    field(FLNK, DBF_FWDLINK) {
+        promptgroup("20 - Scan")
+        interest(1)
+        prompt("Forward Process Link")
+    }
+    field(VAL, DBF_STRING) {
+        promptgroup("40 - Input")
+        asl(ASL0)
+        pp(TRUE)
+        size(40)
+        prompt("Current Value")
+    }
+    field(OVAL, DBF_STRING) {
+        special(SPC_NOMOD)
+        interest(3)
+        size(40)
+        prompt("Previous Value")
+    }
+    field(INP, DBF_INLINK) {
+        promptgroup("40 - Input")
+        interest(1)
+        prompt("Input Specification")
+    }
+    field(MPST, DBF_MENU) {
+        promptgroup("80 - Display")
+        menu(stringinPOST)
+        interest(1)
+        prompt("Post Value Monitors")
+    }
+    field(APST, DBF_MENU) {
+        promptgroup("80 - Display")
+        menu(stringinPOST)
+        interest(1)
+        prompt("Post Archive Monitors")
+    }
+    field(SIOL, DBF_INLINK) {
+        promptgroup("90 - Simulate")
+        interest(1)
+        prompt("Simulation Input Link")
+    }
+    field(SVAL, DBF_STRING) {
+        pp(TRUE)
+        size(40)
+        prompt("Simulation Value")
+    }
+    field(SIML, DBF_INLINK) {
+        promptgroup("90 - Simulate")
+        interest(1)
+        prompt("Simulation Mode Link")
+    }
+    field(SIMM, DBF_MENU) {
+        special(SPC_MOD)
+        menu(menuYesNo)
+        interest(1)
+        prompt("Simulation Mode")
+    }
+    field(SIMS, DBF_MENU) {
+        promptgroup("90 - Simulate")
+        menu(menuAlarmSevr)
+        interest(2)
+        prompt("Simulation Mode Severity")
+    }
+    field(OLDSIMM, DBF_MENU) {
+        special(SPC_NOMOD)
+        menu(menuSimm)
+        interest(4)
+        prompt("Prev. Simulation Mode")
+    }
+    field(SSCN, DBF_MENU) {
+        promptgroup("90 - Simulate")
+        menu(menuScan)
+        initial("65535")
+        interest(1)
+        prompt("Sim. Mode Scan")
+    }
+    field(SDLY, DBF_DOUBLE) {
+        promptgroup("90 - Simulate")
+        initial("-1.0")
+        interest(2)
+        prompt("Sim. Mode Async Delay")
+    }
+    field(SIMPVT, DBF_NOACCESS) {
+        special(SPC_NOMOD)
+        extra("CALLBACK            *simpvt")
+        interest(4)
+        prompt("Sim. Mode Private")
+    }
 }
-recordtype(asyn) {
-	field(NAME,DBF_STRING) {
-		prompt("Record Name")
-		special(SPC_NOMOD)
-		size(61)
-	}
-	field(DESC,DBF_STRING) {
-		prompt("Descriptor")
-		promptgroup(GUI_COMMON)
-		size(41)
-	}
-	field(ASG,DBF_STRING) {
-		prompt("Access Security Group")
-		promptgroup(GUI_COMMON)
-		special(SPC_AS)
-		size(29)
-	}
-	field(SCAN,DBF_MENU) {
-		prompt("Scan Mechanism")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuScan)
-		interest(1)
-	}
-	field(PINI,DBF_MENU) {
-		prompt("Process at iocInit")
-		promptgroup(GUI_SCAN)
-		menu(menuPini)
-		interest(1)
-	}
-	field(PHAS,DBF_SHORT) {
-		prompt("Scan Phase")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(EVNT,DBF_SHORT) {
-		prompt("Event Number")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		interest(1)
-	}
-	field(TSE,DBF_SHORT) {
-		prompt("Time Stamp Event")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(TSEL,DBF_INLINK) {
-		prompt("Time Stamp Link")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(DTYP,DBF_DEVICE) {
-		prompt("Device Type")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(DISV,DBF_SHORT) {
-		prompt("Disable Value")
-		initial("1")
-		promptgroup(GUI_SCAN)
-	}
-	field(DISA,DBF_SHORT) {
-		prompt("Disable")
-	}
-	field(SDIS,DBF_INLINK) {
-		prompt("Scanning Disable")
-		promptgroup(GUI_SCAN)
-		interest(1)
-	}
-	field(MLOK,DBF_NOACCESS) {
-		prompt("Monitor lock")
-		special(SPC_NOMOD)
-		extra("epicsMutexId	mlok")
-		interest(4)
-	}
-	field(MLIS,DBF_NOACCESS) {
-		prompt("Monitor List")
-		special(SPC_NOMOD)
-		extra("ELLLIST		mlis")
-		interest(4)
-	}
-	field(DISP,DBF_UCHAR) {
-		prompt("Disable putField")
-	}
-	field(PROC,DBF_UCHAR) {
-		prompt("Force Processing")
-		pp(TRUE)
-		interest(3)
-	}
-	field(STAT,DBF_MENU) {
-		prompt("Alarm Status")
-		initial("UDF")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-	}
-	field(SEVR,DBF_MENU) {
-		prompt("Alarm Severity")
-		initial("INVALID")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-	}
-	field(NSTA,DBF_MENU) {
-		prompt("New Alarm Status")
-		special(SPC_NOMOD)
-		menu(menuAlarmStat)
-		interest(2)
-	}
-	field(NSEV,DBF_MENU) {
-		prompt("New Alarm Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKS,DBF_MENU) {
-		prompt("Alarm Ack Severity")
-		special(SPC_NOMOD)
-		menu(menuAlarmSevr)
-		interest(2)
-	}
-	field(ACKT,DBF_MENU) {
-		prompt("Alarm Ack Transient")
-		initial("YES")
-		promptgroup(GUI_ALARMS)
-		special(SPC_NOMOD)
-		menu(menuYesNo)
-		interest(2)
-	}
-	field(DISS,DBF_MENU) {
-		prompt("Disable Alarm Sevrty")
-		promptgroup(GUI_SCAN)
-		menu(menuAlarmSevr)
-		interest(1)
-	}
-	field(LCNT,DBF_UCHAR) {
-		prompt("Lock Count")
-		special(SPC_NOMOD)
-		interest(2)
-	}
-	field(PACT,DBF_UCHAR) {
-		prompt("Record active")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(PUTF,DBF_UCHAR) {
-		prompt("dbPutField process")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(RPRO,DBF_UCHAR) {
-		prompt("Reprocess ")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(ASP,DBF_NOACCESS) {
-		prompt("Access Security Pvt")
-		special(SPC_NOMOD)
-		extra("struct asgMember *asp")
-		interest(4)
-	}
-	field(PPN,DBF_NOACCESS) {
-		prompt("addr of PUTNOTIFY")
-		special(SPC_NOMOD)
-		extra("struct putNotify *ppn")
-		interest(4)
-	}
-	field(PPNR,DBF_NOACCESS) {
-		prompt("pputNotifyRecord")
-		special(SPC_NOMOD)
-		extra("struct putNotifyRecord *ppnr")
-		interest(4)
-	}
-	field(SPVT,DBF_NOACCESS) {
-		prompt("Scan Private")
-		special(SPC_NOMOD)
-		extra("struct scan_element *spvt")
-		interest(4)
-	}
-	field(RSET,DBF_NOACCESS) {
-		prompt("Address of RSET")
-		special(SPC_NOMOD)
-		extra("struct rset	*rset")
-		interest(4)
-	}
-	field(DSET,DBF_NOACCESS) {
-		prompt("DSET address")
-		special(SPC_NOMOD)
-		extra("struct dset	*dset")
-		interest(4)
-	}
-	field(DPVT,DBF_NOACCESS) {
-		prompt("Device Private")
-		special(SPC_NOMOD)
-		extra("void		*dpvt")
-		interest(4)
-	}
-	field(RDES,DBF_NOACCESS) {
-		prompt("Address of dbRecordType")
-		special(SPC_NOMOD)
-		extra("struct dbRecordType *rdes")
-		interest(4)
-	}
-	field(LSET,DBF_NOACCESS) {
-		prompt("Lock Set")
-		special(SPC_NOMOD)
-		extra("struct lockRecord *lset")
-		interest(4)
-	}
-	field(PRIO,DBF_MENU) {
-		prompt("Scheduling Priority")
-		promptgroup(GUI_SCAN)
-		special(SPC_SCAN)
-		menu(menuPriority)
-		interest(1)
-	}
-	field(TPRO,DBF_UCHAR) {
-		prompt("Trace Processing")
-	}
-	field(BKPT,DBF_NOACCESS) {
-		prompt("Break Point")
-		special(SPC_NOMOD)
-		extra("char bkpt")
-		interest(1)
-	}
-	field(UDF,DBF_UCHAR) {
-		prompt("Undefined")
-		initial("1")
-		promptgroup(GUI_COMMON)
-		pp(TRUE)
-		interest(1)
-	}
-	field(TIME,DBF_NOACCESS) {
-		prompt("Time")
-		special(SPC_NOMOD)
-		extra("epicsTimeStamp	time")
-		interest(2)
-	}
-	field(FLNK,DBF_FWDLINK) {
-		prompt("Forward Process Link")
-		promptgroup(GUI_LINKS)
-		interest(1)
-	}
-	field(VAL,DBF_LONG) {
-		prompt("Value field (unused)")
-		interest(4)
-		asl(ASL0)
-	}
-	field(PORT,DBF_STRING) {
-		prompt("asyn port")
-		initial("")
-		promptgroup(GUI_INPUTS)
-		special(100)
-		size(40)
-		interest(1)
-	}
-	field(ADDR,DBF_LONG) {
-		prompt("asyn address")
-		initial("0")
-		promptgroup(GUI_INPUTS)
-		special(100)
-		interest(1)
-	}
-	field(PCNCT,DBF_MENU) {
-		prompt("Port Connect/Disconnect")
-		special(100)
-		menu(asynCONNECT)
-		interest(2)
-	}
-	field(DRVINFO,DBF_STRING) {
-		prompt("Driver info string")
-		initial("")
-		promptgroup(GUI_INPUTS)
-		special(100)
-		size(40)
-		interest(2)
-	}
-	field(REASON,DBF_LONG) {
-		prompt("asynUser->reason")
-		special(100)
-		interest(2)
-	}
-	field(TMOD,DBF_MENU) {
-		prompt("Transaction mode")
-		promptgroup(GUI_INPUTS)
-		menu(asynTMOD)
-		interest(1)
-	}
-	field(TMOT,DBF_DOUBLE) {
-		prompt("Timeout (sec)")
-		initial("1.0")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(IFACE,DBF_MENU) {
-		prompt("Interface")
-		promptgroup(GUI_INPUTS)
-		special(100)
-		menu(asynINTERFACE)
-		interest(2)
-	}
-	field(OCTETIV,DBF_LONG) {
-		prompt("asynOctet is valid")
-		interest(2)
-	}
-	field(OPTIONIV,DBF_LONG) {
-		prompt("asynOption is valid")
-		interest(2)
-	}
-	field(GPIBIV,DBF_LONG) {
-		prompt("asynGPIB is valid")
-		interest(2)
-	}
-	field(I32IV,DBF_LONG) {
-		prompt("asynInt32 is valid")
-		interest(2)
-	}
-	field(UI32IV,DBF_LONG) {
-		prompt("asynUInt32Digital is valid")
-		interest(2)
-	}
-	field(F64IV,DBF_LONG) {
-		prompt("asynFloat64 is valid")
-		interest(2)
-	}
-	field(AOUT,DBF_STRING) {
-		prompt("Output (command) string")
-		promptgroup(GUI_OUTPUT)
-		size(40)
-		pp(TRUE)
-		interest(1)
-	}
-	field(OEOS,DBF_STRING) {
-		prompt("Output delimiter")
-		promptgroup(GUI_OUTPUT)
-		special(100)
-		size(40)
-		interest(1)
-	}
-	field(BOUT,DBF_CHAR) {
-		prompt("Output binary data")
-		special(SPC_DBADDR)
-		pp(TRUE)
-		interest(1)
-	}
-	field(OPTR,DBF_NOACCESS) {
-		prompt("Output buffer pointer")
-		special(SPC_NOMOD)
-		extra("void *optr")
-		interest(4)
-	}
-	field(OMAX,DBF_LONG) {
-		prompt("Max. size of output array")
-		initial("80")
-		promptgroup(GUI_OUTPUT)
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(NOWT,DBF_LONG) {
-		prompt("Number of bytes to write")
-		initial("80")
-		promptgroup(GUI_OUTPUT)
-		interest(1)
-	}
-	field(NAWT,DBF_LONG) {
-		prompt("Number of bytes actually written")
-		interest(1)
-	}
-	field(OFMT,DBF_MENU) {
-		prompt("Output format")
-		promptgroup(GUI_OUTPUT)
-		menu(asynFMT)
-		interest(1)
-	}
-	field(AINP,DBF_STRING) {
-		prompt("Input (response) string")
-		special(SPC_NOMOD)
-		size(40)
-		interest(1)
-	}
-	field(TINP,DBF_STRING) {
-		prompt("Translated input string")
-		special(SPC_NOMOD)
-		size(40)
-		interest(1)
-		asl(ASL0)
-	}
-	field(IEOS,DBF_STRING) {
-		prompt("Input Delimiter")
-		promptgroup(GUI_INPUTS)
-		special(100)
-		size(40)
-		interest(1)
-	}
-	field(BINP,DBF_CHAR) {
-		prompt("Input binary data")
-		special(SPC_DBADDR)
-		asl(ASL0)
-	}
-	field(IPTR,DBF_NOACCESS) {
-		prompt("Input buffer pointer")
-		special(SPC_NOMOD)
-		extra("void *iptr")
-		interest(4)
-	}
-	field(IMAX,DBF_LONG) {
-		prompt("Max. size of input array")
-		initial("80")
-		promptgroup(GUI_INPUTS)
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(NRRD,DBF_LONG) {
-		prompt("Number of bytes to read")
-		promptgroup(GUI_INPUTS)
-		interest(1)
-	}
-	field(NORD,DBF_LONG) {
-		prompt("Number of bytes read")
-		special(SPC_NOMOD)
-		interest(1)
-	}
-	field(IFMT,DBF_MENU) {
-		prompt("Input format")
-		promptgroup(GUI_INPUTS)
-		menu(asynFMT)
-		interest(1)
-	}
-	field(EOMR,DBF_MENU) {
-		prompt("EOM reason")
-		special(SPC_NOMOD)
-		menu(asynEOMREASON)
-		interest(1)
-	}
-	field(I32INP,DBF_LONG) {
-		prompt("asynInt32 input")
-		special(SPC_NOMOD)
-		interest(2)
-	}
-	field(I32OUT,DBF_LONG) {
-		prompt("asynInt32 output")
-		promptgroup(GUI_OUTPUT)
-		pp(TRUE)
-		interest(2)
-	}
-	field(UI32INP,DBF_ULONG) {
-		prompt("asynUInt32Digital input")
-		special(SPC_NOMOD)
-		interest(2)
-	}
-	field(UI32OUT,DBF_ULONG) {
-		prompt("asynUInt32Digital output")
-		promptgroup(GUI_OUTPUT)
-		pp(TRUE)
-		interest(2)
-	}
-	field(UI32MASK,DBF_ULONG) {
-		prompt("asynUInt32Digital mask")
-		initial("0xffffffff")
-		promptgroup(GUI_OUTPUT)
-		special(100)
-		interest(2)
-	}
-	field(F64INP,DBF_DOUBLE) {
-		prompt("asynFloat64 input")
-		special(SPC_NOMOD)
-		interest(2)
-	}
-	field(F64OUT,DBF_DOUBLE) {
-		prompt("asynFloat64 output")
-		promptgroup(GUI_OUTPUT)
-		pp(TRUE)
-		interest(2)
-	}
-	field(BAUD,DBF_MENU) {
-		prompt("Baud rate")
-		promptgroup(GUI_INPUTS)
-		special(100)
-		menu(serialBAUD)
-		interest(2)
-	}
-	field(LBAUD,DBF_LONG) {
-		prompt("Baud rate")
-		promptgroup(GUI_INPUTS)
-		special(100)
-		interest(2)
-	}
-	field(PRTY,DBF_MENU) {
-		prompt("Parity")
-		promptgroup(GUI_INPUTS)
-		special(100)
-		menu(serialPRTY)
-		interest(2)
-	}
-	field(DBIT,DBF_MENU) {
-		prompt("Data bits")
-		promptgroup(GUI_INPUTS)
-		special(100)
-		menu(serialDBIT)
-		interest(2)
-	}
-	field(SBIT,DBF_MENU) {
-		prompt("Stop bits")
-		promptgroup(GUI_INPUTS)
-		special(100)
-		menu(serialSBIT)
-		interest(2)
-	}
-	field(MCTL,DBF_MENU) {
-		prompt("Modem control")
-		promptgroup(GUI_INPUTS)
-		special(100)
-		menu(serialMCTL)
-		interest(2)
-	}
-	field(FCTL,DBF_MENU) {
-		prompt("Flow control")
-		promptgroup(GUI_INPUTS)
-		special(100)
-		menu(serialFCTL)
-		interest(2)
-	}
-	field(IXON,DBF_MENU) {
-		prompt("Output XON/XOFF")
-		promptgroup(GUI_INPUTS)
-		special(100)
-		menu(serialIX)
-		interest(2)
-	}
-	field(IXOFF,DBF_MENU) {
-		prompt("Input XON/XOFF")
-		promptgroup(GUI_INPUTS)
-		special(100)
-		menu(serialIX)
-		interest(2)
-	}
-	field(IXANY,DBF_MENU) {
-		prompt("XON=any character")
-		promptgroup(GUI_INPUTS)
-		special(100)
-		menu(serialIX)
-		interest(2)
-	}
-	field(HOSTINFO,DBF_STRING) {
-		prompt("host info")
-		initial("")
-		promptgroup(GUI_INPUTS)
-		special(100)
-		size(40)
-		interest(1)
-	}
-	field(DRTO,DBF_MENU) {
-		prompt("Disconnect on timeout")
-		promptgroup(GUI_INPUTS)
-		special(100)
-		menu(ipDRTO)
-		interest(2)
-	}
-	field(UCMD,DBF_MENU) {
-		prompt("Universal command")
-		promptgroup(GUI_OUTPUT)
-		menu(gpibUCMD)
-		pp(TRUE)
-		interest(2)
-	}
-	field(ACMD,DBF_MENU) {
-		prompt("Addressed command")
-		promptgroup(GUI_OUTPUT)
-		menu(gpibACMD)
-		pp(TRUE)
-		interest(2)
-	}
-	field(SPR,DBF_UCHAR) {
-		prompt("Serial poll response")
-		special(SPC_NOMOD)
-		interest(2)
-	}
-	field(TMSK,DBF_LONG) {
-		prompt("Trace mask")
-		promptgroup(GUI_DISPLAY)
-		special(100)
-		interest(1)
-	}
-	field(TB0,DBF_MENU) {
-		prompt("Trace error")
-		promptgroup(GUI_DISPLAY)
-		special(100)
-		menu(asynTRACE)
-		interest(1)
-	}
-	field(TB1,DBF_MENU) {
-		prompt("Trace IO device")
-		promptgroup(GUI_DISPLAY)
-		special(100)
-		menu(asynTRACE)
-		interest(1)
-	}
-	field(TB2,DBF_MENU) {
-		prompt("Trace IO filter")
-		promptgroup(GUI_DISPLAY)
-		special(100)
-		menu(asynTRACE)
-		interest(1)
-	}
-	field(TB3,DBF_MENU) {
-		prompt("Trace IO driver")
-		promptgroup(GUI_DISPLAY)
-		special(100)
-		menu(asynTRACE)
-		interest(1)
-	}
-	field(TB4,DBF_MENU) {
-		prompt("Trace flow")
-		promptgroup(GUI_DISPLAY)
-		special(100)
-		menu(asynTRACE)
-		interest(1)
-	}
-	field(TB5,DBF_MENU) {
-		prompt("Trace warning")
-		promptgroup(GUI_DISPLAY)
-		special(100)
-		menu(asynTRACE)
-		interest(1)
-	}
-	field(TIOM,DBF_LONG) {
-		prompt("Trace I/O mask")
-		promptgroup(GUI_DISPLAY)
-		special(100)
-		interest(1)
-	}
-	field(TIB0,DBF_MENU) {
-		prompt("Trace IO ASCII")
-		promptgroup(GUI_DISPLAY)
-		special(100)
-		menu(asynTRACE)
-		interest(1)
-	}
-	field(TIB1,DBF_MENU) {
-		prompt("Trace IO escape")
-		promptgroup(GUI_DISPLAY)
-		special(100)
-		menu(asynTRACE)
-		interest(1)
-	}
-	field(TIB2,DBF_MENU) {
-		prompt("Trace IO hex")
-		promptgroup(GUI_DISPLAY)
-		special(100)
-		menu(asynTRACE)
-		interest(1)
-	}
-	field(TINM,DBF_LONG) {
-		prompt("Trace Info mask")
-		promptgroup(GUI_DISPLAY)
-		special(100)
-		interest(1)
-	}
-	field(TINB0,DBF_MENU) {
-		prompt("Trace Info Time")
-		promptgroup(GUI_DISPLAY)
-		special(100)
-		menu(asynTRACE)
-		interest(1)
-	}
-	field(TINB1,DBF_MENU) {
-		prompt("Trace Info Port")
-		promptgroup(GUI_DISPLAY)
-		special(100)
-		menu(asynTRACE)
-		interest(1)
-	}
-	field(TINB2,DBF_MENU) {
-		prompt("Trace Info Source")
-		promptgroup(GUI_DISPLAY)
-		special(100)
-		menu(asynTRACE)
-		interest(1)
-	}
-	field(TINB3,DBF_MENU) {
-		prompt("Trace Info Thread")
-		promptgroup(GUI_DISPLAY)
-		special(100)
-		menu(asynTRACE)
-		interest(1)
-	}
-	field(TSIZ,DBF_LONG) {
-		prompt("Trace IO truncate size")
-		promptgroup(GUI_DISPLAY)
-		special(100)
-		interest(1)
-	}
-	field(TFIL,DBF_STRING) {
-		prompt("Trace IO file")
-		promptgroup(GUI_DISPLAY)
-		special(100)
-		size(40)
-		interest(1)
-	}
-	field(AUCT,DBF_MENU) {
-		prompt("Autoconnect")
-		promptgroup(GUI_INPUTS)
-		special(100)
-		menu(asynAUTOCONNECT)
-		interest(1)
-	}
-	field(CNCT,DBF_MENU) {
-		prompt("Connect/Disconnect")
-		promptgroup(GUI_INPUTS)
-		special(100)
-		menu(asynCONNECT)
-		interest(1)
-	}
-	field(ENBL,DBF_MENU) {
-		prompt("Enable/Disable")
-		promptgroup(GUI_INPUTS)
-		special(100)
-		menu(asynENABLE)
-		interest(1)
-	}
-	field(ERRS,DBF_NOACCESS) {
-		prompt("Error string")
-		special(SPC_DBADDR)
-		extra("char *errs")
-		interest(4)
-	}
-	field(AQR,DBF_UCHAR) {
-		prompt("Abort queueRequest")
-		special(100)
-		interest(4)
-	}
-}
-device(aai,CONSTANT,devAaiSoft,"Soft Channel")
-device(aao,CONSTANT,devAaoSoft,"Soft Channel")
-device(ai,CONSTANT,devAiSoft,"Soft Channel")
-device(ai,CONSTANT,devAiSoftRaw,"Raw Soft Channel")
-device(ai,INST_IO,devTimestampAI,"Soft Timestamp")
-device(ai,INST_IO,devAiGeneralTime,"General Time")
-device(ai,INST_IO,devAiStats,"IOC stats")
-device(ai,INST_IO,devAiClusts,"IOC stats clusts")
-device(ai,INST_IO,asynAiInt32,"asynInt32")
-device(ai,INST_IO,asynAiInt32Average,"asynInt32Average")
-device(ai,INST_IO,asynAiFloat64,"asynFloat64")
-device(ai,INST_IO,asynAiFloat64Average,"asynFloat64Average")
-device(ao,CONSTANT,devAoSoft,"Soft Channel")
-device(ao,CONSTANT,devAoSoftRaw,"Raw Soft Channel")
-device(ao,CONSTANT,devAoSoftCallback,"Async Soft Channel")
-device(ao,INST_IO,devAoStats,"IOC stats")
-device(ao,INST_IO,asynAoInt32,"asynInt32")
-device(ao,INST_IO,asynAoFloat64,"asynFloat64")
-device(bi,CONSTANT,devBiSoft,"Soft Channel")
-device(bi,CONSTANT,devBiSoftRaw,"Raw Soft Channel")
-device(bi,INST_IO,asynBiInt32,"asynInt32")
-device(bi,INST_IO,asynBiUInt32Digital,"asynUInt32Digital")
-device(bo,CONSTANT,devBoSoft,"Soft Channel")
-device(bo,CONSTANT,devBoSoftRaw,"Raw Soft Channel")
-device(bo,CONSTANT,devBoSoftCallback,"Async Soft Channel")
-device(bo,INST_IO,devBoGeneralTime,"General Time")
-device(bo,INST_IO,asynBoInt32,"asynInt32")
-device(bo,INST_IO,asynBoUInt32Digital,"asynUInt32Digital")
-device(calcout,CONSTANT,devCalcoutSoft,"Soft Channel")
-device(calcout,CONSTANT,devCalcoutSoftCallback,"Async Soft Channel")
-device(event,CONSTANT,devEventSoft,"Soft Channel")
-device(longin,CONSTANT,devLiSoft,"Soft Channel")
-device(longin,INST_IO,devLiGeneralTime,"General Time")
-device(longin,INST_IO,asynLiInt32,"asynInt32")
-device(longin,INST_IO,asynLiUInt32Digital,"asynUInt32Digital")
-device(longout,CONSTANT,devLoSoft,"Soft Channel")
-device(longout,CONSTANT,devLoSoftCallback,"Async Soft Channel")
-device(longout,INST_IO,asynLoInt32,"asynInt32")
-device(longout,INST_IO,asynLoUInt32Digital,"asynUInt32Digital")
-device(mbbi,CONSTANT,devMbbiSoft,"Soft Channel")
-device(mbbi,CONSTANT,devMbbiSoftRaw,"Raw Soft Channel")
-device(mbbi,INST_IO,asynMbbiInt32,"asynInt32")
-device(mbbi,INST_IO,asynMbbiUInt32Digital,"asynUInt32Digital")
-device(mbbiDirect,CONSTANT,devMbbiDirectSoft,"Soft Channel")
-device(mbbiDirect,CONSTANT,devMbbiDirectSoftRaw,"Raw Soft Channel")
-device(mbbiDirect,INST_IO,asynMbbiDirectUInt32Digital,"asynUInt32Digital")
-device(mbbo,CONSTANT,devMbboSoft,"Soft Channel")
-device(mbbo,CONSTANT,devMbboSoftRaw,"Raw Soft Channel")
-device(mbbo,CONSTANT,devMbboSoftCallback,"Async Soft Channel")
-device(mbbo,INST_IO,asynMbboInt32,"asynInt32")
-device(mbbo,INST_IO,asynMbboUInt32Digital,"asynUInt32Digital")
-device(mbboDirect,CONSTANT,devMbboDirectSoft,"Soft Channel")
-device(mbboDirect,CONSTANT,devMbboDirectSoftRaw,"Raw Soft Channel")
-device(mbboDirect,CONSTANT,devMbboDirectSoftCallback,"Async Soft Channel")
-device(mbboDirect,INST_IO,asynMbboDirectUInt32Digital,"asynUInt32Digital")
-device(stringin,CONSTANT,devSiSoft,"Soft Channel")
-device(stringin,INST_IO,devTimestampSI,"Soft Timestamp")
-device(stringin,INST_IO,devSiGeneralTime,"General Time")
-device(stringin,INST_IO,devStringinStats,"IOC stats")
-device(stringin,INST_IO,devStringinEnvVar,"IOC env var")
-device(stringin,INST_IO,devStringinEpics,"IOC epics var")
-device(stringin,INST_IO,asynSiOctetCmdResponse,"asynOctetCmdResponse")
-device(stringin,INST_IO,asynSiOctetWriteRead,"asynOctetWriteRead")
-device(stringin,INST_IO,asynSiOctetRead,"asynOctetRead")
-device(stringout,CONSTANT,devSoSoft,"Soft Channel")
-device(stringout,CONSTANT,devSoSoftCallback,"Async Soft Channel")
-device(stringout,INST_IO,devSoStdio,"stdio")
-device(stringout,INST_IO,asynSoOctetWrite,"asynOctetWrite")
-device(subArray,CONSTANT,devSASoft,"Soft Channel")
-device(waveform,CONSTANT,devWfSoft,"Soft Channel")
-device(waveform,INST_IO,asynWfOctetCmdResponse,"asynOctetCmdResponse")
-device(waveform,INST_IO,asynWfOctetWriteRead,"asynOctetWriteRead")
-device(waveform,INST_IO,asynWfOctetRead,"asynOctetRead")
-device(waveform,INST_IO,asynWfOctetWrite,"asynOctetWrite")
-device(waveform,INST_IO,asynWfOctetWriteBinary,"asynOctetWriteBinary")
-device(waveform,INST_IO,asynInt8ArrayWfIn,"asynInt8ArrayIn")
-device(waveform,INST_IO,asynInt8ArrayWfOut,"asynInt8ArrayOut")
-device(waveform,INST_IO,asynInt16ArrayWfIn,"asynInt16ArrayIn")
-device(waveform,INST_IO,asynInt16ArrayWfOut,"asynInt16ArrayOut")
-device(waveform,INST_IO,asynInt32ArrayWfIn,"asynInt32ArrayIn")
-device(waveform,INST_IO,asynInt32ArrayWfOut,"asynInt32ArrayOut")
-device(waveform,INST_IO,asynInt32TimeSeries,"asynInt32TimeSeries")
-device(waveform,INST_IO,asynFloat32ArrayWfIn,"asynFloat32ArrayIn")
-device(waveform,INST_IO,asynFloat32ArrayWfOut,"asynFloat32ArrayOut")
-device(waveform,INST_IO,asynFloat64ArrayWfIn,"asynFloat64ArrayIn")
-device(waveform,INST_IO,asynFloat64ArrayWfOut,"asynFloat64ArrayOut")
-device(waveform,INST_IO,asynFloat64TimeSeries,"asynFloat64TimeSeries")
-device(axis,INST_IO,devMotorAsyn,"asynAxis")
-device(asyn,INST_IO,asynRecordDevice,"asynRecordDevice")
+device(stringin, CONSTANT, devSiSoft, "Soft Channel")
+device(stringin, CONSTANT, devSiSoftCallback, "Async Soft Channel")
+device(stringin, INST_IO, devTimestampSI, "Soft Timestamp")
+device(stringin, INST_IO, devSiGeneralTime, "General Time")
+device(stringin, INST_IO, devSiEnviron, "getenv")
+device(stringin, INST_IO, devStringinStats, "IOC stats")
+device(stringin, INST_IO, devStringinEnvVar, "IOC env var")
+device(stringin, INST_IO, devStringinEpics, "IOC epics var")
+device(stringin, INST_IO, asynSiOctetCmdResponse, "asynOctetCmdResponse")
+device(stringin, INST_IO, asynSiOctetWriteRead, "asynOctetWriteRead")
+device(stringin, INST_IO, asynSiOctetRead, "asynOctetRead")
 driver(drvAsyn)
-registrar(asSub)
-registrar(save_restoreRegister)
+link(state, lnkStateIf)
+link(calc, lnkCalcIf)
+link(trace, lnkTraceIf)
+link(debug, lnkDebugIf)
+link(const, lnkConstIf)
+registrar(asynMotorControllerRegister)
+registrar(tsInitialize)
+registrar(syncInitialize)
 registrar(dbrestoreRegister)
-registrar(asInitHooksRegister)
-registrar(configMenuRegistrar)
+registrar(motorRegister)
 registrar(adsAsynPortDriverRegister)
-registrar(axisUtilRegister)
-registrar(asynAxisControllerRegister)
-registrar(EthercatMCControllerRegister)
+registrar(save_restoreRegister)
 registrar(asynRegister)
 registrar(asynInterposeFlushRegister)
-registrar(asynInterposeEosRegister)
+registrar(infoFieldArchiveRegister)
 registrar(drvAsynIPPortRegisterCommands)
+registrar(motorUtilRegister)
+registrar(arrInitialize)
+registrar(asynInterposeEchoRegister)
+registrar(caPutLogRegister)
+registrar(asInitHooksRegister)
+registrar(asynInterposeDelayRegister)
+registrar(dbndInitialize)
+registrar(EthercatMCControllerRegister)
 registrar(drvAsynIPServerPortRegisterCommands)
-variable(asCaDebug,int)
-variable(dbRecordsOnceOnly,int)
-variable(dbBptNotMonotonic,int)
-variable(dbTemplateMaxVars,int)
-variable(save_restoreDebug,int)
-variable(save_restoreNumSeqFiles,int)
-variable(save_restoreSeqPeriodInSeconds,int)
-variable(save_restoreIncompleteSetsOk,int)
-variable(save_restoreDatedBackupFiles,int)
-variable(save_restoreRemountThreshold,int)
-variable(configMenuDebug,int)
+registrar(configMenuRegistrar)
+registrar(asSub)
+registrar(rsrvRegistrar)
+registrar(asynInterposeEosRegister)
+function(scanMon)
+function(rebootProc)
+function(scanMonInit)
+variable(dbTemplateMaxVars, int)
+variable(lnkDebug_debug, int)
+variable(asCaDebug, int)
+variable(callbackParallelThreadsDefault, int)
+variable(save_restoreRemountThreshold, int)
+variable(dbAccessDebugPUTF, int)
+variable(dbLoadSuspendOnError, int)
+variable(dbRecordsOnceOnly, int)
+variable(save_restoreDebug, int)
+variable(save_restoreDatedBackupFiles, int)
+variable(calcoutODLYlimit, double)
+variable(configMenuDebug, int)
+variable(save_restoreIncompleteSetsOk, int)
+variable(dbBptNotMonotonic, int)
+variable(atExitDebug, int)
+variable(boHIGHlimit, double)
+variable(dbJLinkDebug, int)
+variable(dbConvertStrict, int)
+variable(seqDLYprecision, int)
+variable(dbQuietMacroWarnings, int)
+variable(save_restoreNumSeqFiles, int)
+variable(boHIGHprecision, int)
+variable(dbRecordsAbcSorted, int)
+variable(seqDLYlimit, double)
+variable(calcoutODLYprecision, int)
+variable(histogramSDELprecision, int)
+variable(dbThreadRealtimeLock, int)
+variable(CASDEBUG, int)
+variable(save_restoreLogMissingRecords, int)
+variable(save_restoreSeqPeriodInSeconds, int)


### PR DESCRIPTION
## Context

Closes #286 

## Changes
* Updates the vendored `ads.dbd` to the ads-ioc R0.5.0 database definition file (this makes the diff line count look massive...)
    * This is used in the test suite to verify the fields that we have set
* Adds description field to autosave for all records, input and output
* Adds alarm severity and limit fields to autosave for all relevant input and output records
* Adds control limit (drive low/high) fields to autosave for relevant output records

## Helpful whatrecord blurb

```python
import whatrecord
dbd = whatrecord.parse("pytmc/tests/ads.dbd")
for rtyp in ("ai", "ao", "bi", "bo", "mbbi", "mbbo", "longin", "longout", "waveform"):
    print(f"\n\n{rtyp}\n{'-' * len(rtyp)}")
    for name, fld in dbd.record_types[rtyp].fields.items():
        if fld.prompt and "sev" in fld.prompt.lower():
            print(f'"{name}",  # {fld.prompt}')
```