### PR TITLE
MNT: warn on misconfiguration of TwinCAT IDE/project settings

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
   - lxml
   - epics-pypdb >=0.1.5
   run_constrained:
-  - pyqt <5.15
+  - pyqt =5
 
 test:
   imports:
@@ -33,7 +33,7 @@ test:
   - pytest
   - pytest-qt
   - qtpy
-  - pyqt
+  - pyqt =5
 
 about:
   doc_url: https://pcdshub.github.io/pytmc/

--- a/pytmc/parser.py
+++ b/pytmc/parser.py
@@ -846,7 +846,7 @@ class Plc(TwincatItem):
         """
         return self.find_ancestor(TopLevelProject).target_ip
 
-    def find(self, cls, *, recurse=True):
+    def find(self, cls: typing.Type[T], *, recurse=True) -> Generator[T, None, None]:
         yield from super().find(cls, recurse=recurse)
         if self.project is not None:
             yield from self.project.find(cls, recurse=recurse)

--- a/pytmc/parser.py
+++ b/pytmc/parser.py
@@ -1615,7 +1615,7 @@ class Symbol_ST_MotionStage(Symbol):
         expected = "^" + self.name.lower() + ".axis.nctoplc"
         links = [
             link
-            for link in plc.find(Link, recurse=False)
+            for link in plc.links
             if expected in link.a[1].lower()
         ]
 

--- a/pytmc/parser.py
+++ b/pytmc/parser.py
@@ -807,9 +807,21 @@ class Plc(TwincatItem):
 
     @property
     def links(self) -> list[Link]:
+        mappings = getattr(self, "Mappings", None)
+        if mappings is None:
+            # This is technically a TwinCAT misconfiguration as far as PCDS is
+            # concerned
+            # Mappings are by default stored at the tsproj level and not in the
+            # PLC (XTI) here
+            logger.warning(
+                "TwinCAT/project settings misconfiguration; no mappings in XTI file. "
+                "Please fix your environment and project."
+            )
+            return list(self.root.find(Link, recurse=False))
+
         return [
             link
-            for mapping in self.Mappings
+            for mapping in mappings
             for link in mapping.find(Link, recurse=False)
         ]
 


### PR DESCRIPTION
## The issue

When TwinCAT is not configured according to our setup guide (specifically independent project files), the user gets a confusing traceback while attempting to generate an IOC startup script that links NC axes back to their `DUT_MotionStage` (or `ST_MotionStage`):
```
Traceback (most recent call last):
 File "C:\miniconda\envs\ads-deploy-2.9.1\lib\site-packages\jinja2\environment.py", line 466, in getitem
  return obj[argument]
TypeError: 'Symbol_DUT_MotionStage' object is not subscriptable

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
 File "C:\miniconda\envs\ads-deploy-2.9.1\Scripts\pytmc-script.py", line 33, in <module>
  sys.exit(load_entry_point('pytmc', 'console_scripts', 'pytmc')())
 File "c:\repos\pytmc\pytmc\bin\pytmc.py", line 91, in main
  func(**kwargs)
 File "c:\repos\pytmc\pytmc\bin\template.py", line 742, in main
  raise stashed_exception
 File "c:\repos\pytmc\pytmc\bin\template.py", line 735, in main
  rendered = render_template(template_text, template_args)
 File "c:\repos\pytmc\pytmc\bin\template.py", line 621, in render_template
  return env.get_template('template').render(context)
 File "C:\miniconda\envs\ads-deploy-2.9.1\lib\site-packages\jinja2\environment.py", line 1301, in render
  self.environment.handle_exception()
 File "C:\miniconda\envs\ads-deploy-2.9.1\lib\site-packages\jinja2\environment.py", line 936, in handle_exception
  raise rewrite_traceback_stack(source=source)
 File "<template>", line 156, in top-level template code
 File "C:\miniconda\envs\ads-deploy-2.9.1\lib\site-packages\jinja2\filters.py", line 409, in do_sort
  return sorted(value, key=key_func, reverse=reverse)
 File "C:\miniconda\envs\ads-deploy-2.9.1\lib\site-packages\jinja2\filters.py", line 112, in attrgetter
  item_i = environment.getitem(item_i, part)
 File "C:\miniconda\envs\ads-deploy-2.9.1\lib\site-packages\jinja2\environment.py", line 475, in getitem
  return getattr(obj, attr)
 File "c:\repos\pytmc\pytmc\parser.py", line 1585, in nc_axis
  link = self.nc_to_plc_link
 File "c:\repos\pytmc\pytmc\parser.py", line 1577, in nc_to_plc_link
  raise RuntimeError(f'No NC link to DUT_MotionStage found for '
RuntimeError: No NC link to DUT_MotionStage found for 'Main.M1'
```

This was a bit of a rabbit hole, because this error:
```
TypeError: 'Symbol_DUT_MotionStage' object is not subscriptable
```
Is due to Jinja confusingly doing the following:
1. Trying `motor.nc_axis` and having it raise with the "No NC link found"
2. Trying `motor["nc_axis"]` and having it raise because `Symbol_DUT_MotionStage` does not support `__getitem__`

The core of the issue is not the getitem exception, but rather that there was no NC link found.
Yet the NC links clearly existed in the project! So what was going on?

When misconfigured (or in the default configuration), TwinCAT stores mappings inside the `.tsproj` file (and in fact there is no XTI file to speak of for a PLC project).
While technically this is OK from what TwinCAT expects, pytmc assumes you've gone through the process listed below. So it finds no mappings where it expects, and it can't correlate your symbol with an NC axis.

## The fix

1. We want people to follow the guide
2. But failing miserably with a confusing error is bad for them (and for me because I forget about this stuff)
3. So this PR adds in support for the misconfiguration but is loud about it, such that when you build an IOC you see this:
```
WARNING:pytmc.parser:TwinCAT/project settings misconfiguration; no mappings in XTI file.Please fix your environment and project.
WARNING:pytmc.parser:TwinCAT/project settings misconfiguration; no mappings in XTI file.Please fix your environment and project.
WARNING:pytmc.parser:TwinCAT/project settings misconfiguration; no mappings in XTI file.Please fix your environment and project.
* Copying envPaths and fixing variables...
```

(Several times multiplied by the number of NC axes in your project)
So it's loud but it should still generate the IOC.

## Configuration reference

> TwinCAT will bundle components of a PLC solution into 2-3 files by default. This default behavior will obscure/conflate changes between seemingly unrelated parts of the project. That means when you change a setting in an EtherCAT terminal, the overall project item will appear changed. So basically the project item always appears changed, and it's difficult to tell what caused it!
> 
> To keep things clear, you must tell TwinCAT to track project files individually. [This guide shows how](https://infosys.beckhoff.com/english.php?content=../content/1033/tc3_sourcecontrol/18014399277376779.html&id=). > Do everything they suggest, ensuring:
> 1.    All options are set to True in Tools / Options / TwinCAT / XAE Environment / File settings:
> ![image](https://github.com/pcdshub/pytmc/assets/5139267/fb6fbc41-5dc4-4379-a17d-0e809d3fd03a)
> 2. Your PLC project instance has "Keep unrestored link info" checked:
> ![image](https://github.com/pcdshub/pytmc/assets/5139267/a2986a11-b00c-4483-aa71-ac4e244bfd34)

