### PR TITLE
MNT: back-compat for 'pytmc template' delimiter-less filename

### DIFF
--- a/pytmc/bin/template.py
+++ b/pytmc/bin/template.py
@@ -729,15 +729,15 @@ def split_input_output(arg: str) -> tuple[str, str]:
     input_filename : str
         The input filename.
     output_filename : str
-        The output filename.
+        The output filename.  Empty filename implies stdout.
     """
     delim = ":"
+
     num_delim = arg.count(delim)
     if num_delim == 0:
-        raise ValueError(
-            f"Invalid input: {arg!r} should be in the format "
-            f"'input_filename:output_filename'"
-        )
+        # Without a delimiter, assume the file is the template filename
+        # and the user wants to write to standard output
+        return arg, ""
 
     if num_delim == 1:
         # Our job is easy in this scenario

--- a/pytmc/tests/test_commandline.py
+++ b/pytmc/tests/test_commandline.py
@@ -122,7 +122,12 @@ def test_template_smoke(project_filename, template):
     "argument, input_filename, output_filename",
     [
         pytest.param(
-            "a", "", "", marks=pytest.mark.xfail(strict=True, reason="no delimiter")
+            "a", "a", "",
+            id="template-file-to-stdout"
+        ),
+        pytest.param(
+            "-", "-", "",
+            id="stdin-to-stdout",
         ),
         pytest.param(
             "a:b", "a", "b",
@@ -157,7 +162,7 @@ def test_filename_split(
 ):
 
     def exists(fn: str) -> bool:
-        if fn == "-":
+        if fn in {"-", ""}:
             return False
         print("Exists?", fn, fn in {input_filename, output_filename})
         return fn in {input_filename, output_filename}


### PR DESCRIPTION
(Short follow-up PR to #320 )

``pytmc template``, which takes a TwinCAT project and jinja template source
  code to generate project-specific output, now expects all platforms to use
  the same delimiter (``":"``) for template filename patterns. Examples include:

  * Read template from ``a.template`` and write expanded version to ``a.txt``:
    ``pytmc template my.tsproj --template a.template:a.txt``
  * Read template from ``a.template`` and write results to standard output:
    ``pytmc template my.tsproj --template a.template``       **This PR fixes this scenario for back-compat purposes**
  * Read template from standard input and write results to standard output:
    ``pytmc template my.tsproj --template -``
  * Read template from standard input and write results to ``/path/to/a.txt``:
    ``pytmc template my.tsproj --template -:/path/to/a.txt``
