### PR TITLE
FIX: hotfix for couple issues found on plcprog-console

### DIFF
--- a/pytmc/bin/template.py
+++ b/pytmc/bin/template.py
@@ -751,7 +751,7 @@ def main(
 
     all_rendered = {}
     for template in templates:
-        input_filename, output_filename = template.split(os.pathsep, 1)
+        input_filename, output_filename = template.rsplit(":", 1)
         if input_filename == "-":
             # Check if it's an interactive user to warn them what we're doing:
             is_tty = os.isatty(sys.stdin.fileno())

--- a/pytmc/parser.py
+++ b/pytmc/parser.py
@@ -1634,7 +1634,8 @@ class Symbol_ST_MotionStage(Symbol):
         return nc_axis
 
 
-Symbol_DUT_MotionStage = Symbol_ST_MotionStage
+class Symbol_DUT_MotionStage(Symbol_ST_MotionStage):
+    """Back-compatibility alias for previous versions of lcls-twincat-motion."""
 
 
 class GVL(_TwincatProjectSubItem):


### PR DESCRIPTION
* Related to #299 but may not necessarily close it (it's a bit of a hack)
* Patches over bizarre `DUT_MotionStage` aliasing issue where sphinx was failing to find the `nc_axis` attribute of `Symbol_ST_MotionStage` instances and trying to use `__getitem__` on it (`x.nc_axis` -> `x["nc_axis"]`) and throwing nonsensical errors in the meantime
  * This was evaluated from this line in the IOC startup script: https://github.com/pcdshub/ads-ioc/blob/98b6bbd49c2433ae9ddc962ec229732cfa8ecbde/iocBoot/templates/st.cmd.template#L156C17-L156C17