### PR TITLE
FIX: also allow BYTE arrays to be waveform records

### DIFF
--- a/pytmc/record.py
+++ b/pytmc/record.py
@@ -905,6 +905,7 @@ class WaveformRecordPackage(TwincatTypeRecordPackage):
         """Field type of value"""
         ftvl = {
             "BOOL": "CHAR",
+            "BYTE": "CHAR",
             "INT": "SHORT",
             "ENUM": "SHORT",
             "DINT": "LONG",


### PR DESCRIPTION
Prospective update as a possible way for us to get long long long long strings from a PLC