### PR TITLE
REF: always use colon delimiter for `pytmc template`

### DIFF
--- a/pytmc/bin/template.py
+++ b/pytmc/bin/template.py
@@ -751,7 +751,7 @@ def main(
 
     all_rendered = {}
     for template in templates:
-        input_filename, output_filename = template.split(os.pathsep, 1)
+        input_filename, output_filename = template.rsplit(":", 1)
         if input_filename == "-":
             # Check if it's an interactive user to warn them what we're doing:
             is_tty = os.isatty(sys.stdin.fileno())

--- a/pytmc/bin/template.py
+++ b/pytmc/bin/template.py
@@ -715,6 +715,53 @@ def _split_macro(macro: str) -> tuple[str, str]:
     return tuple(parts)
 
 
+def split_input_output(arg: str) -> tuple[str, str]:
+    """
+    Split user-specified template argument into input/output file.
+
+    Parameters
+    ----------
+    arg : str
+        The user-specified command-line argument for ``--template``.
+
+    Returns
+    -------
+    input_filename : str
+        The input filename.
+    output_filename : str
+        The output filename.
+    """
+    delim = ":"
+    num_delim = arg.count(delim)
+    if num_delim == 0:
+        raise ValueError(
+            f"Invalid input: {arg!r} should be in the format "
+            f"'input_filename:output_filename'"
+        )
+
+    if num_delim == 1:
+        # Our job is easy in this scenario
+        return tuple(arg.split(delim, 1))
+
+    input_parts = arg.split(delim)
+    if input_parts[0] == "-":
+        # Special case: - as input file means read /dev/stdin
+        return "-", delim.join(input_parts[1:])
+
+    output_parts = []
+    while input_parts:
+        input_filename = delim.join(input_parts)
+        if os.path.exists(input_filename):
+            return input_filename, delim.join(output_parts)
+        output_parts.insert(0, input_parts.pop(-1))
+
+    raise ValueError(
+        f"Invalid input: {arg!r} should be in the format "
+        f"'input_filename:output_filename' but input filenames were "
+        f"found that matched"
+    )
+
+
 def main(
     projects: list[parser.AnyPath],
     templates: Optional[Union[list[str], str]] = None,
@@ -751,7 +798,7 @@ def main(
 
     all_rendered = {}
     for template in templates:
-        input_filename, output_filename = template.rsplit(":", 1)
+        input_filename, output_filename = split_input_output(template)
         if input_filename == "-":
             # Check if it's an interactive user to warn them what we're doing:
             is_tty = os.isatty(sys.stdin.fileno())

--- a/pytmc/tests/test_commandline.py
+++ b/pytmc/tests/test_commandline.py
@@ -3,6 +3,7 @@ import sys
 
 import pytest
 
+import pytmc
 import pytmc.bin.pytmc as pytmc_main
 from pytmc.bin.code import main as code_main
 from pytmc.bin.db import main as db_main
@@ -115,3 +116,46 @@ def test_template_smoke(project_filename, template):
     )
 
     print("templated", templated)
+
+
+@pytest.mark.parametrize(
+    "argument, input_filename, output_filename",
+    [
+        pytest.param(
+            "a", "", "", marks=pytest.mark.xfail(strict=True, reason="no delimiter")
+        ),
+        pytest.param(
+            "a:b", "a", "b",
+        ),
+        pytest.param(
+            "C:/a/b/c.def:D:/d/e/f.ghi",
+            "C:/a/b/c.def",
+            "D:/d/e/f.ghi",
+        ),
+        pytest.param(
+            "//a/b/c.def:D:/d/e/f.ghi",
+            "//a/b/c.def",
+            "D:/d/e/f.ghi",
+        ),
+        pytest.param(
+            "/tmp/:messed:up:filename:/tmp/a/b:c:d",
+            "/tmp/:messed:up:filename",
+            "/tmp/a/b:c:d",
+        ),
+    ],
+)
+def test_filename_split(
+    argument: str,
+    input_filename: str,
+    output_filename: str,
+    monkeypatch,
+):
+
+    def exists(fn: str) -> bool:
+        print("Exists?", fn, fn in {input_filename, output_filename})
+        return fn in {input_filename, output_filename}
+
+    monkeypatch.setattr(os.path, "exists", exists)
+    inp, outp = pytmc.bin.template.split_input_output(argument)
+    assert inp == input_filename
+    assert outp == output_filename

--- a/pytmc/tests/test_commandline.py
+++ b/pytmc/tests/test_commandline.py
@@ -142,6 +142,11 @@ def test_template_smoke(project_filename, template):
             "/tmp/:messed:up:filename",
             "/tmp/a/b:c:d",
         ),
+        pytest.param(
+            "-:output_fn",
+            "-",
+            "output_fn",
+        ),
     ],
 )
 def test_filename_split(
@@ -152,6 +157,8 @@ def test_filename_split(
 ):
 
     def exists(fn: str) -> bool:
+        if fn == "-":
+            return False
         print("Exists?", fn, fn in {input_filename, output_filename})
         return fn in {input_filename, output_filename}
 


### PR DESCRIPTION
Closes https://github.com/pcdshub/pytmc/issues/299

For `pytmc template`, always use a colon delimiter, regardless of the platform.
That means that the input file should be of the form: `input_filename:output_filename` on Windows, Mac, Linux.
(Previously this could have been `input_filename;output_filename` on Windows)

Some special handling is then required to parse these appropriately, since Windows paths can have colons in them. Two absolute paths could then look like `C:\a\b.c.txt:C:\d\e\f.txt` - confusingly enough. The algorithm here checks to see if the first file exists in the case where the delimiter itself is ambiguous.

A quicker hack/fix is already out on plcprog-console: (`filename.rsplit(":", 1)`) - because we only use one absolute filename, the output is relative to the IOC directory. 

I don't think this is the cleanest solution, but it is _a_ solution...