### PR TITLE
ENH: include type alias source pragmas in db generation

### DIFF
--- a/pytmc/parser.py
+++ b/pytmc/parser.py
@@ -1191,6 +1191,11 @@ class DataType(_TmcItem):
             yield []
             return
 
+        # Type alias
+        if self.base_type is not None:
+            yield from self.base_type.walk(condition=condition)
+
+        # Type subclass
         extends_types = [
             self._get_data_type(ext_type)
             for ext_type in getattr(self, "ExtendsType", [])
@@ -1198,6 +1203,7 @@ class DataType(_TmcItem):
         for extend_type in extends_types:
             yield from extend_type.walk(condition=condition)
 
+        # Types attached to our type
         if hasattr(self, "SubItem"):
             for subitem in self.SubItem:
                 for item in subitem.walk(condition=condition):

--- a/pytmc/tests/test_integrations.py
+++ b/pytmc/tests/test_integrations.py
@@ -64,7 +64,7 @@ def test_allow_no_pragma():
         allow_no_pragma=True,
     )
     good_records = 129
-    total_records = 1002
+    total_records = 1005
 
     assert good_records == len(records)
     assert good_records == len(list(x.valid for x in records if x.valid))

--- a/pytmc/tests/test_parsing.py
+++ b/pytmc/tests/test_parsing.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 from pytmc.parser import get_pou_call_blocks, parse, variables_from_declaration
@@ -230,3 +232,21 @@ def test_route_parsing():
             "Type": "TCP_IP",
         },
     }
+
+
+def test_type_alias_parsing():
+    """
+    Type aliases should resolve to the same walk as their source
+    """
+    file = Path(__file__).parent / 'tmc_files' / 'tc_mot_example.tmc'
+    tmc_item = parse(file)
+    dut_mot = None
+    st_mot = None
+    for dtyp in tmc_item.DataTypes[0].DataType:
+        if dtyp.name == 'DUT_MotionStage':
+            dut_mot = dtyp
+        elif dtyp.name == 'ST_MotionStage':
+            st_mot = dtyp
+    assert dut_mot is not None, "Did not find DUT_MotionStage in test setup"
+    assert st_mot is not None, "Did not find ST_MotionStage in test setup"
+    assert list(dut_mot.walk()) == list(st_mot.walk())


### PR DESCRIPTION
Without this PR, type aliases don't "see" the pragmas from their type source.
This means the database is generated with large numbers of missing records if we keep using the old names (DUT_MotionStage, DUT_PositionState)
Database generation diff: https://github.com/pcdshub/lcls-plc-example-motion/pull/10/commits/6bbae6b30127325e0c5d012191152e551f4600b0