### PR TITLE
MAINT: scripted fix for precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
     -   id: debug-statements
         exclude: '^(pytmc/bin/util.py)$'
 
--   repo: https://gitlab.com/pycqa/flake8.git
+-   repo: https://github.com/pycqa/flake8.git
     rev: 3.9.2
     hooks:
     -   id: flake8


### PR DESCRIPTION
PR generated from script to fix .pre-commit-config.yaml in all repos, switching out the missing flake8 gitlab mirror for github.