### PR TITLE
Adding setuptools_scm to conda recipe

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -15,7 +15,7 @@ build:
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
-  build
+  build:
   - setuptools_scm
   host:
   - python >=3.9

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -15,11 +15,10 @@ build:
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
-  build:
-  - setuptools_scm
   host:
   - python >=3.9
   - pip
+  - setuptools_scm
   run:
   - python >=3.9
   - jinja2

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -15,6 +15,8 @@ build:
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
+  build
+  - setuptools_scm
   host:
   - python >=3.9
   - pip


### PR DESCRIPTION
Noticed that conda tests were failing because setuptools wasn't implicitly present in #332.