### PR TITLE
FIX: safety PLCs are located in _Config/SPLC

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -88,7 +88,7 @@ release = ''
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/pytmc/parser.py
+++ b/pytmc/parser.py
@@ -106,6 +106,25 @@ def element_to_class_name(
     tag = strip_namespace(element.tag)
     extension = os.path.splitext(element.base)[-1].lower()
 
+    # `Project` is an overloaded tag in TwinCAT XML files. It can be:
+    # * A `TcSmProject`
+    #     - The `.tsproj` root node
+    # * A top-level project -> `TopLevelProject`
+    #     - This contains PLCs, motion, safety, IO
+    #     - Found in `.tsproj` under `TcSmProject`
+    # * An embedded PLC project -> `Plc`
+    #     - Found in `.tsproj`
+    #     - `Project` inside a `Plc` node underneath a `TopLevelProject`
+    # * An external PLC project reference -> `Plc`
+    #     - Marked with "File" or "PrjFilePath" attributes
+    #     - Found under `TcSmProject` / `TopLevelProject` / `Plc`
+    # * The top-level of an external `.plcproj` project -> `PlcProject`
+    #     - Found in the `.plcproj` file referenced via `TcSmProject` /
+    #     `TopLevelProject` / `Plc`
+    # * A safety PLC (found under a `Safety` node) -> `SafetyPlc`
+    #     - Found under `TcSmProject` / `TopLevelProject` / `Safety`
+    # * A give-up fallback `Project` container that is pretty much ignored in
+    #   pytmc
     if tag == 'Project':
         if isinstance(parent, TcSmProject):
             return 'TopLevelProject', TwincatItem
@@ -499,7 +518,12 @@ class Link(TwincatItem):
 
 
 class TopLevelProject(TwincatItem):
-    '[tsproj] Containing Io, System, Motion, TopLevelPlc, etc.'
+    """
+    [tsproj] A top-level project.
+
+    Contains Io, System, Motion, Safety, TopLevelPlc, etc.
+    Found in ``.tsproj`` under ``TcSmProject``.
+    """
 
     @property
     def ams_id(self):
@@ -520,11 +544,20 @@ class TopLevelProject(TwincatItem):
 
 
 class PlcProject(TwincatItem):
-    ...
+    """
+    The top-level of an external ``.plcproj`` project -> ``PlcProject``.
+
+    Found in the ``.plcproj`` file referenced via ``TcSmProject`` /
+    ``TopLevelProject`` / ``Plc``
+    """
 
 
 class TcSmProject(TwincatItem):
-    '[tsproj] A top-level TwinCAT tsproj'
+    """
+    [tsproj] A top-level TwinCAT tsproj
+
+    The ``.tsproj`` root node.
+    """
     def post_init(self):
         self.top_level_plc, = list(self.find(TopLevelPlc, recurse=False))
 
@@ -664,7 +697,15 @@ class TopLevelPlc(TwincatItem):
 
 
 class Plc(TwincatItem):
-    '[tsproj] A project which contains Plc, Io, Mappings, etc.'
+    """
+    [tsproj] A project which contains Plc, Io, Mappings, etc.
+
+    This can be an embedded ``Plc`` node in a ``TopLeveLProject`` or an
+    external PLC project reference in a ``Plc`` node marked with "File" or
+    "PrjFilePath" attributes.
+
+    These can be found under ``TcSmProject`` / ``TopLevelProject`` / ``Plc``.
+    """
     _load_path_hint = pathlib.Path('_Config') / 'PLC'
 
     def post_init(self):
@@ -774,7 +815,11 @@ class Safety(TwincatItem):
 
 
 class SafetyPlc(TwincatItem):
-    '[tsproj] A safety PLC project'
+    """
+    [tsproj] A safety PLC project
+
+    Found under ``TcSmProject`` / ``TopLevelProject`` / ``Safety``.
+    """
     _load_path_hint = pathlib.Path('_Config') / 'SPLC'
 
 

--- a/pytmc/parser.py
+++ b/pytmc/parser.py
@@ -109,6 +109,8 @@ def element_to_class_name(
     if tag == 'Project':
         if isinstance(parent, TcSmProject):
             return 'TopLevelProject', TwincatItem
+        if isinstance(parent, Safety):
+            return 'SafetyPlc', TwincatItem
         if 'File' in element.attrib:
             # File to be loaded will contain PrjFilePath
             return 'Plc', TwincatItem
@@ -359,7 +361,6 @@ class TwincatItem:
         -------
         item : TwincatItem
         '''
-
         classname, base = element_to_class_name(element, parent=parent)
 
         try:
@@ -766,6 +767,15 @@ class Plc(TwincatItem):
             for item in source_items
             if hasattr(item, 'get_source_code')
         )
+
+
+class Safety(TwincatItem):
+    '[tsproj] A container for a safety PLC project (SafetyPlc)'
+
+
+class SafetyPlc(TwincatItem):
+    '[tsproj] A safety PLC project'
+    _load_path_hint = pathlib.Path('_Config') / 'SPLC'
 
 
 class Compile(TwincatItem):


### PR DESCRIPTION
## Context
Closes #288 

@ghalym discovered this which I summarized in #288 

## Background

`Project` is an overloaded tag in TwinCAT XML files. It can be:
* A `TcSmProject`
    - The `.tsproj` root node
* A top-level project -> `TopLevelProject`
    - This contains PLCs, motion, safety, IO
    - Found in `.tsproj` under `TcSmProject`
* An embedded PLC project -> `Plc`
    - Found in `.tsproj`
    - `Project` inside a `Plc` node underneath a `TopLevelProject`
* An external PLC project reference -> `Plc`
    - Marked with "File" or "PrjFilePath" attributes
    - Found under `TcSmProject` / `TopLevelProject` / `Plc`
* The top-level of an external `.plcproj` project -> `PlcProject`
    - Found in the `.plcproj` file referenced via `TcSmProject` /
    `TopLevelProject` / `Plc`
* A safety PLC (found under a `Safety` node) -> `SafetyPlc`
    - Found under `TcSmProject` / `TopLevelProject` / `Safety`
* A give-up fallback `Project` container that is pretty much ignored in
  pytmc
 


## Changes

This PR adds support for the last option.
