### PR TITLE
FIX: macro sub in st.cmd motor records

### DIFF
--- a/pytmc/tests/tmc_files/tc_mot_example.tmc
+++ b/pytmc/tests/tmc_files/tc_mot_example.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{3B7A44B6-61AE-B9E4-96D9-84598AFCE26B}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{C6745EEA-54D5-EE1D-B0DB-580573B6B612}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="LCLS_General">ST_System</Name>
@@ -55239,7 +55239,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
               <Property>
                 <Name>pytmc</Name>
                 <Value>
-        pv: @PREFIX:SIM:01
+        pv: @(PREFIX):01
         field: DESC Simulated Working Motor
     </Value>
               </Property>
@@ -55261,7 +55261,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
               <Property>
                 <Name>pytmc</Name>
                 <Value>
-        pv: @PREFIX:SIM:02
+        pv: @(PREFIX):02
         field: DESC Simulated Broken Motor
     </Value>
               </Property>
@@ -55283,7 +55283,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
               <Property>
                 <Name>pytmc</Name>
                 <Value>
-        pv: @PREFIX:SIM:03
+        pv: @(PREFIX):03
         field: DESC Simulated Working Motor With Limits
     </Value>
               </Property>
@@ -55305,7 +55305,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
               <Property>
                 <Name>pytmc</Name>
                 <Value>
-        pv: @PREFIX:SIM:XPIM:Y
+        pv: IMTST:XTES:MMS
         field: DESC Simulated XPIM Y
     </Value>
               </Property>
@@ -55321,7 +55321,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
               <Property>
                 <Name>pytmc</Name>
                 <Value>
-        pv: @PREFIX:SIM:XPIM:ZOOM
+        pv: IMTST:XTES:CLZ
         field: DESC Simulated XPIM ZOOM
     </Value>
               </Property>
@@ -55337,7 +55337,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
               <Property>
                 <Name>pytmc</Name>
                 <Value>
-        pv: @PREFIX:SIM:XPIM:FOCUS
+        pv: IMTST:XTES:CLF
         field: DESC Simulated XPIM FOCUS
     </Value>
               </Property>
@@ -55352,7 +55352,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
               <Property>
                 <Name>pytmc</Name>
                 <Value>
-        pv: @PREFIX:SIM:XPIM
+        pv: IMTST:XTES
         io: io
     </Value>
               </Property>
@@ -55368,7 +55368,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
               <Property>
                 <Name>pytmc</Name>
                 <Value>
-        pv: @PREFIX:SIM:3D:X
+        pv: @(PREFIX):3D:X
         field: DESC Simulated X motor for 3d move
     </Value>
               </Property>
@@ -55390,7 +55390,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
               <Property>
                 <Name>pytmc</Name>
                 <Value>
-        pv: @PREFIX:SIM:3D:Y
+        pv: @(PREFIX):3D:Y
         field: DESC Simulated Y motor for 3d move
     </Value>
               </Property>
@@ -55412,7 +55412,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
               <Property>
                 <Name>pytmc</Name>
                 <Value>
-        pv: @PREFIX:SIM:3D:Z
+        pv: @(PREFIX):3D:Z
         field: DESC Simulated Z motor for 3d move
     </Value>
               </Property>
@@ -55433,7 +55433,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
               <Property>
                 <Name>pytmc</Name>
                 <Value>
-        pv: @PREFIX:SIM:3D
+        pv: @(PREFIX):3D
     </Value>
               </Property>
             </Properties>
@@ -55477,7 +55477,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
               <Property>
                 <Name>pytmc</Name>
                 <Value>
-        pv: @PREFIX:SIM:3D:SET
+        pv: @(PREFIX):3D:SET
         io: io
     </Value>
               </Property>
@@ -55492,7 +55492,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
               <Property>
                 <Name>pytmc</Name>
                 <Value>
-        pv: @PREFIX:SIM:3D:GET
+        pv: @(PREFIX):3D:GET
         io: i
     </Value>
               </Property>
@@ -55507,7 +55507,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
               <Property>
                 <Name>pytmc</Name>
                 <Value>
-        pv: @PREFIX:SIM:L2L:SET
+        pv: @(PREFIX):L2L:SET
         io: io
     </Value>
               </Property>
@@ -55522,7 +55522,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
               <Property>
                 <Name>pytmc</Name>
                 <Value>
-        pv: @PREFIX:SIM:L2L:GET
+        pv: @(PREFIX):L2L:GET
         io: io
     </Value>
               </Property>
@@ -55538,7 +55538,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
               <Property>
                 <Name>pytmc</Name>
                 <Value>
-        pv: @PREFIX:SIM:L2L:MOT
+        pv: @(PREFIX):L2L:MOT
         field: DESC Simulated motor for limit to limit state move
     </Value>
               </Property>
@@ -55559,7 +55559,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
               <Property>
                 <Name>pytmc</Name>
                 <Value>
-        pv: @PREFIX:SIM:L2L
+        pv: @(PREFIX):L2L
     </Value>
               </Property>
             </Properties>
@@ -56041,7 +56041,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2023-06-06T16:31:28</Value>
+          <Value>2023-06-12T11:39:59</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>


### PR DESCRIPTION
Previously, the `@` macro substitution machinery did not run for the st.cmd motor records.
This PR removes the duplicated logic and paths us through the same record generation code used for general-purpose db files. This fixes the aforementioned issue.

See https://github.com/pcdshub/lcls-plc-example-motion/pull/10/commits/15bc045b52321a7968d50101f573b8d4a7148177 for mild proof that this works. I've conflated the fix here with some unrelated edits to make my pvnames shorter (they were too long) and edits I made to add parentheses in my substitution lines, but you can see the `@` symbol turning into a `$`

I've also added a unit test.