### PR TITLE
DEV: Making _RBV PVs read-only

### DIFF
--- a/pytmc/templates/asyn_standard_record.jinja2
+++ b/pytmc/templates/asyn_standard_record.jinja2
@@ -22,4 +22,7 @@ record({{record.record_type}}, "{{record.pvname}}") {
   info(archive, "{{ record.archive_settings['method'] }} {{ record.archive_settings['seconds'] }}: {{ record.archive_settings['fields'] | join(' ') }}")
   {% endif %}
 {% endif %}
+{% if record.direction == "input" %}
+  field(ASG, "NO_WRITE")
+{% endif %}
 }

--- a/pytmc/tests/test_record.py
+++ b/pytmc/tests/test_record.py
@@ -54,11 +54,10 @@ def test_output_record_with_write_access():
         "record_type": "ao",
         "direction": "output",
     }
-
     ec = EPICSRecord(**kwargs)
     record = ec.render()
     assert "ASG" not in record
-    
+
 
 def test_sort_fields():
     unsorted_entry = OrderedDict(

--- a/pytmc/tests/test_record.py
+++ b/pytmc/tests/test_record.py
@@ -35,6 +35,31 @@ def test_epics_record_with_linter(dbd_file):
     assert not (linted.errors)
 
 
+def test_input_record_without_write_access():
+    kwargs = {
+        "pvname": "Tst:pv",
+        "record_type": "ai",
+        "direction": "input",
+    }
+
+    ec = EPICSRecord(**kwargs)
+    record = ec.render()
+    assert "ASG" in record
+    assert "NO_WRITE" in record
+
+
+def test_output_record_with_write_access():
+    kwargs = {
+        "pvname": "Tst:pv",
+        "record_type": "ao",
+        "direction": "output",
+    }
+
+    ec = EPICSRecord(**kwargs)
+    record = ec.render()
+    assert "ASG" not in record
+    
+
 def test_sort_fields():
     unsorted_entry = OrderedDict(
         [


### PR DESCRIPTION
https://jira.slac.stanford.edu/browse/ECS-5005

This adds an ASG field with the value NO_WRITE to any EPICSRecord with direction input in the jinja database template. This access security group will be added to a new version of ads-ioc and will only allow reading, not writing to pvs. 

https://github.com/pcdshub/ioc-common-ads-ioc/pull/103